### PR TITLE
fix(utils): don't create sourcemap file if disabled

### DIFF
--- a/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts
@@ -254,7 +254,7 @@ const writeLazyChunk = async (
     destinations.map((dst) => {
       const filePath = join(dst, rollupResult.fileName);
       let fileCode = code;
-      if (rollupResult.map) {
+      if (sourceMap) {
         fileCode = code + getSourceMappingUrlForEndOfFile(rollupResult.fileName);
         compilerCtx.fs.writeFile(filePath + '.map', JSON.stringify(sourceMap), { outputTargetType });
       }

--- a/src/utils/sourcemaps.ts
+++ b/src/utils/sourcemaps.ts
@@ -11,7 +11,7 @@ export function rollupToStencilSourceMap(rollupSourceMap: null): null;
 export function rollupToStencilSourceMap(rollupSourceMap: undefined): null;
 export function rollupToStencilSourceMap(rollupSourceMap: RollupSourceMap): d.SourceMap;
 export function rollupToStencilSourceMap(rollupSourceMap: RollupSourceMap | undefined | null): d.SourceMap | null {
-  if (!rollupSourceMap) {
+  if (!rollupSourceMap || !rollupSourceMap.file) {
     return null;
   }
 

--- a/src/utils/test/sourcemaps.spec.ts
+++ b/src/utils/test/sourcemaps.spec.ts
@@ -18,6 +18,10 @@ describe('sourcemaps', () => {
       expect(rollupToStencilSourceMap(undefined)).toBeNull();
     });
 
+    it('returns null if the given sourcemap has no file', () => {
+      expect(rollupToStencilSourceMap({ sourcesContent: [] } as RollupSourceMap)).toBeNull();
+    });
+
     it('transforms a rollup sourcemap to a stencil sourcemap', () => {
       const rollupSourceMap: RollupSourceMap = {
         file: 'index.js',


### PR DESCRIPTION
## What is the current behavior?
Stencil creates empty sourcemap files with `{ "sourcesContent": [] }` content if `sourceMap` is disabled. This may be related to the Rollup upgrade which now emits these files.

GitHub Issue Number: ionic-team/ionic-framework#30323

## What is the new behavior?
Add an additional check to verify that there is a sourcemap file.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Added unit tests.

## Other information

n/a
