### PR TITLE
fix(utils): single global stylesheet instance for performance

### DIFF
--- a/src/utils/shadow-root.ts
+++ b/src/utils/shadow-root.ts
@@ -5,31 +5,7 @@ import { CMP_FLAGS } from '@utils';
 import type * as d from '../declarations';
 import { createStyleSheetIfNeededAndSupported } from './style';
 
-/**
- * Create a single, shared global stylesheet for all shadow roots.
- *
- * This singleton avoids the performance and memory hit of
- * creating a new CSSStyleSheet every time a shadow root is created.
- *
- * Lazy getter due to "ReferenceError: Cannot access 'globalStyles'
- * before initialization" if setup is run at root level
- *
- * internal state:
- * - undefined: not yet computed
- * - null: computed and cached, but stylesheet not needed/supported
- * - CSSStyleSheet: computed and cached
- *
- * @returns CSSStyleSheet | null
- */
-const getLazyGlobalStyleSheet = (() => {
-  let value: CSSStyleSheet | null | undefined;
-
-  return () => {
-    if (value === undefined) value = createStyleSheetIfNeededAndSupported(globalStyles) ?? null;
-
-    return value;
-  };
-})();
+let globalStyleSheet: CSSStyleSheet | null | undefined;
 
 export function createShadowRoot(this: HTMLElement, cmpMeta: d.ComponentRuntimeMeta) {
   const shadowRoot = BUILD.shadowDelegatesFocus
@@ -39,6 +15,9 @@ export function createShadowRoot(this: HTMLElement, cmpMeta: d.ComponentRuntimeM
       })
     : this.attachShadow({ mode: 'open' });
 
-  const globalStyleSheet = getLazyGlobalStyleSheet();
+  // Initialize if undefined, set to CSSStyleSheet or null
+  if (globalStyleSheet === undefined) globalStyleSheet = createStyleSheetIfNeededAndSupported(globalStyles) ?? null;
+
+  // Use initialized global stylesheet if available
   if (globalStyleSheet) shadowRoot.adoptedStyleSheets.push(globalStyleSheet);
 }

--- a/src/utils/shadow-root.ts
+++ b/src/utils/shadow-root.ts
@@ -1,9 +1,17 @@
 import { BUILD } from '@app-data';
 import { globalStyles } from '@app-globals';
-import { supportsConstructableStylesheets } from '@platform';
 import { CMP_FLAGS } from '@utils';
 
 import type * as d from '../declarations';
+import { createStyleSheetIfNeededAndSupported } from './style';
+
+/**
+ * Create a single, shared global stylesheet for all shadow roots.
+ *
+ * This singleton avoids the performance and memory hit of
+ * creating a new CSSStyleSheet every time a shadow root is created.
+ */
+export const globalStyleSheet = createStyleSheetIfNeededAndSupported(globalStyles);
 
 export function createShadowRoot(this: HTMLElement, cmpMeta: d.ComponentRuntimeMeta) {
   const shadowRoot = BUILD.shadowDelegatesFocus
@@ -13,13 +21,5 @@ export function createShadowRoot(this: HTMLElement, cmpMeta: d.ComponentRuntimeM
       })
     : this.attachShadow({ mode: 'open' });
 
-  /**
-   * If constructable stylesheets are supported, we can use them to
-   * add the global styles to the shadow root.
-   */
-  if (supportsConstructableStylesheets) {
-    const sheet = new CSSStyleSheet();
-    sheet.replaceSync(globalStyles);
-    shadowRoot.adoptedStyleSheets.push(sheet);
-  }
+  if (globalStyleSheet) shadowRoot.adoptedStyleSheets.push(globalStyleSheet);
 }

--- a/src/utils/style.ts
+++ b/src/utils/style.ts
@@ -1,0 +1,16 @@
+import { supportsConstructableStylesheets } from '@platform';
+
+/**
+ * If (1) styles is not empty string, and (2) constructable stylesheets are supported,
+ * then make a stylesheet.
+ *
+ * @param styles - The styles to add to the stylesheet. If empty string, then no stylesheet is returned.
+ * @returns A stylesheet if it can be created, otherwise undefined.
+ */
+export function createStyleSheetIfNeededAndSupported(styles: string): CSSStyleSheet | undefined {
+  if (!styles || !supportsConstructableStylesheets) return undefined;
+
+  const sheet = new CSSStyleSheet();
+  sheet.replaceSync(styles);
+  return sheet;
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

GitHub Issue Number: None

Since Ionic v8.6.0 I've been experiencing component instance creation performance issues, especially in virtual lists, where it can take items longer to appear. This was originally identified by end users: https://vger.social/post/20787019

I narrowed it down to the [stencil upgrade here](https://github.com/ionic-team/ionic-framework/pull/30450).

From there I found the regression occurring in [Stencil v4.33.0](https://github.com/stenciljs/core/releases/tag/v4.33.0) specifically. When I reverted [33363d4077728793e0c6f635a22dccbb5740be49](https://github.com/stenciljs/core/commit/33363d4077728793e0c6f635a22dccbb5740be49) the problem went away.

Once I identified the source of the issue, I found [some suspicious code](https://github.com/stenciljs/core/commit/33363d4077728793e0c6f635a22dccbb5740be49#diff-eefa0ad2088331387be8cbea3bea2bd4996fb27dbe458a6c89d10d3cc9c59853R15-R17) that was creating a new `CSSStyleSheet` every time a new component instance is created.

What is interesting is this performance issue exists even if `globalStyles` is empty. Simply creating a new `CSSStyleSheets` and calling `replaceSync` on an empty string every instantiation is enough to hurt performance.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

I have modified the code to only create one global `CSSStyleSheet` (if necessary) on startup that is appended to `adoptedStyleSheets` in the `createShadowRoot` function.

This solves performance issues of using `globalStyles`. In addition, I added an early return to not create the global style sheet at all, if `globalStyles` is empty. This doesn't seem to affect perf, just makes the DX a bit nicer by not having a useless/empty `CSSStyleSheet` in the `adoptedStyleSheets` array.


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

I tested these changes against [Voyager](https://github.com/aeharding/voyager) by building stencil, building ionic, and finally installing in Voyager.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
