### PR TITLE
fix: add missing name attribute for details html element

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -921,6 +921,7 @@ export namespace JSXBase {
 
   export interface DetailsHTMLAttributes<T> extends HTMLAttributes<T> {
     open?: boolean;
+    name?: string;
     onToggle?: (event: Event) => void;
   }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
I wanted to use the `details` html element with the `name` property in Stencil's TSX and got the error:
```
Type '{ name: string; }' is not assignable to type 'DetailsHTMLAttributes<HTMLElement>'.Property 'name' does
           not exist on type 'DetailsHTMLAttributes<HTMLElement>'.
```

The `name` property seems to be missing here: https://github.com/stenciljs/core/blob/30fc9f5985120e636eec8acbe2253145c97072d9/src/declarations/stencil-public-runtime.ts#L922

The `name` attribute is part of the web standard and allows grouping multiple `details` elements: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details#multiple_named_disclosure_boxes

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
The name attribute is added to the definitions and can be used in TSX.


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
