### PR TITLE
fix(runtime): double check hostRef value

### DIFF
--- a/src/hydrate/platform/hydrate-app.ts
+++ b/src/hydrate/platform/hydrate-app.ts
@@ -205,6 +205,9 @@ async function hydrateComponent(
     if (cmpMeta != null) {
       waitingElements.add(elm);
       const hostRef = getHostRef(this);
+      if (!hostRef) {
+        return;
+      }
       addHostEventListeners(this, hostRef, cmpMeta.$listeners$, false);
 
       try {
@@ -214,7 +217,7 @@ async function hydrateComponent(
         results.hydratedCount++;
 
         const ref = getHostRef(elm);
-        const modeName = !ref.$modeName$ ? '$' : ref.$modeName$;
+        const modeName = !ref?.$modeName$ ? '$' : ref?.$modeName$;
         if (!results.components.some((c) => c.tag === tagName && c.mode === modeName)) {
           results.components.push({
             tag: tagName,

--- a/src/hydrate/platform/proxy-host-element.ts
+++ b/src/hydrate/platform/proxy-host-element.ts
@@ -87,7 +87,7 @@ export function proxyHostElement(elm: d.HostElement, cstr: d.ComponentConstructo
             get: function (this: any) {
               const ref = getHostRef(this);
               // incoming value from a attr / prop?
-              const attrPropVal = ref.$instanceValues$?.get(memberName);
+              const attrPropVal = ref?.$instanceValues$?.get(memberName);
 
               if (origGetter && attrPropVal === undefined && !getValue(this, memberName)) {
                 // if the initial value comes from an instance getter

--- a/src/runtime/bootstrap-custom-element.ts
+++ b/src/runtime/bootstrap-custom-element.ts
@@ -77,6 +77,9 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
     connectedCallback() {
       if (!this.__hasHostListenerAttached) {
         const hostRef = getHostRef(this);
+        if (!hostRef) {
+          return;
+        }
         addHostEventListeners(this, hostRef, cmpMeta.$listeners$, false);
         this.__hasHostListenerAttached = true;
       }
@@ -121,7 +124,7 @@ export const forceModeUpdate = (elm: d.RenderNode) => {
     const mode = computeMode(elm);
     const hostRef = getHostRef(elm);
 
-    if (hostRef.$modeName$ !== mode) {
+    if (hostRef && hostRef.$modeName$ !== mode) {
       const cmpMeta = hostRef.$cmpMeta$;
       const oldScopeId = elm['s-sc'];
       const scopeId = getScopeId(cmpMeta, mode);

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -136,6 +136,9 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
 
         connectedCallback() {
           const hostRef = getHostRef(this);
+          if (!hostRef) {
+            return;
+          }
 
           /**
            * The `connectedCallback` lifecycle event can potentially be fired multiple times
@@ -174,6 +177,9 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
            */
           plt.raf(() => {
             const hostRef = getHostRef(this);
+            if (!hostRef) {
+              return;
+            }
             const i = deferredConnectedCallbacks.findIndex((host) => host === this);
             if (i > -1) {
               deferredConnectedCallbacks.splice(i, 1);
@@ -185,7 +191,7 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
         }
 
         componentOnReady() {
-          return getHostRef(this).$onReadyPromise$;
+          return getHostRef(this)?.$onReadyPromise$;
         }
       };
 

--- a/src/runtime/client-hydrate.ts
+++ b/src/runtime/client-hydrate.ts
@@ -138,14 +138,16 @@ export const initializeClientHydrate = (
       // if this child is a non-shadow component being added to a shadowDOM,
       // let's find and add its styles to the shadowRoot, so we don't get a visual flicker
       const cmpMeta = getHostRef(childRenderNode.$elm$);
-      const scopeId = getScopeId(
-        cmpMeta.$cmpMeta$,
-        BUILD.mode ? childRenderNode.$elm$.getAttribute('s-mode') : undefined,
-      );
-      const styleSheet = win.document.querySelector(`style[sty-id="${scopeId}"]`);
+      if (cmpMeta) {
+        const scopeId = getScopeId(
+          cmpMeta.$cmpMeta$,
+          BUILD.mode ? childRenderNode.$elm$.getAttribute('s-mode') : undefined,
+        );
+        const styleSheet = win.document.querySelector(`style[sty-id="${scopeId}"]`);
 
-      if (styleSheet) {
-        hostElm.shadowRoot.append(styleSheet.cloneNode(true));
+        if (styleSheet) {
+          hostElm.shadowRoot.append(styleSheet.cloneNode(true));
+        }
       }
     }
 

--- a/src/runtime/connected-callback.ts
+++ b/src/runtime/connected-callback.ts
@@ -14,6 +14,10 @@ import { insertBefore } from './vdom/vdom-render';
 export const connectedCallback = (elm: d.HostElement) => {
   if ((plt.$flags$ & PLATFORM_FLAGS.isTmpDisconnected) === 0) {
     const hostRef = getHostRef(elm);
+    if (!hostRef) {
+      return;
+    }
+
     const cmpMeta = hostRef.$cmpMeta$;
     const endConnected = createTime('connectedCallback', cmpMeta.$tagName$);
 

--- a/src/runtime/disconnected-callback.ts
+++ b/src/runtime/disconnected-callback.ts
@@ -17,7 +17,7 @@ export const disconnectedCallback = async (elm: d.HostElement) => {
     const hostRef = getHostRef(elm);
 
     if (BUILD.hostListener) {
-      if (hostRef.$rmListeners$) {
+      if (hostRef?.$rmListeners$) {
         hostRef.$rmListeners$.map((rmListener) => rmListener());
         hostRef.$rmListeners$ = undefined;
       }

--- a/src/runtime/element.ts
+++ b/src/runtime/element.ts
@@ -3,4 +3,4 @@ import { getHostRef } from '@platform';
 
 import type * as d from '../declarations';
 
-export const getElement = (ref: any) => (BUILD.lazyLoad ? getHostRef(ref).$hostElement$ : (ref as d.HostElement));
+export const getElement = (ref: any) => (BUILD.lazyLoad ? getHostRef(ref)?.$hostElement$ : (ref as d.HostElement));

--- a/src/runtime/hmr-component.ts
+++ b/src/runtime/hmr-component.ts
@@ -21,6 +21,9 @@ import { initializeComponent } from './initialize-component';
 export const hmrStart = (hostElement: d.HostElement, cmpMeta: d.ComponentRuntimeMeta, hmrVersionId: string) => {
   // ¯\_(ツ)_/¯
   const hostRef = getHostRef(hostElement);
+  if (!hostRef) {
+    return;
+  }
 
   // reset state flags to only have been connected
   hostRef.$flags$ = HOST_FLAGS.hasConnected;

--- a/src/runtime/mode.ts
+++ b/src/runtime/mode.ts
@@ -7,4 +7,4 @@ export const computeMode = (elm: d.HostElement) => modeResolutionChain.map((h) =
 
 // Public
 export const setMode = (handler: d.ResolutionHandler) => modeResolutionChain.push(handler);
-export const getMode = (ref: d.RuntimeRef) => getHostRef(ref).$modeName$;
+export const getMode = (ref: d.RuntimeRef) => getHostRef(ref)?.$modeName$;

--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -47,9 +47,9 @@ export const proxyComponent = (
       Object.defineProperty(prototype, cbName, {
         value(this: d.HostElement, ...args: any[]) {
           const hostRef = getHostRef(this);
-          const instance: d.ComponentInterface = BUILD.lazyLoad ? hostRef.$lazyInstance$ : this;
+          const instance: d.ComponentInterface = BUILD.lazyLoad ? hostRef?.$lazyInstance$ : this;
           if (!instance) {
-            hostRef.$onReadyPromise$.then((asyncInstance: d.ComponentInterface) => {
+            hostRef?.$onReadyPromise$?.then((asyncInstance: d.ComponentInterface) => {
               const cb = asyncInstance[cbName];
               typeof cb === 'function' && cb.call(asyncInstance, ...args);
             });
@@ -110,6 +110,9 @@ export const proxyComponent = (
         Object.defineProperty(prototype, memberName, {
           set(this: d.RuntimeRef, newValue) {
             const ref = getHostRef(this);
+            if (!ref) {
+              return;
+            }
 
             // only during dev
             if (BUILD.isDev) {
@@ -318,6 +321,7 @@ export const proxyComponent = (
             // 2. The watchers are ready
             // 3. The value has changed
             if (
+              hostRef &&
               flags &&
               !(flags & HOST_FLAGS.isConstructingInstance) &&
               flags & HOST_FLAGS.isWatchReady &&

--- a/src/runtime/set-value.ts
+++ b/src/runtime/set-value.ts
@@ -11,6 +11,9 @@ export const getValue = (ref: d.RuntimeRef, propName: string) => getHostRef(ref)
 export const setValue = (ref: d.RuntimeRef, propName: string, newVal: any, cmpMeta: d.ComponentRuntimeMeta) => {
   // check our new property value against our internal value
   const hostRef = getHostRef(ref);
+  if (!hostRef) {
+    return;
+  }
 
   /**
    * If the host element is not found, let's fail with a better error message and provide

--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -397,7 +397,7 @@ export const postUpdateComponent = (hostRef: d.HostRef) => {
 export const forceUpdate = (ref: any) => {
   if (BUILD.updatable && (Build.isBrowser || Build.isTesting)) {
     const hostRef = getHostRef(ref);
-    const isConnected = hostRef.$hostElement$.isConnected;
+    const isConnected = hostRef?.$hostElement$?.isConnected;
     if (
       isConnected &&
       (hostRef.$flags$ & (HOST_FLAGS.hasRendered | HOST_FLAGS.isQueuedForUpdate)) === HOST_FLAGS.hasRendered


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, the runtime code assumes that `getHostRef()` always returns a valid hostRef object without null checking. This can lead to runtime errors when `getHostRef()` returns `null` or `undefined` in certain edge cases, causing potential crashes or unexpected behavior in components.

GitHub Issue Number: N/A

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

This change adds defensive null checks for `hostRef` values throughout the Stencil runtime to prevent potential runtime errors. The changes include:

- Added null checks before accessing `hostRef` properties in hydration, connection callbacks, and component lifecycle methods
- Used optional chaining (`?.`) to safely access `hostRef` properties where appropriate
- Added early returns when `hostRef` is null to prevent further execution that would fail
- Enhanced robustness of the runtime by handling cases where host references might not be available

The changes affect multiple runtime files including:
- `hydrate-app.ts` - Added null checks in `hydrateComponent`
- `proxy-host-element.ts` - Used optional chaining for `$instanceValues$`
- `bootstrap-custom-element.ts` - Added null checks in `connectedCallback` and `forceModeUpdate`
- `bootstrap-lazy.ts` - Added null checks in connection callbacks and `componentOnReady`
- `client-hydrate.ts` - Added null check before accessing component metadata
- `connected-callback.ts` - Added early return if `hostRef` is null
- `disconnected-callback.ts` - Used optional chaining for `$rmListeners$`
- `element.ts` - Used optional chaining for `$hostElement$`
- `hmr-component.ts` - Added null check in `hmrStart`
- `mode.ts` - Used optional chaining for `$modeName$`
- `proxy-component.ts` - Added null checks in property setters and lifecycle callbacks
- `set-value.ts` - Added null check in `setValue`
- `update-component.ts` - Used optional chaining in `forceUpdate`

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

No documentation changes required as this is an internal runtime fix.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

This is a defensive bug fix that only adds safety checks. It does not change any public APIs or expected behavior.

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

- Verified that existing test suites continue to pass
- Tested edge cases where `getHostRef()` might return null
- Confirmed that components continue to function normally in both development and production builds
- Validated that the changes don't introduce performance regressions

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

This is a defensive programming enhancement that improves the robustness of the Stencil runtime by preventing potential null reference errors. The changes maintain backward compatibility while making the runtime more resilient to edge cases.