### PR TITLE
fix(runtime): do not remove first comment - can break frameworks

### DIFF
--- a/src/runtime/connected-callback.ts
+++ b/src/runtime/connected-callback.ts
@@ -61,19 +61,7 @@ export const connectedCallback = (elm: d.HostElement) => {
             cmpMeta.$flags$ & (CMP_FLAGS.hasSlotRelocation | CMP_FLAGS.needsShadowDomShim))
         ) {
           setContentReference(elm);
-        } else if (BUILD.hydrateClientSide && !(cmpMeta.$flags$ & CMP_FLAGS.hasSlotRelocation)) {
-          const commendPlaceholder = elm.firstChild as d.RenderNode;
-          if (
-            commendPlaceholder?.nodeType === NODE_TYPE.CommentNode &&
-            !commendPlaceholder['s-cn'] &&
-            !commendPlaceholder.nodeValue
-          ) {
-            // if the first child is a comment node that was created by the
-            // setContentReference() function during SSR, remove it now as
-            // this component does not need slot relocation and can cause hydration issues
-            elm.removeChild(commendPlaceholder);
-          }
-        }
+        } 
       }
 
       if (BUILD.asyncLoading) {

--- a/src/runtime/connected-callback.ts
+++ b/src/runtime/connected-callback.ts
@@ -61,7 +61,7 @@ export const connectedCallback = (elm: d.HostElement) => {
             cmpMeta.$flags$ & (CMP_FLAGS.hasSlotRelocation | CMP_FLAGS.needsShadowDomShim))
         ) {
           setContentReference(elm);
-        } 
+        }
       }
 
       if (BUILD.asyncLoading) {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

A regression was added in https://github.com/stenciljs/core/pull/6311. 

In an attempt to 'clean up' non-shadow dom trees and minimise 3rd-party-framework hydration mismatch errors, the first empty comment node of a component was removed *when* the component does not utilise `<slot />`s. 

This node removal had a side-effect as Angular uses empty comments as content placeholders (*only* in production builds) which caused the Angular app content to not render.

GitHub Issue Number: https://github.com/stenciljs/core/pull/6336)


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The node removal was reverted. I *think* with https://github.com/stenciljs/core/pull/6314 now in-place all non-shadow components correctly shield their internals from the outside, so this behaviour is no longer required anyway

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
