### PR TITLE
feat(cli): Add ability to specify component generation config parameters

### DIFF
--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -249,6 +249,7 @@ export interface StencilConfig {
   excludeUnusedDependencies?: boolean;
   typescriptPath?: string;
   stencilCoreResolvedId?: string;
+  componentGeneratorConfig?: ComponentGeneratorConfig;
 }
 
 export interface ConfigExtras {
@@ -1870,6 +1871,11 @@ export interface ServiceWorkerConfig {
   runtimeCaching?: any[];
   ignoreUrlParametersMatching?: any[];
   handleFetch?: boolean;
+}
+
+export interface ComponentGeneratorConfig {
+  prefix?: string;
+  styleFormat?: string;
 }
 
 export interface LoadConfigInit {


### PR DESCRIPTION
A user can define a `prefix `and `styleFormat` parameter in `stencil.config.ts` to provide more flexibility when working with the `stencil generate` CLI command.

eg.
```
import { Config } from '@stencil/core';

export const config: Config = {
...
  componentGeneratorConfig: {
    prefix: 'ion',
    styleFormat: 'scss'
  }
}
```

The toggle prompts remain the same, referencing `scss` instead of `css` in the above example.

This object is optional, with a default `app` prefix and `css` format being applied.

Generated files and folders are created without the prefix within the name. Eg. `ion-button` component would create file/folder structure `button`, `button.tsx` etc.

The generation command would change to:

`npx stencil generate button` instead of `npx stencil generate ion-button`

Resolves:
https://github.com/ionic-team/stencil/issues/2303
https://github.com/ionic-team/stencil/issues/2347
https://github.com/ionic-team/stencil/issues/2348
https://github.com/ionic-team/stencil/issues/2396