### PR TITLE
ci: update GitHub Actions workflows

### DIFF
--- a/.github/workflows/actions/get-core-dependencies/action.yml
+++ b/.github/workflows/actions/get-core-dependencies/action.yml
@@ -9,7 +9,7 @@ runs:
     - name: Use Node Version from Volta
       uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4.0.3
       with:
-        node-version-file: './package.json'
+        node-version-file: './.nvmrc'
         cache: 'npm'
 
     - name: Install Dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     name: Core
     strategy:
       matrix:
-        os: ['ubuntu-22.04', 'windows-latest']
+        os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Code
@@ -32,7 +32,7 @@ jobs:
         shell: bash
 
       - name: Upload Build Artifacts
-        if: ${{ matrix.os == 'ubuntu-22.04' }}
+        if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: ./.github/workflows/actions/upload-archive
         with:
           name: stencil-core

--- a/.github/workflows/lint-and-format.yml
+++ b/.github/workflows/lint-and-format.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   format:
     name: Check
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout Code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/release-dev.yml
+++ b/.github/workflows/release-dev.yml
@@ -18,7 +18,7 @@ jobs:
   get-dev-version:
     name: Get Dev Build Version
     needs: [build_core]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       dev-version: ${{ steps.get-dev-version.outputs.DEV_VERSION }}
     steps:
@@ -55,7 +55,7 @@ jobs:
   release-stencil-dev-build:
     name: Publish Dev Build
     needs: [get-dev-version, build_core]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/release-nightly.yml
+++ b/.github/workflows/release-nightly.yml
@@ -17,7 +17,7 @@ jobs:
   get-nightly-version:
     name: Get Nightly Build Version
     needs: [build_core]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     outputs:
       nightly-version: ${{ steps.get-nightly-version.outputs.NIGHTLY_VERSION }}
     steps:
@@ -57,7 +57,7 @@ jobs:
   release-stencil-nightly-build:
     name: Publish Nightly Build
     needs: [get-nightly-version, build_core]
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/test-analysis.yml
+++ b/.github/workflows/test-analysis.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['18', '20', '22']
+        node: ['20', '22', '24']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-bundlers.yml
+++ b/.github/workflows/test-bundlers.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   bundler_tests:
     name: Verify Bundlers
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout Code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/test-component-starter.yml
+++ b/.github/workflows/test-component-starter.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         jest: ['24', '25', '26', '27', '28', '29']
-        node: ['18', '20', '22']
+        node: ['20', '22', '24']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-copytask.yml
+++ b/.github/workflows/test-copytask.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   bundler_tests:
     name: Verify Copy Task
-    runs-on: 'ubuntu-22.04'
+    runs-on: 'ubuntu-latest'
     steps:
       - name: Checkout Code
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6

--- a/.github/workflows/test-docs-build.yml
+++ b/.github/workflows/test-docs-build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['16', '18', '20', '22']
+        node: ['20', '22', '24']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['18', '20', '22']
+        node: ['20', '22', '24']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-types.yml
+++ b/.github/workflows/test-types.yml
@@ -8,8 +8,6 @@ on:
 jobs:
   unit_test:
     name: Type Tests
-    strategy:
-      fail-fast: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ['16', '18', '20', '22']
+        node: ['20', '22', '24']
         os: ['ubuntu-latest', 'windows-latest']
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test-wdio.yml
+++ b/.github/workflows/test-wdio.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   wdio_test:
     name: Run WebdriverIO Component Tests (${{ matrix.browser }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         # browser: [CHROME, FIREFOX, EDGE]


### PR DESCRIPTION
## Summary

This PR modernizes our GitHub Actions workflows by updating Node.js support matrix, Ubuntu runners, and Node version management configuration.

## Changes

### Node.js Version Updates
- **Updated support matrix**: Now supports Node.js 20, 22, and 24
- **Dropped support**: Removed Node.js 16 and 18 from test matrix
- **Version source**: Changed from `package.json` to `.nvmrc` for Node version detection

### Runner Updates
- **Ubuntu version**: Migrated from `ubuntu-22.04` to `ubuntu-latest` across all workflows
- **Consistency**: Standardized runner versions across build, test, and release workflows

### Workflow Optimizations
- **Type tests**: Removed unnecessary `fail-fast: false` strategy configuration

## Motivation

- **Node.js 16 & 18**: Both versions have reached or are approaching end-of-life
- **Node.js 24**: Latest LTS version should be supported
- **Ubuntu latest**: Using `ubuntu-latest` ensures we get security updates and latest tooling
- **`.nvmrc` consistency**: Aligns with local development environment setup

## Files Modified

- `.github/workflows/actions/get-core-dependencies/action.yml`
- `.github/workflows/build.yml`
- `.github/workflows/lint-and-format.yml`
- `.github/workflows/release-dev.yml`
- `.github/workflows/release-nightly.yml`
- `.github/workflows/test-analysis.yml`
- `.github/workflows/test-bundlers.yml`
- `.github/workflows/test-component-starter.yml`
- `.github/workflows/test-copytask.yml`
- `.github/workflows/test-docs-build.yml`
- `.github/workflows/test-e2e.yml`
- `.github/workflows/test-types.yml`
- `.github/workflows/test-unit.yml`
- `.github/workflows/test-wdio.yml`

## Testing

All existing workflows will continue to function with the updated configurations. The test matrix changes will:
- ✅ Continue testing on Node.js 20 and 22 (existing coverage)
- ✅ Add Node.js 24 testing (new coverage)
- ⚠️ Remove Node.js 16 and 18 testing (intentional)

## Breaking Changes

None for users, but CI will no longer test Node.js 16 and 18 compatibility.