### PR TITLE
fix(compiler): support rollup's external input option for collection dependencies

### DIFF
--- a/src/compiler/bundle/bundle-output.ts
+++ b/src/compiler/bundle/bundle-output.ts
@@ -135,6 +135,8 @@ export const getRollupOptions = (
     onwarn: createOnWarnFn(buildCtx.diagnostics),
 
     cache: compilerCtx.rollupCache.get(bundleOpts.id),
+
+    external: config.rollupConfig.inputOptions.external,
   };
 
   return rollupOptions;

--- a/src/compiler/bundle/bundle-output.ts
+++ b/src/compiler/bundle/bundle-output.ts
@@ -136,7 +136,7 @@ export const getRollupOptions = (
 
     cache: compilerCtx.rollupCache.get(bundleOpts.id),
 
-    external: config.rollupConfig.inputOptions.external,
+    external: config.rollupConfig?.inputOptions?.external,
   };
 
   return rollupOptions;

--- a/src/compiler/config/test/validate-rollup-config.spec.ts
+++ b/src/compiler/config/test/validate-rollup-config.spec.ts
@@ -62,6 +62,7 @@ describe('validateStats', () => {
     config.rollupConfig = {
       inputOptions: {
         context: 'window',
+        external: 'external_symbol',
         notAnOption: {},
       },
       outputOptions: {
@@ -76,6 +77,7 @@ describe('validateStats', () => {
       rollupConfig: {
         inputOptions: {
           context: 'window',
+          external: 'external_symbol',
         },
         outputOptions: {
           globals: {

--- a/src/compiler/config/validate-rollup-config.ts
+++ b/src/compiler/config/validate-rollup-config.ts
@@ -17,7 +17,7 @@ const getCleanRollupConfig = (rollupConfig: d.RollupConfig): d.RollupConfig => {
   if (rollupConfig.inputOptions && isObject(rollupConfig.inputOptions)) {
     cleanRollupConfig = {
       ...cleanRollupConfig,
-      inputOptions: pluck(rollupConfig.inputOptions, ['context', 'moduleContext', 'treeshake']),
+      inputOptions: pluck(rollupConfig.inputOptions, ['context', 'moduleContext', 'treeshake', 'external']),
     };
   }
 

--- a/src/compiler/transformers/collections/parse-collection-manifest.ts
+++ b/src/compiler/transformers/collections/parse-collection-manifest.ts
@@ -16,6 +16,8 @@ export const parseCollectionManifest = (
 
   const compilerVersion: d.CollectionCompilerVersion = collectionManifest.compiler || ({} as any);
 
+  const isExternal = buildCtx.isExternal(collectionName, 'collection', true);
+
   const collection: d.CollectionCompilerMeta = {
     collectionName: collectionName,
     moduleId: collectionName,
@@ -27,10 +29,13 @@ export const parseCollectionManifest = (
       typescriptVersion: compilerVersion.typescriptVersion || '',
     },
     bundles: parseBundles(collectionManifest),
+    isExternal,
   };
 
-  parseGlobal(config, compilerCtx, buildCtx, collectionDir, collectionManifest, collection);
-  parseCollectionComponents(config, compilerCtx, buildCtx, collectionDir, collectionManifest, collection);
+  if (!isExternal) {
+    parseGlobal(config, compilerCtx, buildCtx, collectionDir, collectionManifest, collection);
+    parseCollectionComponents(config, compilerCtx, buildCtx, collectionDir, collectionManifest, collection);
+  }
 
   return collection;
 };

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -253,6 +253,7 @@ export interface BuildCtx {
   indexBuildCount: number;
   indexDoc: Document;
   isRebuild: boolean;
+  isExternal: (id: string, importer: string, isResolved: boolean) => boolean;
   moduleFiles: Module[];
   packageJson: PackageJsonData;
   pendingCopyTasks: Promise<CopyResults>[];
@@ -474,6 +475,7 @@ export interface CollectionCompilerMeta {
   bundles?: {
     components: string[];
   }[];
+  isExternal?: boolean;
 }
 
 export interface CollectionCompilerVersion {

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1494,6 +1494,11 @@ export interface RollupInputOptions {
   context?: string;
   moduleContext?: ((id: string) => string) | { [id: string]: string };
   treeshake?: boolean;
+  external?:
+    | (string | RegExp)[]
+    | string
+    | RegExp
+    | ((source: string, importer: string | undefined, isResolved: boolean) => boolean | null | undefined);
 }
 
 export interface RollupOutputOptions {


### PR DESCRIPTION
This PR builds upon #3227 to exclude external collection dependencies.



<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/.github/CONTRIBUTING.md -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Unit tests (`npm test`) were run locally and passed
- [ ] E2E Tests (`npm run test.karma.prod`) were run locally and passed
- [x] Prettier (`npm run prettier`) was run locally and passed

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [x] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #3576

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Passing a `external` to `rollupConfig.inputOptions` will be applied to external component collections.

When a collection is parsed, the compiler checks if it matches an `external` id.
If it is matched, the collection info is retained in the cache, but the components are not built, and child collections are not resolved. The side effect import is still removed. 


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Currently, external is not supported, so this behaviour cannot be accidentally triggered. 

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

- Create a local test project. 
- Link to stencil built with changes
- Add a library dependency
- Add the library name to `rollupConfig.inputOptions.external`
- Build the project, and ensure the components are excluded from the build

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
