### PR TITLE
feat(hydrate): add `serializeShadowroot` to hydrateDocument

### DIFF
--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -974,34 +974,6 @@ export interface SerializeDocumentOptions extends HydrateDocumentOptions {
    */
   removeHtmlComments?: boolean;
   /**
-   * Configure how Stencil serializes the components shadow root.
-   * - If set to `declarative-shadow-dom` the component will be rendered within a Declarative Shadow DOM.
-   * - If set to `scoped` Stencil will render the contents of the shadow root as a `scoped: true` component
-   *   and the shadow DOM will be created during client-side hydration.
-   * - Alternatively you can mix and match the two by providing an object with `declarative-shadow-dom` and `scoped` keys,
-   * the value arrays containing the tag names of the components that should be rendered in that mode.
-   *
-   * Examples:
-   * - `{ 'declarative-shadow-dom': ['my-component-1', 'another-component'], default: 'scoped' }`
-   * Render all components as `scoped` apart from `my-component-1` and `another-component`
-   * -  `{ 'scoped': ['an-option-component'], default: 'declarative-shadow-dom' }`
-   * Render all components within `declarative-shadow-dom` apart from `an-option-component`
-   * - `'scoped'` Render all components as `scoped`
-   * - `false` disables shadow root serialization
-   *
-   * *NOTE* `true` has been deprecated in favor of `declarative-shadow-dom` and `scoped`
-   * @default 'declarative-shadow-dom'
-   */
-  serializeShadowRoot?:
-    | 'declarative-shadow-dom'
-    | 'scoped'
-    | {
-        'declarative-shadow-dom'?: string[];
-        scoped?: string[];
-        default: 'declarative-shadow-dom' | 'scoped';
-      }
-    | boolean;
-  /**
    * The `fullDocument` flag determines the format of the rendered output. Set it to true to
    * generate a complete HTML document, or false to render only the component.
    * @default true

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -902,6 +902,34 @@ export interface HydrateDocumentOptions {
    * Sets `navigator.userAgent`
    */
   userAgent?: string;
+  /**
+   * Configure how Stencil serializes the components shadow root.
+   * - If set to `declarative-shadow-dom` the component will be rendered within a Declarative Shadow DOM.
+   * - If set to `scoped` Stencil will render the contents of the shadow root as a `scoped: true` component
+   *   and the shadow DOM will be created during client-side hydration.
+   * - Alternatively you can mix and match the two by providing an object with `declarative-shadow-dom` and `scoped` keys,
+   * the value arrays containing the tag names of the components that should be rendered in that mode.
+   *
+   * Examples:
+   * - `{ 'declarative-shadow-dom': ['my-component-1', 'another-component'], default: 'scoped' }`
+   * Render all components as `scoped` apart from `my-component-1` and `another-component`
+   * -  `{ 'scoped': ['an-option-component'], default: 'declarative-shadow-dom' }`
+   * Render all components within `declarative-shadow-dom` apart from `an-option-component`
+   * - `'scoped'` Render all components as `scoped`
+   * - `false` disables shadow root serialization
+   *
+   * *NOTE* `true` has been deprecated in favor of `declarative-shadow-dom` and `scoped`
+   * @default 'declarative-shadow-dom'
+   */
+  serializeShadowRoot?:
+    | 'declarative-shadow-dom'
+    | 'scoped'
+    | {
+        'declarative-shadow-dom'?: string[];
+        scoped?: string[];
+        default: 'declarative-shadow-dom' | 'scoped';
+      }
+    | boolean;
 }
 
 export interface SerializeDocumentOptions extends HydrateDocumentOptions {

--- a/src/hydrate/runner/render.ts
+++ b/src/hydrate/runner/render.ts
@@ -70,6 +70,11 @@ export function hydrateDocument(
   asStream?: boolean,
 ): Promise<HydrateResults> | Readable {
   const opts = normalizeHydrateOptions(options);
+  /**
+   * Defines whether we render the shadow root as a declarative shadow root or as scoped shadow root.
+   */
+  opts.serializeShadowRoot =
+    typeof opts.serializeShadowRoot === 'undefined' ? 'declarative-shadow-dom' : opts.serializeShadowRoot;
 
   let win: MockWindow | null = null;
   const results = generateHydrateResults(opts);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6240


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
`hydrateDocument` has been extended to provide the `serializeShadowRoot` opt to be inline with what is provided with `renderToString`


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Test was added to `test.e2e.ts` to verify the new option

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
