### PR TITLE
fix(mock-doc): ensure event bubbling follows shadow DOM boundaries

### DIFF
--- a/src/mock-doc/event.ts
+++ b/src/mock-doc/event.ts
@@ -218,8 +218,28 @@ function triggerEventListener(elm: any, ev: MockEvent) {
   } else if (elm.parentElement == null && elm.tagName === 'HTML') {
     triggerEventListener(elm.ownerDocument, ev);
   } else {
-    triggerEventListener(elm.parentElement, ev);
+    const nextTarget = getNextEventTarget(elm, ev);
+    triggerEventListener(nextTarget, ev);
   }
+}
+
+function getNextEventTarget(elm: any, ev: MockEvent) {
+  // If current element has a parent, bubble to parent
+  if (elm.parentElement) {
+    return elm.parentElement;
+  }
+
+  // If current element is a Shadow Root (has host property), bubble to the host
+  if (elm.host && ev.composed) {
+    return elm.host;
+  }
+
+  // If we're at a Shadow Root boundary and event is composed, bubble to Shadow Host
+  if (ev.composed && elm.parentNode && elm.parentNode.host) {
+    return elm.parentNode.host;
+  }
+
+  return null;
 }
 
 export function dispatchEvent(currentTarget: any, ev: MockEvent) {

--- a/src/mock-doc/test/shadow-dom-event-bubbling.spec.ts
+++ b/src/mock-doc/test/shadow-dom-event-bubbling.spec.ts
@@ -1,0 +1,95 @@
+import { MockDocument } from '../document';
+import { MockWindow } from '../window';
+
+describe('Shadow DOM event bubbling', () => {
+  let win: MockWindow;
+  let doc: MockDocument;
+
+  beforeEach(() => {
+    win = new MockWindow();
+    doc = win.document as unknown as MockDocument;
+  });
+
+  it('should allow events to bubble from shadow DOM children to shadow host when composed: true', () => {
+    const parentHost = doc.createElement('my-parent');
+    const parentShadow = parentHost.attachShadow({ mode: 'open' });
+
+    const childHost = doc.createElement('my-child');
+    childHost.attachShadow({ mode: 'open' });
+
+    doc.body.appendChild(parentHost);
+    parentShadow.appendChild(childHost);
+
+    let parentEventReceived = false;
+    let receivedEventType = '';
+    let receivedComposed = false;
+
+    parentHost.addEventListener('custom-event', (event: any) => {
+      parentEventReceived = true;
+      receivedEventType = event.type;
+      receivedComposed = event.composed;
+    });
+
+    const customEvent = new Event('custom-event', {
+      bubbles: true,
+      composed: true,
+    });
+
+    childHost.dispatchEvent(customEvent);
+
+    expect(parentEventReceived).toBe(true);
+    expect(receivedEventType).toBe('custom-event');
+    expect(receivedComposed).toBe(true);
+  });
+
+  it('should NOT allow events to bubble across shadow boundaries when composed: false', () => {
+    const parentHost = doc.createElement('my-parent');
+    const parentShadow = parentHost.attachShadow({ mode: 'open' });
+
+    const childHost = doc.createElement('my-child');
+
+    doc.body.appendChild(parentHost);
+    parentShadow.appendChild(childHost);
+
+    let parentEventReceived = false;
+
+    parentHost.addEventListener('custom-event', () => {
+      parentEventReceived = true;
+    });
+
+    const customEvent = new Event('custom-event', {
+      bubbles: true,
+      composed: false, // This should NOT cross shadow boundaries
+    });
+
+    childHost.dispatchEvent(customEvent);
+
+    expect(parentEventReceived).toBe(false);
+  });
+
+  it('should work with CustomEvent and detail property', () => {
+    const parentHost = doc.createElement('my-parent');
+    const parentShadow = parentHost.attachShadow({ mode: 'open' });
+
+    const childHost = doc.createElement('my-child');
+
+    doc.body.appendChild(parentHost);
+    parentShadow.appendChild(childHost);
+
+    let receivedDetail: any = null;
+
+    parentHost.addEventListener('custom-event', (event: any) => {
+      receivedDetail = event.detail;
+    });
+
+    const customEvent = new CustomEvent('custom-event', {
+      bubbles: true,
+      composed: true,
+      detail: { message: 'test data', value: 42 },
+    });
+
+    childHost.dispatchEvent(customEvent);
+
+    expect(receivedDetail).toEqual({ message: 'test data', value: 42 });
+  });
+});


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
MockDoc bubbles DOM events to `parentElement` every time during simulation, completely ignoring the special boundary rules of the Shadow DOM. For example, with the following DOM structure:

```bash
parent-host (Shadow Host)
  └── #shadow-root (Shadow Root) 
      └── child-host
```

When the event bubbles from the `child-host`, its `parentElement` is null, but its container is the shadow-root, and `shadow-root.host` points to the `parent-host`.

GitHub Issue Number: #5676


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
According to the W3C specification, when the event is set to `composed: true`, it can cross Shadow DOM boundaries.

Therefore, for the DOM structure example above, the correct bubbling path should be: `child → shadow-root → shadow-host → parent`.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
**Test Coverage:**

Added consistency test: New test `src/mock-doc/test/shadow-dom-event-bubbling.spec.ts`.

**Test Results:**

✅ All 3 tests in the modified test file pass

**Manual Verification:**

In this [minimal reproducible example](https://github.com/tomherni/stencil-event-bug), after linking `@stencil/core` and re-running `npm run test`, the previously failing test case `my-parent: logs 3 separate steps to the console` has now succeeded.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
