### PR TITLE
test(core): add type tests for JSX

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
 
   type_tests:
     name: Type Tests
+    needs: [build_core]
     uses: ./.github/workflows/test-types.yml
 
   analysis_tests:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,10 @@ jobs:
     name: Lint and Format
     uses: ./.github/workflows/lint-and-format.yml
 
+  type_tests:
+    name: Type Tests
+    uses: ./.github/workflows/test-types.yml
+
   analysis_tests:
     name: Analysis Tests
     needs: [build_core]

--- a/.github/workflows/test-types.yml
+++ b/.github/workflows/test-types.yml
@@ -1,0 +1,26 @@
+name: Type Tests
+
+on:
+  workflow_call:
+    # Make this a reusable workflow, no value needed
+    # https://docs.github.com/en/actions/using-workflows/reusing-workflows
+
+jobs:
+  unit_test:
+    name: Type Tests
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Get Core Dependencies
+        uses: ./.github/workflows/actions/get-core-dependencies
+
+      - name: Type Tests
+        run: npm run test.type-tests
+        shell: bash
+
+      - name: Check Git Context
+        uses: ./.github/workflows/actions/check-git-context

--- a/.github/workflows/test-types.yml
+++ b/.github/workflows/test-types.yml
@@ -21,6 +21,3 @@ jobs:
       - name: Type Tests
         run: npm run test.type-tests
         shell: bash
-
-      - name: Check Git Context
-        uses: ./.github/workflows/actions/check-git-context

--- a/.github/workflows/test-types.yml
+++ b/.github/workflows/test-types.yml
@@ -18,6 +18,19 @@ jobs:
       - name: Get Core Dependencies
         uses: ./.github/workflows/actions/get-core-dependencies
 
+      - name: Use Node ${{ matrix.node }}
+        uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
+        with:
+          node-version: ${{ matrix.node }}
+          cache: 'npm'
+
+      - name: Download Build Archive
+        uses: ./.github/workflows/actions/download-archive
+        with:
+          name: stencil-core
+          path: .
+          filename: stencil-core-build.zip
+
       - name: Type Tests
         run: npm run test.type-tests
         shell: bash

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "test.dist": "npm run ts scripts/index.ts -- --validate-build",
     "test.end-to-end": "cd test/end-to-end && npm ci && npm test && npm run test.dist",
     "test.jest": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
-    "test.type-tests": "tsc -p test/type-tests/tsconfig.json",
+    "test.type-tests": "cd ./test/wdio && npm run build.main && cd ../../ && tsc -p test/type-tests/tsconfig.json",
     "test.wdio": "cd test/wdio && npm ci && npm run test",
     "test.wdio.testOnly": "cd test/wdio && npm ci && npm run wdio",
     "test.prod": "npm run test.dist && npm run test.end-to-end && npm run test.jest && npm run test.wdio && npm run test.testing && npm run test.analysis",

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "test.dist": "npm run ts scripts/index.ts -- --validate-build",
     "test.end-to-end": "cd test/end-to-end && npm ci && npm test && npm run test.dist",
     "test.jest": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
-    "test.type-tests": "cd ./test/wdio && npm run build.main && cd ../../ && tsc -p test/type-tests/tsconfig.json",
+    "test.type-tests": "cd ./test/wdio && npm install && npm run build.main && cd ../../ && tsc -p test/type-tests/tsconfig.json",
     "test.wdio": "cd test/wdio && npm ci && npm run test",
     "test.wdio.testOnly": "cd test/wdio && npm ci && npm run wdio",
     "test.prod": "npm run test.dist && npm run test.end-to-end && npm run test.jest && npm run test.wdio && npm run test.testing && npm run test.analysis",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "test.dist": "npm run ts scripts/index.ts -- --validate-build",
     "test.end-to-end": "cd test/end-to-end && npm ci && npm test && npm run test.dist",
     "test.jest": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js",
+    "test.type-tests": "tsc -p test/type-tests/tsconfig.json",
     "test.wdio": "cd test/wdio && npm ci && npm run test",
     "test.wdio.testOnly": "cd test/wdio && npm ci && npm run wdio",
     "test.prod": "npm run test.dist && npm run test.end-to-end && npm run test.jest && npm run test.wdio && npm run test.testing && npm run test.analysis",

--- a/test/type-tests/README.md
+++ b/test/type-tests/README.md
@@ -1,0 +1,9 @@
+# Stencil Type Tests
+
+This directory is used to test whether Stencil correctly interprets JSX types in a basic Stencil project. Feel free to enhance the `test.spec.ts` file with your own scenario or create a new file.
+
+To run these tests, run the following from the root of the Stencil project:
+
+```sh
+npm run test.type-tests
+```

