### PR TITLE
fix(compiler): revert deprecation changes to components.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,9 @@
   ],
   "exports": {
     ".": {
+      "types": "./internal/stencil-core/index.d.ts",
       "import": "./internal/stencil-core/index.js",
-      "require": "./internal/stencil-core/index.cjs",
-      "types": "./internal/stencil-core/index.d.ts"
+      "require": "./internal/stencil-core/index.cjs"
     },
     "./cli": {
       "import": "./cli/index.js",
@@ -48,40 +48,40 @@
       "import": "./internal/testing/*"
     },
     "./internal/app-data": {
+      "types": "./internal/app-data/index.d.ts",
       "import": "./internal/app-data/index.js",
-      "require": "./internal/app-data/index.cjs",
-      "types": "./internal/app-data/index.d.ts"
+      "require": "./internal/app-data/index.cjs"
     },
     "./mock-doc": {
+      "types": "./mock-doc/index.d.ts",
       "import": "./mock-doc/index.js",
-      "require": "./mock-doc/index.cjs",
-      "types": "./mock-doc/index.d.ts"
+      "require": "./mock-doc/index.cjs"
     },
     "./compiler": {
+      "types": "./compiler/stencil.d.ts",
       "import": "./compiler/stencil.js",
-      "require": "./compiler/stencil.js",
-      "types": "./compiler/stencil.d.ts"
+      "require": "./compiler/stencil.js"
     },
     "./compiler/*": {
-      "import": "./compiler/*",
-      "types": "./compiler/*"
+      "types": "./compiler/*",
+      "import": "./compiler/*"
     },
     "./screenshot": {
-      "require": "./screenshot/index.js",
-      "types": "./screenshot/index.d.ts"
+      "types": "./screenshot/index.d.ts",
+      "require": "./screenshot/index.js"
     },
     "./sys/node": {
+      "types": "./sys/node/index.d.ts",
       "import": "./sys/node/index.js",
-      "require": "./sys/node/index.js",
-      "types": "./sys/node/index.d.ts"
+      "require": "./sys/node/index.js"
     },
     "./sys/node/*": {
       "import": "./sys/node/*",
       "require": "./sys/node/*"
     },
     "./testing": {
-      "import": "./testing/index.js",
       "types": "./testing/index.d.ts",
+      "import": "./testing/index.js",
       "require": "./testing/index.js"
     },
     "./testing/jest-preset": {

--- a/src/compiler/types/generate-component-types.ts
+++ b/src/compiler/types/generate-component-types.ts
@@ -76,22 +76,6 @@ const attributesToMultiLineString = (attributes: d.TypeInfo, jsxAttributes: bool
       }
       const optional = jsxAttributes ? !type.required : type.optional;
       fullList.push(`        "${type.name}"${optional ? '?' : ''}: ${type.type};`);
-
-      /**
-       * deprecated usage of dash-casing in JSX, use camelCase instead
-       */
-      if (type.attributeName && type.attributeName !== type.name) {
-        const padding = ' '.repeat(8);
-        fullList.push(
-          [
-            `${padding}/**`,
-            `${padding} * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.`,
-            `${padding} */`,
-          ].join('\n'),
-        );
-        fullList.push(`${padding}"${type.attributeName}"?: ${type.type};`);
-      }
-
       return fullList;
     }, [] as string[])
     .join(`\n`);

