### PR TITLE
fix(compiler): disable dynamic imports in cjs when pass enableImportI…

### DIFF
--- a/src/compiler/output-targets/dist-lazy/generate-cjs.ts
+++ b/src/compiler/output-targets/dist-lazy/generate-cjs.ts
@@ -23,6 +23,12 @@ export const generateCjs = async (
       assetFileNames: '[name]-[hash][extname]',
       sourcemap: config.sourceMap,
     };
+
+    if (!!config.extras.experimentalImportInjection || !!config.extras.enableImportInjection) {
+      esmOpts.interop = 'auto';
+      esmOpts.dynamicImportInCjs = false;
+    }
+
     const results = await generateRollupOutput(rollupBuild, esmOpts, config, buildCtx.entryModules);
     if (results != null) {
       const destinations = cjsOutputs


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When set `enableImportInjection` this code uses `_interopNamespace` rollup helper to inject
https://github.com/stenciljs/core/blob/33363d4077728793e0c6f635a22dccbb5740be49/src/compiler/output-targets/dist-lazy/generate-lazy-module.ts#L175-L181

After Rollup upgrade currently CJS build with this flag enabled, don't have the rollup helper.

GitHub Issue Number: #6270 

## What is the new behavior?

Basically we are making sure that it is generating the _interopNamespace when the `enableImportInjection` setting is being used.

## Documentation

[Rollup Interop](https://rollupjs.org/configuration-options/#output-interop)
[Rollup Dynamic Import is the new default](https://rollupjs.org/migration/#dynamic-import-in-commonjs-output)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Generate a dev stencil build, link with npm link, and test inside the issue repo.
Check the index.js that loader.cjs uses

## Other information
