### PR TITLE
fix(mock-doc): move slot event listener support from runtime to MockDoc

### DIFF
--- a/src/mock-doc/node.ts
+++ b/src/mock-doc/node.ts
@@ -202,6 +202,18 @@ export class MockNode {
     this._nodeValue = String(value);
   }
 
+  addEventListener(type: string, handler: (ev?: any) => void) {
+    addEventListener(this, type, handler);
+  }
+
+  removeEventListener(type: string, handler: any) {
+    removeEventListener(this, type, handler);
+  }
+
+  dispatchEvent(ev: MockEvent) {
+    return dispatchEvent(this, ev);
+  }
+
   static ELEMENT_NODE = 1;
   static TEXT_NODE = 3;
   static PROCESSING_INSTRUCTION_NODE = 7;
@@ -254,7 +266,7 @@ export class MockElement extends MockNode {
     this.__attributeMap = null;
   }
 
-  addEventListener(type: string, handler: (ev?: any) => void) {
+  override addEventListener(type: string, handler: (ev?: any) => void) {
     addEventListener(this, type, handler);
   }
 
@@ -379,7 +391,7 @@ export class MockElement extends MockNode {
     this.setAttributeNS(null, 'dir', value);
   }
 
-  dispatchEvent(ev: MockEvent) {
+  override dispatchEvent(ev: MockEvent) {
     return dispatchEvent(this, ev);
   }
 
@@ -674,7 +686,7 @@ export class MockElement extends MockNode {
     }
   }
 
-  removeEventListener(type: string, handler: any) {
+  override removeEventListener(type: string, handler: any) {
     removeEventListener(this, type, handler);
   }
 

--- a/src/runtime/slot-polyfill-utils.ts
+++ b/src/runtime/slot-polyfill-utils.ts
@@ -197,28 +197,12 @@ export const getSlotName = (node: d.PatchedSlotNode) =>
     : (node.nodeType === 1 && (node as Element).getAttribute('slot')) || undefined;
 
 /**
- * Enhanced slot node type with additional properties
- * for event listeners, assignedElements, and assignedNodes
- */
-type EnhancedStencilSlotElement = HTMLSlotElement & {
-  __eventListeners: { type: string; listener: EventListenerOrEventListenerObject }[];
-};
-
-/**
  * Add `assignedElements` and `assignedNodes` methods on a fake slot node
  *
  * @param node - slot node to patch
  */
 export function patchSlotNode(node: d.RenderNode) {
-  const slotNode = node as HTMLSlotElement & EnhancedStencilSlotElement;
-
-  /**
-   * If the slot node already has assignedElements or assignedNodes,
-   * we don't need to patch it again.
-   */
-  if (slotNode.assignedElements || slotNode.assignedNodes || !node['s-sr']) {
-    return;
-  }
+  if ((node as any).assignedElements || (node as any).assignedNodes || !node['s-sr']) return;
 
   const assignedFactory = (elementsOnly: boolean) =>
     function (opts?: { flatten: boolean }) {
@@ -250,48 +234,8 @@ export function patchSlotNode(node: d.RenderNode) {
       return toReturn;
     }.bind(node);
 
-  slotNode.assignedElements = assignedFactory(true);
-  slotNode.assignedNodes = assignedFactory(false);
-
-  // Add event listener support for slot nodes
-  // Store event listeners on the node
-  slotNode.__eventListeners = slotNode.__eventListeners ?? [];
-
-  // Only add event listener methods if they don't already exist
-  if (!slotNode.addEventListener) {
-    slotNode.addEventListener = function (type: string, listener: EventListenerOrEventListenerObject) {
-      this.__eventListeners = this.__eventListeners || [];
-      this.__eventListeners.push({ type, listener });
-    };
-  }
-
-  if (!slotNode.removeEventListener) {
-    slotNode.removeEventListener = function (type: string, listener: EventListenerOrEventListenerObject) {
-      if (!this.__eventListeners) return;
-      this.__eventListeners = this.__eventListeners.filter((l: any) => !(l.type === type && l.listener === listener));
-    };
-  }
-
-  if (!slotNode.dispatchEvent) {
-    slotNode.dispatchEvent = function (event: Event) {
-      if (!this.__eventListeners) return true;
-
-      const listeners = this.__eventListeners.filter((l: any) => l.type === event.type);
-      for (const { listener } of listeners) {
-        try {
-          if (typeof listener === 'function') {
-            listener.call(this, event);
-          } else if (listener && typeof listener.handleEvent === 'function') {
-            listener.handleEvent(event);
-          }
-        } catch (err) {
-          console.error('Error in slot event listener:', err);
-        }
-      }
-
-      return !event.defaultPrevented;
-    };
-  }
+  (node as any).assignedElements = assignedFactory(true);
+  (node as any).assignedNodes = assignedFactory(false);
 }
 
 /**

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -81,16 +81,6 @@ const createElm = (oldParentVNode: d.VNode, newParentVNode: d.VNode, childIndex:
       BUILD.isDebug || BUILD.hydrateServerSide
         ? slotReferenceDebugNode(newVNode)
         : (win.document.createTextNode('') as any);
-
-    // Set slot node properties before calling updateElement so that addEventListener is available
-    elm['s-sr'] = true;
-    elm['s-cr'] = contentRef;
-    elm['s-sn'] = newVNode.$name$ || '';
-    elm['s-rf'] = newVNode.$attrs$?.ref;
-
-    // Patch the slot node immediately to add addEventListener support
-    patchSlotNode(elm);
-
     // add css classes, attrs, props, listeners, etc.
     if (BUILD.vdomAttribute) {
       updateElement(null, newVNode, isSvgMode);
@@ -169,23 +159,20 @@ const createElm = (oldParentVNode: d.VNode, newParentVNode: d.VNode, childIndex:
   elm['s-hn'] = hostTagName;
   if (BUILD.slotRelocation) {
     if (newVNode.$flags$ & (VNODE_FLAGS.isSlotFallback | VNODE_FLAGS.isSlotReference)) {
-      // For slot reference nodes, these properties were already set earlier
-      if (!(newVNode.$flags$ & VNODE_FLAGS.isSlotReference)) {
-        // remember the content reference comment
-        elm['s-sr'] = true;
+      // remember the content reference comment
+      elm['s-sr'] = true;
 
-        // remember the content reference comment
-        elm['s-cr'] = contentRef;
+      // remember the content reference comment
+      elm['s-cr'] = contentRef;
 
-        // remember the slot name, or empty string for default slot
-        elm['s-sn'] = newVNode.$name$ || '';
+      // remember the slot name, or empty string for default slot
+      elm['s-sn'] = newVNode.$name$ || '';
 
-        // remember the ref callback function
-        elm['s-rf'] = newVNode.$attrs$?.ref;
+      // remember the ref callback function
+      elm['s-rf'] = newVNode.$attrs$?.ref;
 
-        // give this node `assignedElements` and `assignedNodes` methods
-        patchSlotNode(elm);
-      }
+      // give this node `assignedElements` and `assignedNodes` methods
+      patchSlotNode(elm);
 
       // check if we've got an old vnode for this slot
       oldVNode = oldParentVNode && oldParentVNode.$children$ && oldParentVNode.$children$[childIndex];


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The slot event listener fix from PR #6281 was incorrectly implemented in the runtime layer (`src/runtime/slot-polyfill-utils.ts` and `src/runtime/vdom/vdom-render.ts`). However, as correctly pointed out by @johnjenkins in https://github.com/stenciljs/core/pull/6281#issuecomment-2963161151, this issue only manifests during unit testing with Stencil's MockDoc implementation, not in actual runtime scenarios.

The problem occurs because in scoped components, slot elements are polyfilled using text/comment nodes, and MockDoc's `MockTextNode` class (which inherits from `MockNode`) lacked the necessary event handling methods (`addEventListener`, `removeEventListener`, `dispatchEvent`), causing "addEventListener is not a function" errors during unit tests.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This PR moves the slot event listener support from the runtime to MockDoc where it properly belongs:

- **Reverts** the runtime changes from PR #6281 in `src/runtime/slot-polyfill-utils.ts` and `src/runtime/vdom/vdom-render.ts`
- **Adds** event handling methods (`addEventListener`, `removeEventListener`, `dispatchEvent`) to the base `MockNode` class in `src/mock-doc/node.ts`
- **Maintains** all existing test functionality - the slot onSlotchange tests continue to pass

This ensures that all MockDoc node types (including text nodes used for slot polyfills) can handle events during unit testing, while keeping the runtime code clean and focused on actual browser behavior.


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

N/A


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

- ✅ Verified all slot onSlotchange tests pass: `npm run test.jest -- src/runtime/test/scoped.spec.tsx`
- ✅ Confirmed MockDoc test suite continues to pass: `npm run test.jest -- src/mock-doc`
- ✅ Verified runtime tests remain functional: `npm run test.jest -- src/runtime/test/render-vdom.spec.tsx`
- ✅ All existing functionality preserved while fixing the architectural issue


## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

Special thanks to @johnjenkins for correctly identifying that this fix belonged in MockDoc rather than the runtime! 🙏 

This refactoring addresses his feedback and results in a cleaner, more appropriate solution that:
- Keeps runtime code focused on browser behavior
- Places test-specific fixes in the testing infrastructure (MockDoc)
- Maintains the same end-user functionality
- Follows better architectural principles

The original issue from #6269 is still resolved, but now with the fix in the correct layer of the codebase.