--- a/src/compiler/types/generate-prop-types.ts
+++ b/src/compiler/types/generate-prop-types.ts
@@ -20,7 +20,6 @@ export const generatePropTypes = (cmpMeta: d.ComponentCompilerMeta, typeImportDa
       }
       return {
         name: cmpProp.name,
-        attributeName: cmpProp.attribute,
         type: getType(cmpProp, typeImportData, cmpMeta.sourceFilePath),
         optional: cmpProp.optional,
         required: cmpProp.required,

--- a/src/compiler/types/tests/generate-app-types.spec.ts
+++ b/src/compiler/types/tests/generate-app-types.spec.ts
@@ -847,10 +847,6 @@ export namespace Components {
      */
     interface MyComponent {
         "name": UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
 }
 declare global {
@@ -873,10 +869,6 @@ declare namespace LocalJSX {
      */
     interface MyComponent {
         "name"?: UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
     interface IntrinsicElements {
         "my-component": MyComponent;
@@ -957,15 +949,7 @@ export namespace Components {
      */
     interface MyComponent {
         "email": SecondUserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: SecondUserImplementedPropType;
         "name": UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
 }
 declare global {
@@ -988,15 +972,7 @@ declare namespace LocalJSX {
      */
     interface MyComponent {
         "email"?: SecondUserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: SecondUserImplementedPropType;
         "name"?: UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
     interface IntrinsicElements {
         "my-component": MyComponent;
@@ -1087,20 +1063,12 @@ export namespace Components {
      */
     interface MyComponent {
         "name": UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
     /**
      * docs
      */
     interface MyNewComponent {
         "fullName": UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
 }
 declare global {
@@ -1133,20 +1101,12 @@ declare namespace LocalJSX {
      */
     interface MyComponent {
         "name"?: UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
     /**
      * docs
      */
     interface MyNewComponent {
         "fullName"?: UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
     interface IntrinsicElements {
         "my-component": MyComponent;
@@ -1247,20 +1207,12 @@ export namespace Components {
      */
     interface MyComponent {
         "name": UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
     /**
      * docs
      */
     interface MyNewComponent {
         "newName": UserImplementedPropType1;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType1;
     }
 }
 declare global {
@@ -1293,20 +1245,12 @@ declare namespace LocalJSX {
      */
     interface MyComponent {
         "name"?: UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
     /**
      * docs
      */
     interface MyNewComponent {
         "newName"?: UserImplementedPropType1;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType1;
     }
     interface IntrinsicElements {
         "my-component": MyComponent;
@@ -1407,20 +1351,12 @@ export namespace Components {
      */
     interface MyComponent {
         "name": UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
     /**
      * docs
      */
     interface MyNewComponent {
         "name": UserImplementedPropType1;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType1;
     }
 }
 declare global {
@@ -1453,20 +1389,12 @@ declare namespace LocalJSX {
      */
     interface MyComponent {
         "name"?: UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
     /**
      * docs
      */
     interface MyNewComponent {
         "name"?: UserImplementedPropType1;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType1;
     }
     interface IntrinsicElements {
         "my-component": MyComponent;
@@ -1544,10 +1472,6 @@ export namespace Components {
      */
     interface MyComponent {
         "name": UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
 }
 export interface MyComponentCustomEvent<T> extends CustomEvent<T> {
@@ -1585,10 +1509,6 @@ declare namespace LocalJSX {
      */
     interface MyComponent {
         "name"?: UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
         "onMyEvent"?: (event: MyComponentCustomEvent<UserImplementedEventType>) => void;
     }
     interface IntrinsicElements {
@@ -1670,10 +1590,6 @@ export namespace Components {
      */
     interface MyComponent {
         "name": UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
 }
 declare global {
@@ -1696,10 +1612,6 @@ declare namespace LocalJSX {
      */
     interface MyComponent {
         "name"?: UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
     interface IntrinsicElements {
         "my-component": MyComponent;
@@ -1770,10 +1682,6 @@ export namespace Components {
      */
     interface MyComponent {
         "name": UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
 }
 declare global {
@@ -1796,10 +1704,6 @@ declare namespace LocalJSX {
      */
     interface MyComponent {
         "name"?: UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
     interface IntrinsicElements {
         "my-component": MyComponent;
@@ -1879,10 +1783,6 @@ export namespace Components {
      */
     interface MyComponent {
         "name": UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
 }
 declare global {
@@ -1905,10 +1805,6 @@ declare namespace LocalJSX {
      */
     interface MyComponent {
         "name"?: UserImplementedPropType;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "my-cmp"?: UserImplementedPropType;
     }
     interface IntrinsicElements {
         "my-component": MyComponent;

--- a/src/compiler/types/tests/generate-prop-types.spec.ts
+++ b/src/compiler/types/tests/generate-prop-types.spec.ts
@@ -44,7 +44,6 @@ describe('generate-prop-types', () => {
 
       const expectedTypeInfo: d.TypeInfo = [
         {
-          attributeName: 'my-cmp',
           jsdoc: '',
           internal: false,
           name: 'propName',
@@ -70,7 +69,6 @@ describe('generate-prop-types', () => {
 
       const expectedTypeInfo: d.TypeInfo = [
         {
-          attributeName: 'my-cmp',
           jsdoc: '',
           internal: false,
           name: 'propName',
@@ -116,7 +114,6 @@ describe('generate-prop-types', () => {
 
       const expectedTypeInfo: d.TypeInfo = [
         {
-          attributeName: 'my-cmp',
           jsdoc: '',
           internal: false,
           name: 'propName',
@@ -152,7 +149,6 @@ describe('generate-prop-types', () => {
 
       const expectedTypeInfo: d.TypeInfo = [
         {
-          attributeName: 'my-cmp',
           jsdoc: '@readonly',
           internal: false,
           name: 'propName',
@@ -180,7 +176,6 @@ describe('generate-prop-types', () => {
 
       const expectedTypeInfo: d.TypeInfo = [
         {
-          attributeName: 'my-cmp',
           jsdoc: '',
           internal: false,
           name: 'propName',

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -2554,7 +2554,6 @@ export interface TypesModule {
 export type TypeInfo = {
   name: string;
   type: string;
-  attributeName?: string;
   optional: boolean;
   required: boolean;
   internal: boolean;

--- a/test/end-to-end/package-lock.json
+++ b/test/end-to-end/package-lock.json
@@ -24,7 +24,8 @@
       }
     },
     "../..": {
-      "version": "4.23.2",
+      "name": "@stencil/core",
+      "version": "4.27.1",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -58,7 +59,7 @@
         "conventional-changelog-cli": "^5.0.0",
         "cspell": "^8.0.0",
         "dts-bundle-generator": "~9.5.0",
-        "esbuild": "^0.21.0",
+        "esbuild": "^0.25.0",
         "esbuild-plugin-replace": "^1.4.0",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^9.0.0",
@@ -5379,7 +5380,7 @@
         "conventional-changelog-cli": "^5.0.0",
         "cspell": "^8.0.0",
         "dts-bundle-generator": "~9.5.0",
-        "esbuild": "^0.21.0",
+        "esbuild": "^0.25.0",
         "esbuild-plugin-replace": "^1.4.0",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^9.0.0",

--- a/test/end-to-end/src/components.d.ts
+++ b/test/end-to-end/src/components.d.ts
@@ -40,10 +40,6 @@ export namespace Components {
     }
     interface CmpDsd {
         "initialCounter": number;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "initial-counter"?: number;
     }
     interface CmpServerVsClient {
     }
@@ -105,10 +101,6 @@ export namespace Components {
          */
         "someMethodWithArgs": (unit: string, value: number) => Promise<string>;
         "someProp": number;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "some-prop"?: number;
     }
     interface MyCmp {
         /**
@@ -118,17 +110,9 @@ export namespace Components {
          */
         "barProp": string;
         /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "bar-prop"?: string;
-        /**
           * foo prop
          */
         "fooProp": string;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "foo-prop"?: string;
         /**
           * Mode
          */
@@ -142,17 +126,9 @@ export namespace Components {
          */
         "barProp": string;
         /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "bar-prop"?: string;
-        /**
           * foo prop
          */
         "fooProp": string;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "foo-prop"?: string;
         /**
           * Mode
          */
@@ -183,15 +159,7 @@ export namespace Components {
           * @readonly
          */
         "fullName": string;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "full-name"?: string;
         "lastName": string;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "last-name"?: string;
         /**
           * Mode
          */
@@ -199,20 +167,8 @@ export namespace Components {
     }
     interface RuntimeDecorators {
         "basicProp": string;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "basic-prop"?: string;
         "decoratedGetterSetterProp": number;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "decorated-getter-setter-prop"?: number;
         "decoratedProp": number;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "decorated-prop"?: number;
     }
     interface ScopedCarDetail {
         "car": CarData;
@@ -670,10 +626,6 @@ declare namespace LocalJSX {
     }
     interface CmpDsd {
         "initialCounter"?: number;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "initial-counter"?: number;
     }
     interface CmpServerVsClient {
     }
@@ -709,10 +661,6 @@ declare namespace LocalJSX {
     }
     interface MethodCmp {
         "someProp"?: number;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "some-prop"?: number;
     }
     interface MyCmp {
         /**
@@ -722,17 +670,9 @@ declare namespace LocalJSX {
          */
         "barProp"?: string;
         /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "bar-prop"?: string;
-        /**
           * foo prop
          */
         "fooProp"?: string;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "foo-prop"?: string;
         /**
           * Mode
          */
@@ -746,17 +686,9 @@ declare namespace LocalJSX {
          */
         "barProp"?: string;
         /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "bar-prop"?: string;
-        /**
           * foo prop
          */
         "fooProp"?: string;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "foo-prop"?: string;
         /**
           * Mode
          */
@@ -787,15 +719,7 @@ declare namespace LocalJSX {
           * @readonly
          */
         "fullName"?: string;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "full-name"?: string;
         "lastName"?: string;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "last-name"?: string;
         /**
           * Mode
          */
@@ -803,20 +727,8 @@ declare namespace LocalJSX {
     }
     interface RuntimeDecorators {
         "basicProp"?: string;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "basic-prop"?: string;
         "decoratedGetterSetterProp"?: number;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "decorated-getter-setter-prop"?: number;
         "decoratedProp"?: number;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "decorated-prop"?: number;
     }
     interface ScopedCarDetail {
         "car"?: CarData;

--- a/test/wdio/package-lock.json
+++ b/test/wdio/package-lock.json
@@ -26,7 +26,7 @@
     },
     "../..": {
       "name": "@stencil/core",
-      "version": "4.24.0",
+      "version": "4.27.1",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -60,7 +60,7 @@
         "conventional-changelog-cli": "^5.0.0",
         "cspell": "^8.0.0",
         "dts-bundle-generator": "~9.5.0",
-        "esbuild": "^0.21.0",
+        "esbuild": "^0.25.0",
         "esbuild-plugin-replace": "^1.4.0",
         "eslint": "^8.23.1",
         "eslint-config-prettier": "^9.0.0",

--- a/test/wdio/src/components.d.ts
+++ b/test/wdio/src/components.d.ts
@@ -20,10 +20,6 @@ export namespace Components {
     }
     interface CmpD {
         "uniqueId": string;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "unique-id"?: string;
     }
     interface CmpScopedA {
     }
@@ -139,10 +135,6 @@ declare namespace LocalJSX {
     }
     interface CmpD {
         "uniqueId"?: string;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "unique-id"?: string;
     }
     interface CmpScopedA {
     }

--- a/test/wdio/ts-target-props/components.d.ts
+++ b/test/wdio/ts-target-props/components.d.ts
@@ -8,20 +8,8 @@ import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 export namespace Components {
     interface TsTargetProps {
         "basicProp": string;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "basic-prop"?: string;
         "decoratedGetterSetterProp": number;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "decorated-getter-setter-prop"?: number;
         "decoratedProp": number;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "decorated-prop"?: number;
         "dynamicLifecycle": string[];
     }
 }
@@ -39,20 +27,8 @@ declare global {
 declare namespace LocalJSX {
     interface TsTargetProps {
         "basicProp"?: string;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "basic-prop"?: string;
         "decoratedGetterSetterProp"?: number;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "decorated-getter-setter-prop"?: number;
         "decoratedProp"?: number;
-        /**
-         * @deprecated use camelCase instead. Support for dash-casing will be removed in Stencil v5.
-         */
-        "decorated-prop"?: number;
         "dynamicLifecycle"?: string[];
     }
     interface IntrinsicElements {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/ionic-team/stencil/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
We have recently pushed a change to the compiler to notify users about the deprecation of using kebab-casing in JSX environments. While this may have been a good idea in theory, it has caused more confusion and devx issues. Let's get rid of it again.

fixes #6184
fixes #6183

## What is the new behavior?
Don't deprecate these attributes and make sure the v5 release notes highlight this breaking change visible enough.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
