### PR TITLE
onClick returns PointerEvent instead of MouseEvent

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1781,7 +1781,7 @@ export namespace JSXBase {
 
     // MouseEvents
     onAuxClick?: (event: MouseEvent) => void;
-    onClick?: (event: MouseEvent) => void;
+    onClick?: (event: PointerEvent) => void;
     onClickCapture?: (event: MouseEvent) => void;
     onContextMenu?: (event: MouseEvent) => void;
     onContextMenuCapture?: (event: MouseEvent) => void;


### PR DESCRIPTION
resolve https://github.com/stenciljs/core/issues/6217


## What is the current behavior?
onClick attribute returns a `MouseEvent`


## What is the new behavior?
As per MDN documentation, onClick attribute now returns a `PointerEvent`


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

Is any test needed?

