### PR TITLE
feat(runtime): skip initial task queue to improve first time rendering

### DIFF
--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -37,7 +37,7 @@ export const scheduleUpdate = (hostRef: d.HostRef, isInitialLoad: boolean) => {
   // has already fired off its lifecycle update then
   // fire off the initial update
   const dispatch = () => dispatchHooks(hostRef, isInitialLoad);
-  return BUILD.taskQueue ? writeTask(dispatch) : dispatch();
+  return BUILD.taskQueue && !isInitialLoad ? writeTask(dispatch) : dispatch();
 };
 
 /**

--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -23,7 +23,7 @@ export const attachToAncestor = (hostRef: d.HostRef, ancestorComponent?: d.HostE
   }
 };
 
-export const scheduleUpdate = (hostRef: d.HostRef, isInitialLoad: boolean) => {
+export const scheduleUpdate = (hostRef: d.HostRef, isInitialLoad: boolean): Promise<void> | void => {
   if (BUILD.taskQueue && BUILD.updatable) {
     hostRef.$flags$ |= HOST_FLAGS.isQueuedForUpdate;
   }
@@ -37,7 +37,15 @@ export const scheduleUpdate = (hostRef: d.HostRef, isInitialLoad: boolean) => {
   // has already fired off its lifecycle update then
   // fire off the initial update
   const dispatch = () => dispatchHooks(hostRef, isInitialLoad);
-  return BUILD.taskQueue && !isInitialLoad ? writeTask(dispatch) : dispatch();
+
+  if (isInitialLoad) {
+    queueMicrotask(() => {
+      dispatch();
+    });
+    return;
+  }
+
+  return BUILD.taskQueue ? writeTask(dispatch) : dispatch();
 };
 
 /**


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: Fixes #6317


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Speedup initial rendering of the components by skipping the task queue and use the [browser queue](https://developer.mozilla.org/en-US/docs/Web/API/Window/queueMicrotask).

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
