### PR TITLE
feat(jsx): add support for aria-* attributes in JSX typings

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1853,6 +1853,10 @@ export namespace JSXBase {
     onTransitionRunCapture?: (event: TransitionEvent) => void;
     onTransitionStart?: (event: TransitionEvent) => void;
     onTransitionStartCapture?: (event: TransitionEvent) => void;
+
+    // WAI-ARIA Attributes
+    [key: `aria-${string}`]: string | boolean | undefined;
+    [key: `aria${string}`]: string | boolean | undefined;
   }
 }
 


### PR DESCRIPTION
Add typings for ARIA attributes like `aria-labelledby`, `aria-hidden`, etc., to the DOMAttributes interface. This allows better accessibility support and developer experience via type safety and IntelliSense.

fixes: #6182

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6182 
Currently, JSX attributes with ARIA prefixes such as aria-label, aria-hidden, etc., are not typed, leading to missing IntelliSense and potential type errors in TypeScript.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

JSX ARIA attributes are now explicitly typed in the DOMAttributes interface, enabling proper IntelliSense, autocomplete, and validation in IDEs and TypeScript-aware tooling.
This includes support for all standard ARIA attributes, and optionally, a generic index signature for custom aria-* values.


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
