### PR TITLE
fix(loader): remove package.json as it interferes with main

### DIFF
--- a/src/compiler/output-targets/output-lazy-loader.ts
+++ b/src/compiler/output-targets/output-lazy-loader.ts
@@ -27,23 +27,6 @@ const generateLoader = async (
   }
 
   const es5HtmlElement = await getClientPolyfill(config, compilerCtx, 'es5-html-element.js');
-
-  const packageJsonContent = JSON.stringify(
-    {
-      name: config.fsNamespace + '-loader',
-      private: true,
-      typings: './index.d.ts',
-      module: './index.js',
-      main: './index.cjs.js',
-      'jsnext:main': './index.es2017.js',
-      es2015: './index.es2017.js',
-      es2017: './index.es2017.js',
-      unpkg: './cdn.js',
-    },
-    null,
-    2,
-  );
-
   const polyfillsEntryPoint = join(es2017Dir, 'polyfills/index.js');
   const polyfillsExport = `export * from '${relative(loaderPath, polyfillsEntryPoint)}';`;
 
@@ -72,7 +55,6 @@ const generateLoader = async (
   const indexDtsPath = join(loaderPath, 'index.d.ts');
 
   await Promise.all([
-    compilerCtx.fs.writeFile(join(loaderPath, 'package.json'), packageJsonContent),
     compilerCtx.fs.writeFile(join(loaderPath, 'index.d.ts'), generateIndexDts(indexDtsPath, outputTarget.componentDts)),
     compilerCtx.fs.writeFile(join(loaderPath, 'index.js'), indexContent),
     compilerCtx.fs.writeFile(join(loaderPath, 'index.cjs.js'), indexCjsContent),


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->

The auto-generated `package.json` that Stencil inserts within the `loader` dir seems unnecessary now. 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The auto-generated `package.json`: 
- overrules settings within the main `package.json` [leading to unexpected behaviour](https://github.com/stenciljs/core/issues/5637) 
- removes developer wishes and agency - "*I* should control how & what is exported"


GitHub Issue Number: https://github.com/stenciljs/core/issues/5637 < the fix was merely a stop gap and is not a 'modern' solution (node now supports es modules natively) 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Stop stencil inserting the loader `package.json`

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
