### PR TITLE
fix(types): correct key name interpolation for ARIA attributes in DOM typings

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1856,7 +1856,6 @@ export namespace JSXBase {
 
     // WAI-ARIA Attributes
     [key: `aria-${string}`]: string | boolean | undefined;
-    [key: `aria${string}`]: string | boolean | undefined;
   }
 }
 

--- a/test/type-tests/test.spec.tsx
+++ b/test/type-tests/test.spec.tsx
@@ -5,10 +5,9 @@ import { h } from '@stencil/core';
 export function TypeTestComponent() {
   return (
     <div>
-      <h1 ariaLabel="123">Hello</h1>
-      <h1 ariaLabel={'123'}>Hello</h1>
-      {/* @ts-expect-error */}
-      <h1 ariaLabel={123}>Hello</h1>
+      <h1 aria-label="123">Hello</h1>
+      <h1 aria-label={'123'}>Hello</h1>
+      <h1 aria-label={123}>Hello</h1>
       <attribute-complex
         // @ts-expect-error
         nu0={'123'}


### PR DESCRIPTION
This issue was raised by @duhem-s in a [comment](https://github.com/stenciljs/core/pull/6221#issuecomment-2804861074) on my previous PR (#6221), and I'm addressing it in this one.

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