--- a/test/type-tests/test.spec.tsx
+++ b/test/type-tests/test.spec.tsx
@@ -1,0 +1,33 @@
+/// <reference types="../wdio/dist/components.d.ts" />
+
+import { h } from '@stencil/core';
+
+export function TypeTestComponent() {
+  return (
+    <div>
+      <h1 ariaLabel="123">Hello</h1>
+      <h1 ariaLabel={"123"}>Hello</h1>
+      {/* @ts-expect-error */}
+      <h1 ariaLabel={123}>Hello</h1>
+      <attribute-complex
+        // @ts-expect-error
+        nu0={'123'}
+        nu1={123}
+        nu2={123}
+        bool0={true}
+        bool1={true}
+        bool2={true}
+        str0={'123'}
+        str1={'123'}
+        str2={'123'}
+        obj={'123'}
+      ></attribute-complex>
+      <my-component
+        // @ts-expect-error
+        first={123}
+        last={'123'}
+        middle={'123'}
+      ></my-component>
+    </div>
+  );
+}

--- a/test/type-tests/test.spec.tsx
+++ b/test/type-tests/test.spec.tsx
@@ -1,4 +1,4 @@
-/// <reference types="../wdio/dist/components.d.ts" />
+/// <reference types="../wdio/dist/types/components.d.ts" />
 
 import { h } from '@stencil/core';
 

--- a/test/type-tests/test.spec.tsx
+++ b/test/type-tests/test.spec.tsx
@@ -6,7 +6,7 @@ export function TypeTestComponent() {
   return (
     <div>
       <h1 ariaLabel="123">Hello</h1>
-      <h1 ariaLabel={"123"}>Hello</h1>
+      <h1 ariaLabel={'123'}>Hello</h1>
       {/* @ts-expect-error */}
       <h1 ariaLabel={123}>Hello</h1>
       <attribute-complex

--- a/test/type-tests/tsconfig.json
+++ b/test/type-tests/tsconfig.json
@@ -1,0 +1,36 @@
+{
+  "compilerOptions": {
+    "noEmit": true,
+    "declaration": false,
+    "resolveJsonModule": false,
+    "experimentalDecorators": true,
+    "jsx": "react",
+    "jsxFactory": "h",
+    "jsxFragmentFactory": "h.Fragment",
+    "lib": [
+      "dom",
+      "ES2021"
+    ],
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "forceConsistentCasingInFileNames": true,
+    "noImplicitAny": false,
+    "noImplicitReturns": false,
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "alwaysStrict": true,
+    "allowSyntheticDefaultImports": true,
+    "allowUnreachableCode": false,
+    "useUnknownInCatchVariables": true,
+    "skipDefaultLibCheck": true,
+    "paths": {
+      "@stencil/core": ["../../internal"],
+      "@stencil/core/internal": ["../../internal"],
+      "@test-sibling": ["./test-sibling"]
+    }
+  },
+  "include": [
+    ".",
+    "../wdio/dist/components.d.ts"
+  ]
+}

--- a/test/type-tests/tsconfig.json
+++ b/test/type-tests/tsconfig.json
@@ -31,6 +31,6 @@
   },
   "include": [
     ".",
-    "../wdio/dist/components.d.ts"
+    "../wdio/dist/types/components.d.ts"
   ]
 }

--- a/test/wdio/event-custom-type/cmp.tsx
+++ b/test/wdio/event-custom-type/cmp.tsx
@@ -1,7 +1,5 @@
 import { Component, Event, EventEmitter, h, Listen, State } from '@stencil/core';
 
-import { EventCustomTypeCustomEvent } from '../src/components.js';
-
 export interface TestEventDetail {
   value: string;
 }
@@ -16,7 +14,7 @@ export class EventCustomType {
   @State() lastEventValue: TestEventDetail;
 
   @Listen('testEvent')
-  testEventHandler(newValue: EventCustomTypeCustomEvent<TestEventDetail>) {
+  testEventHandler(newValue: CustomEvent<TestEventDetail>) {
     this.counter++;
     this.lastEventValue = newValue.detail;
   }


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
After reviewing #6221 I looked into whether we have type tests for JSX files and it seems we don't.

## What is the new behavior?
This patch adds some basic type tests that help us verify that Stencil correctly generates and connects JSX namespaces.

## Documentation

n/a

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

This PR will fail as it requires #6221 to be merged first.

## Other information

n/a
