### PR TITLE
refactor(runtime): don't recreate adoptedStyleSheets

### DIFF
--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -120,7 +120,12 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
                  */
                 const stylesheet = new CSSStyleSheet();
                 stylesheet.replaceSync(style);
-                styleContainerNode.adoptedStyleSheets = [stylesheet, ...styleContainerNode.adoptedStyleSheets];
+
+                /**
+                 * > If the array needs to be modified, use in-place mutations like push().
+                 * https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets
+                 */
+                styleContainerNode.adoptedStyleSheets.unshift(stylesheet);
               } else {
                 /**
                  * If a scoped component is used within a shadow root and constructable stylesheets are
@@ -162,7 +167,11 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
         }
       }
     } else if (BUILD.constructableCSS && !styleContainerNode.adoptedStyleSheets.includes(style)) {
-      styleContainerNode.adoptedStyleSheets = [...styleContainerNode.adoptedStyleSheets, style];
+      /**
+       * > If the array needs to be modified, use in-place mutations like push().
+       * https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets
+       */
+      styleContainerNode.adoptedStyleSheets.push(style);
     }
   }
   return scopeId;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A

When investigating #6320 I saw that there were places that the adoptedStyleSheets array was being recreated instead of mutated. MDN docs say you should only mutate this array: https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The array is mutated instead of recreated

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

I don't think this is a breaking change, since we already mutate adoptedStyleSheets [here (as an example)](https://github.com/stenciljs/core/pull/6268). However, I believe this was originally done because adoptedStyleSheets used to be frozen: https://github.com/GoogleChrome/web.dev/issues/10294

Because there's other places in the codebase that treat adoptedStyleSheets as mutable I don't think this is breaking but I do want to highlight that.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
