### PR TITLE
fix(declarations): update PluginTransformResults after Rollup update

### DIFF
--- a/src/compiler/style/global-styles.ts
+++ b/src/compiler/style/global-styles.ts
@@ -58,13 +58,7 @@ const buildGlobalStyles = async (config: d.ValidatedConfig, compilerCtx: d.Compi
         return null;
       }
 
-      const optimizedCss = await optimizeCss(
-        config,
-        compilerCtx,
-        buildCtx.diagnostics,
-        cssCode,
-        globalStylePath,
-      );
+      const optimizedCss = await optimizeCss(config, compilerCtx, buildCtx.diagnostics, cssCode, globalStylePath);
       compilerCtx.cachedGlobalStyle = optimizedCss;
 
       if (Array.isArray(dependencies)) {

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1299,10 +1299,12 @@ export interface Plugin {
     sourceText: string,
     id: string,
     context: PluginCtx,
-  ) => Promise<PluginTransformResults> | PluginTransformResults | string;
+  ) => Promise<PluginTransformResults> | PluginTransformResults;
 }
 
-export interface PluginTransformResults {
+export type PluginTransformResults = PluginTransformationDescriptor | string | null;
+
+export interface PluginTransformationDescriptor {
   code?: string;
   map?: string;
   id?: string;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
Some Rollup types are incorrect after update.

GitHub Issue Number: #6231

## What is the new behavior?
Update the types.

## Documentation

n/a

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

n/a

## Other information

n/a
