### PR TITLE
feat(global-styles): new `addGlobalStyleToComponents` extras option. Opt-out of new globalStyle behaviour

### DIFF
--- a/src/compiler/bundle/app-data-plugin.ts
+++ b/src/compiler/bundle/app-data-plugin.ts
@@ -202,7 +202,10 @@ const appendGlobalScripts = (globalScripts: GlobalScript[], s: MagicString) => {
  * @param s the MagicString to append the global styles onto
  */
 const appendGlobalStyles = async (buildCtx: d.BuildCtx, s: MagicString) => {
-  const globalStyles = buildCtx.config.globalStyle ? await buildCtx.stylesPromise : '';
+  const globalStyles =
+    buildCtx.config.globalStyle && buildCtx.config.extras.addGlobalStyleToComponents !== false
+      ? await buildCtx.stylesPromise
+      : '';
   s.append(`export const globalStyles = ${JSON.stringify(globalStyles)};\n`);
 };
 

--- a/src/compiler/config/test/validate-config.spec.ts
+++ b/src/compiler/config/test/validate-config.spec.ts
@@ -393,6 +393,7 @@ describe('validation', () => {
     expect(config.extras.initializeNextTick).toBe(false);
     expect(config.extras.tagNameTransform).toBe(false);
     expect(config.extras.scopedSlotTextContentFix).toBe(false);
+    expect(config.extras.addGlobalStyleToComponents).toBe(true);
   });
 
   it('should set slot config based on `experimentalSlotFixes`', () => {

--- a/src/compiler/config/validate-config.ts
+++ b/src/compiler/config/validate-config.ts
@@ -150,6 +150,7 @@ export const validateConfig = (
   validatedConfig.extras.scriptDataOpts = !!validatedConfig.extras.scriptDataOpts;
   validatedConfig.extras.initializeNextTick = !!validatedConfig.extras.initializeNextTick;
   validatedConfig.extras.tagNameTransform = !!validatedConfig.extras.tagNameTransform;
+  validatedConfig.extras.addGlobalStyleToComponents = validatedConfig.extras.addGlobalStyleToComponents !== false;
 
   // TODO(STENCIL-914): remove when `experimentalSlotFixes` is the default behavior
   // If the user set `experimentalSlotFixes` and any individual slot fix flags to `false`, we need to log a warning

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -192,6 +192,7 @@ export interface BuildConditionals extends Partial<BuildFeatures> {
   experimentalSlotFixes?: boolean;
   // TODO(STENCIL-1086): remove this option when it's the default behavior
   experimentalScopedSlotChanges?: boolean;
+  addGlobalStyleToComponents?: boolean;
 }
 
 export type ModuleFormat =

--- a/src/declarations/stencil-public-compiler.ts
+++ b/src/declarations/stencil-public-compiler.ts
@@ -374,10 +374,21 @@ interface ConfigExtrasBase {
    * Experimental flag.
    * Updates the behavior of scoped components to align more closely with the behavior of the native
    * Shadow DOM when using `slot`s.
-   *
    * Defaults to `false`.
    */
   experimentalScopedSlotChanges?: boolean;
+
+  /**
+   * By default Stencil turns the stylesheet provided to `globalStyle` into a constructable stylesheet
+   * and adds it to each component which can be useful for sharing styles efficiently across components.
+   * In some cases this can be undesirable:
+   * - If `globalStyle` is intended to configure the lightDOM only
+   * - If `globalStyle` is large it can bloat the size of SSR output when using declarative-shadow-dom
+   * Setting this to `false` will prevent Stencil from adding any `globalStyle` to each component.
+   *
+   * Defaults to `true`.
+   */
+  addGlobalStyleToComponents?: boolean;
 }
 
 // TODO(STENCIL-914): delete this interface when `experimentalSlotFixes` is the default behavior


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The new behaviour added via https://github.com/stenciljs/core/pull/6268 is probably desirable for a lot of users and use-cases; sharing globalStyle across all components. 
For some users however, this new behaviour might be undesirable if (for example): 

- They have designed their globalStyles around the lightDOM *alone*. For them, adding such a stylesheet to all components is completely unnecessary. An example might be globalStyles in a design-system that seek to control the marriage of potential components: doing something like `my-menu > my-link-item::part(icon)` [is not an option via traditional ::slotted(...) selectors atm](https://github.com/w3c/csswg-drafts/issues/3896)
- They are using their components during SSR. The nature of declarative-shadow-dom for SSR being declarative (😄) means that a potentially large globalStyle sheet will be added to every component as part of a server's payload is ([this is not a solved issue atm](https://github.com/whatwg/html/issues/10673))

GitHub Issue Number: N/A

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

An escape hatch for users wanting to opt-out of the behaviour: 

`config.extras.addGlobalStyleToComponents` which defaults to `true`



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

https://github.com/stenciljs/site/pull/1532

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
