### PR TITLE
build: improve `nodeResolve` config

### DIFF
--- a/src/compiler/bundle/bundle-output.ts
+++ b/src/compiler/bundle/bundle-output.ts
@@ -62,8 +62,8 @@ export const getRollupOptions = (
     browser: bundleOpts.platform !== 'hydrate',
     rootDir: config.rootDir,
     exportConditions: ['default', 'module', 'import', 'require'],
-    ...(config.nodeResolve as any),
     extensions: ['.tsx', '.ts', '.mts', '.cts', '.js', '.mjs', '.cjs', '.json', '.d.ts', '.d.mts', '.d.cts'],
+    ...config.nodeResolve,
   });
 
   // @ts-expect-error - this is required now.

--- a/src/compiler/bundle/bundle-output.ts
+++ b/src/compiler/bundle/bundle-output.ts
@@ -59,8 +59,9 @@ export const getRollupOptions = (
 ): RollupOptions => {
   const nodeResolvePlugin = rollupNodeResolvePlugin({
     mainFields: ['collection:main', 'jsnext:main', 'es2017', 'es2015', 'module', 'main'],
-    browser: true,
+    browser: bundleOpts.platform !== 'hydrate',
     rootDir: config.rootDir,
+    exportConditions: ['default', 'module', 'import', 'require'],
     ...(config.nodeResolve as any),
     extensions: ['.tsx', '.ts', '.mts', '.cts', '.js', '.mjs', '.cjs', '.json', '.d.ts', '.d.mts', '.d.cts'],
   });

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1772,15 +1772,19 @@ export interface BundlingConfig {
 }
 
 export interface NodeResolveConfig {
-  module?: boolean;
-  jsnext?: boolean;
-  main?: boolean;
+  exportConditions?: string[];
   browser?: boolean;
-  extensions?: string[];
-  preferBuiltins?: boolean;
+  moduleDirectories?: string[];
+  modulePaths?: string[];
+  dedupe?: string[] | ((importee: string) => boolean);
+  extensions?: readonly string[];
   jail?: string;
-  only?: Array<string | RegExp>;
+  mainFields?: readonly string[];
   modulesOnly?: boolean;
+  preferBuiltins?: boolean | ((module: string) => boolean);
+  resolveOnly?: ReadonlyArray<string | RegExp> | null | ((module: string) => boolean);
+  rootDir?: string;
+  allowExportsFolderMapping?: boolean;
 
   // TODO(STENCIL-1107): Remove this field [BREAKING_CHANGE]
   /**

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1779,7 +1779,7 @@ export interface NodeResolveConfig {
   dedupe?: string[] | ((importee: string) => boolean);
   extensions?: readonly string[];
   jail?: string;
-  mainFields?: readonly string[];
+  mainFields?: string[];
   modulesOnly?: boolean;
   preferBuiltins?: boolean | ((module: string) => boolean);
   resolveOnly?: ReadonlyArray<string | RegExp> | null | ((module: string) => boolean);

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -1779,7 +1779,7 @@ export interface NodeResolveConfig {
   dedupe?: string[] | ((importee: string) => boolean);
   extensions?: readonly string[];
   jail?: string;
-  mainFields?: string[];
+  mainFields?: readonly string[];
   modulesOnly?: boolean;
   preferBuiltins?: boolean | ((module: string) => boolean);
   resolveOnly?: ReadonlyArray<string | RegExp> | null | ((module: string) => boolean);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Stencil's default `nodeResolve` config doesn't pay attention to the `exports` > `require` field (which is present in the axios lib - https://github.com/axios/axios/issues/5888)

GitHub Issue Number: https://github.com/stenciljs/core/issues/6202


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Closes https://github.com/stenciljs/core/issues/6202

- Include `require` in nodeResolve `exportConditions` (Note - I'm not 100% sure if we should as I *think* axios is in the wrong here - https://github.com/axios/axios/issues/5888#issuecomment-2721184793)
- update `nodeResolve` types to match the plugin
- allow users' `nodeResolve` config to take precedence over default - giving users more control

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
