### PR TITLE
feat(hydrate): export style content from hydrated scoped components

### DIFF
--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1196,7 +1196,9 @@ export interface HydrateScriptElement extends HydrateElement {
 }
 
 export interface HydrateStyleElement extends HydrateElement {
+  id?: string;
   href?: string;
+  content?: string;
 }
 
 export interface HydrateStaticData {

--- a/src/hydrate/runner/render.ts
+++ b/src/hydrate/runner/render.ts
@@ -4,6 +4,7 @@ import { hydrateFactory } from '@hydrate-factory';
 import { modeResolutionChain, setMode } from '@platform';
 import { MockWindow, serializeNodeToHtml } from '@stencil/core/mock-doc';
 import { hasError } from '@utils';
+import { HYDRATED_STYLE_ID } from '@runtime';
 
 import { updateCanonicalLink } from '../../compiler/html/canonical-link';
 import { relocateMetaCharset } from '../../compiler/html/relocate-meta-charset';
@@ -208,6 +209,15 @@ function finalizeHydrate(win: MockWindow, doc: Document, opts: HydrateFactoryOpt
 
     if (opts.removeScripts) {
       removeScripts(doc.documentElement);
+    }
+
+    const styles = doc.querySelectorAll('head style');
+    if (styles.length > 0) {
+      results.styles.push(...Array.from(styles).map((style) => ({
+        href: style.getAttribute('href'),
+        id: style.getAttribute(HYDRATED_STYLE_ID),
+        content: style.textContent,
+      })));
     }
 
     try {

--- a/src/runtime/index.ts
+++ b/src/runtime/index.ts
@@ -18,3 +18,4 @@ export { forceUpdate, getRenderingRef, postUpdateComponent } from './update-comp
 export { h, Host } from './vdom/h';
 export { insertVdomAnnotations } from './vdom/vdom-annotations';
 export { renderVdom } from './vdom/vdom-render';
+export { HYDRATED_STYLE_ID } from './runtime-constants';

--- a/test/end-to-end/package-lock.json
+++ b/test/end-to-end/package-lock.json
@@ -25,7 +25,7 @@
     },
     "../..": {
       "name": "@stencil/core",
-      "version": "4.28.2",
+      "version": "4.31.0",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/test/end-to-end/src/miscellaneous/renderToString.e2e.ts
+++ b/test/end-to-end/src/miscellaneous/renderToString.e2e.ts
@@ -159,4 +159,12 @@ describe('renderToString', () => {
       '<head><meta charset="utf-8"><style sty-id="sc-scoped-car-list">.sc-scoped-car-list-h{display:block;margin:10px;padding:10px;border:1px solid blue}ul.sc-scoped-car-list{display:block;margin:0;padding:0}li.sc-scoped-car-list{list-style:none;margin:0;padding:20px}.selected.sc-scoped-car-list{font-weight:bold;background:rgb(255, 255, 210)}</style><style class="vjs-styles-defaults">.video-js {width: 300px;height: 150px;}.vjs-fluid:not(.vjs-audio-only-mode) {padding-top: 56.25%}</style> <link rel="stylesheet" href="whatever.css"> </head>',
     );
   });
+
+  it('populates style information even if we do not render the whole document', async () => {
+    const { styles } = await renderToString(`<scoped-car-list cars=${JSON.stringify([vento, beetle])}></scoped-car-list>`);
+    expect(styles.length).toBe(2);
+    expect(styles[0].id).toBe('sc-scoped-car-list');
+    expect(styles[0].content).toContain('.sc-scoped-car-list-h{display:block;');
+    expect(styles[1].content).toContain('.video-js {');
+  });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
Rendering scoped components through the hydrate module doesn't allow users to access the style information of scoped components unless they render the whole document and parse the style tags out.

## What is the new behavior?
This patch populates style information as part of the `HydrateResults` object.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Added e2e tests for this.

## Other information

n/a
