### PR TITLE
fix: contructable stylesheets with older immutable spec (chrome <99)

### DIFF
--- a/src/client/client-window.ts
+++ b/src/client/client-window.ts
@@ -60,4 +60,10 @@ export const supportsConstructableStylesheets = BUILD.constructableCSS
     })()
   : false;
 
+// https://github.com/salesforce/lwc/blob/5af18fdd904bc6cfcf7b76f3c539490ff11515b2/packages/%40lwc/engine-dom/src/renderer.ts#L41-L43
+export const supportsMutableAdoptedStyleSheets = supportsConstructableStylesheets
+  ? /*@__PURE__*/ (() =>
+      !!win.document && Object.getOwnPropertyDescriptor(win.document.adoptedStyleSheets, 'length')!.writable)()
+  : false;
+
 export { H as HTMLElement };

--- a/src/hydrate/platform/index.ts
+++ b/src/hydrate/platform/index.ts
@@ -124,6 +124,7 @@ export const supportsShadow = BUILD.shadowDom;
 export const supportsListenerOptions = false;
 
 export const supportsConstructableStylesheets = false;
+export const supportsMutableAdoptedStyleSheets = false;
 
 export const getHostRef = (ref: d.RuntimeRef) => {
   if (ref.__stencil__getHostRef) {

--- a/src/runtime/styles.ts
+++ b/src/runtime/styles.ts
@@ -1,5 +1,12 @@
 import { BUILD } from '@app-data';
-import { plt, styles, supportsConstructableStylesheets, supportsShadow, win } from '@platform';
+import {
+  plt,
+  styles,
+  supportsConstructableStylesheets,
+  supportsMutableAdoptedStyleSheets,
+  supportsShadow,
+  win,
+} from '@platform';
 import { CMP_FLAGS, queryNonceMetaTagContent } from '@utils';
 
 import type * as d from '../declarations';
@@ -125,7 +132,11 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
                  * > If the array needs to be modified, use in-place mutations like push().
                  * https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets
                  */
-                styleContainerNode.adoptedStyleSheets.unshift(stylesheet);
+                if (supportsMutableAdoptedStyleSheets) {
+                  styleContainerNode.adoptedStyleSheets.unshift(stylesheet);
+                } else {
+                  styleContainerNode.adoptedStyleSheets = [stylesheet, ...styleContainerNode.adoptedStyleSheets];
+                }
               } else {
                 /**
                  * If a scoped component is used within a shadow root and constructable stylesheets are
@@ -171,7 +182,11 @@ export const addStyle = (styleContainerNode: any, cmpMeta: d.ComponentRuntimeMet
        * > If the array needs to be modified, use in-place mutations like push().
        * https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets
        */
-      styleContainerNode.adoptedStyleSheets.push(style);
+      if (supportsMutableAdoptedStyleSheets) {
+        styleContainerNode.adoptedStyleSheets.push(style);
+      } else {
+        styleContainerNode.adoptedStyleSheets = [...styleContainerNode.adoptedStyleSheets, style];
+      }
     }
   }
   return scopeId;

--- a/src/testing/platform/index.ts
+++ b/src/testing/platform/index.ts
@@ -14,6 +14,7 @@ export {
   stopAutoApplyChanges,
   supportsConstructableStylesheets,
   supportsListenerOptions,
+  supportsMutableAdoptedStyleSheets,
   supportsShadow,
 } from './testing-platform';
 export { flushAll, flushLoadModule, flushQueue, loadModule, nextTick, readTask, writeTask } from './testing-task-queue';

--- a/src/testing/platform/testing-platform.ts
+++ b/src/testing/platform/testing-platform.ts
@@ -28,6 +28,7 @@ export const setPlatformHelpers = (helpers: {
 
 export const supportsListenerOptions = true;
 export const supportsConstructableStylesheets = false;
+export const supportsMutableAdoptedStyleSheets = false;
 
 /**
  * Helper function to programmatically set shadow DOM support in testing scenarios.

--- a/src/utils/shadow-root.ts
+++ b/src/utils/shadow-root.ts
@@ -1,5 +1,6 @@
 import { BUILD } from '@app-data';
 import { globalStyles } from '@app-globals';
+import { supportsMutableAdoptedStyleSheets } from '@platform';
 import { CMP_FLAGS } from '@utils';
 
 import type * as d from '../declarations';
@@ -19,5 +20,11 @@ export function createShadowRoot(this: HTMLElement, cmpMeta: d.ComponentRuntimeM
   if (globalStyleSheet === undefined) globalStyleSheet = createStyleSheetIfNeededAndSupported(globalStyles) ?? null;
 
   // Use initialized global stylesheet if available
-  if (globalStyleSheet) shadowRoot.adoptedStyleSheets.push(globalStyleSheet);
+  if (globalStyleSheet) {
+    if (supportsMutableAdoptedStyleSheets) {
+      shadowRoot.adoptedStyleSheets.push(globalStyleSheet);
+    } else {
+      shadowRoot.adoptedStyleSheets = [...shadowRoot.adoptedStyleSheets, globalStyleSheet];
+    }
+  }
 }


### PR DESCRIPTION
Resolves #6326

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6326


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Stencil constructable style sheets works with old spec where the array was immutable.

Note: I strongly recommend dropping support for < chrome 99 in stencil v5. Patches like this increase the bundle size for everyone in order to support *very* insecure/outdated browsers.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

~~I would like help testing this before merge.~~ Tested loading stencil from Ionic list starter on chrome 98 and works OK.

## Other information

https://github.com/salesforce/lwc/issues/2828
