### PR TITLE
fix(compiler): fix file watcher sometimes doesn't trigger rebuild

### DIFF
--- a/src/compiler/transpile/create-watch-program.ts
+++ b/src/compiler/transpile/create-watch-program.ts
@@ -24,7 +24,6 @@ export const createTsWatchProgram = async (
   let isRunning = false;
   let lastTsBuilder: any;
   let timeoutId: any;
-  let rebuildTimer: any;
 
   // Get the pre-baked TS options we want to use for our builder program
   const optionsToExtend = getTsOptionsToExtend(config);
@@ -44,19 +43,18 @@ export const createTsWatchProgram = async (
      * @returns A {@link NodeJs.Timer} instance
      */
     setTimeout(callback, time) {
-      clearInterval(rebuildTimer);
-      const t = (timeoutId = setInterval(() => {
+      clearTimeout(timeoutId);
+      const delay = config.sys.watchTimeout || time;
+      const tick = () => {
         if (!isRunning) {
           callback();
-          clearInterval(t);
-          timeoutId = rebuildTimer = null;
+          timeoutId = null;
+        } else {
+          timeoutId = setTimeout(tick, delay);
         }
-      }, config.sys.watchTimeout || time));
-      return t;
-    },
-
-    clearTimeout(id) {
-      return clearInterval(id);
+      }
+      timeoutId = setTimeout(tick, delay);
+      return timeoutId;
     },
   };
 
@@ -111,8 +109,8 @@ export const createTsWatchProgram = async (
     // This will be called via a callback on the watch build whenever a file
     // change is detected
     rebuild: () => {
-      if (lastTsBuilder && !timeoutId) {
-        rebuildTimer = tsWatchSys.setTimeout(() => tsWatchHost.afterProgramCreate(lastTsBuilder), 300);
+      if (lastTsBuilder) {
+        tsWatchSys.setTimeout(() => tsWatchHost.afterProgramCreate(lastTsBuilder), 300);
       }
     },
   };

--- a/src/compiler/transpile/create-watch-program.ts
+++ b/src/compiler/transpile/create-watch-program.ts
@@ -52,7 +52,7 @@ export const createTsWatchProgram = async (
         } else {
           timeoutId = setTimeout(tick, delay);
         }
-      }
+      };
       timeoutId = setTimeout(tick, delay);
       return timeoutId;
     },


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6190

The file watcher sometimes fails to trigger a rebuild:

![2025-03-11 18 16 49](https://github.com/user-attachments/assets/3ffaa9c0-215c-437f-a346-5115be73331c)

This is caused by the "Back up files before saving" option in my editor.
When this option is disabled the file watcher works just fine.
However, the "Back up files before saving" option is enabled per default and Stencil should be able to handle this.

> The above demo was recorded on a clean install of Stencil. It should be fairly simple to reproduce the issue as long you're using "Back up files before saving". (I don't know if it's just PHPStorm or other editors as well.)

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

After applying these changes the watcher behaves beautifully with or without "Back up files before saving" option enabled.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

–

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

I tested the code with a custom `@stencil/core` build in my application running `stencil build --watch --verbose`. I also made sure that the issue is not specific to my project. I installed a clean Stencil project and repeated my tests with and without the "Back up files before saving" option.

I ran the test suite via `npm run test` and made sure tests are still passing. I did not add any new tests.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

Ignoring backup files via [`watchIgnoredRegex: [/\.\w+~$/]`](https://stenciljs.com/docs/config#watchignoredregex) or using `"**/*.*~"` on the `watchOptions.excludeFiles` `tsconfig.json` option did not work.

> These options generally don't work for me. (Or I'm misinterpreting the `NODE_SYS_DEBUG` and `WATCH_BUILD` logging.)

The existing implementation was running into the `lastTsBuilder && !timeoutId` condition with a `timeoutId` being present even though there was no running build or any other good reason not to rebuild.

The change simplifies the implementation by using a recursive `setTimeout` to wait for pending builds.

This allows to:

  - remove the extra `rebuildTimer` which was arguably confusing
  - remove the clearTimeout override

Since we immediately call `clearTimeout(timeoutId)` in the `setTimeout` override, we don't stack up rebuild requests.
