### PR TITLE
fix(runtime): fixed parsing of complex attributes that contains JSON strings

### DIFF
--- a/src/runtime/test/prop.spec.tsx
+++ b/src/runtime/test/prop.spec.tsx
@@ -212,14 +212,16 @@ describe('prop', () => {
   it('should demonstrate JSON parsing for complex object props', async () => {
     @Component({ tag: 'simple-demo' })
     class SimpleDemo {
-      @Prop() message: {text: string} = {text: 'default'};
-      @Prop() messageAny: any = {text: 'default'};
+      @Prop() message: { text: string } = { text: 'default' };
+      @Prop() messageAny: any = { text: 'default' };
 
       render() {
-        return <div>
-          <div>{this.message.text}</div>
-          <div>{this.messageAny.text}</div>
-        </div>;
+        return (
+          <div>
+            <div>{this.message.text}</div>
+            <div>{this.messageAny.text}</div>
+          </div>
+        );
       }
     }
 

--- a/src/runtime/test/prop.spec.tsx
+++ b/src/runtime/test/prop.spec.tsx
@@ -208,4 +208,33 @@ describe('prop', () => {
       <cmp-a>4</cmp-a>
     `);
   });
+
+  it('should demonstrate JSON parsing for complex object props', async () => {
+    @Component({ tag: 'simple-demo' })
+    class SimpleDemo {
+      @Prop() message: {text: string} = {text: 'default'};
+      @Prop() messageAny: any = {text: 'default'};
+
+      render() {
+        return <div>
+          <div>{this.message.text}</div>
+          <div>{this.messageAny.text}</div>
+        </div>;
+      }
+    }
+
+    const { root } = await newSpecPage({
+      components: [SimpleDemo],
+      html: `<simple-demo message='{"text": "Hello World"}' message-any='{"text": "Hello World"}'></simple-demo>`,
+    });
+
+    expect(root).toEqualHtml(`
+      <simple-demo message='{"text": "Hello World"}' message-any='{"text": "Hello World"}'>
+        <div>
+          <div>Hello World</div>
+          <div>Hello World</div>
+        </div>
+      </simple-demo>
+    `);
+  });
 });

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -17,7 +17,7 @@ export const enum MEMBER_FLAGS {
   Setter = 1 << 12,
 
   Prop = String | Number | Boolean | Any | Unknown,
-  HasAttribute = String | Number | Boolean | Any,
+  HasAttribute = String | Number | Boolean | Any | Unknown,
   PropLike = Prop | State,
 }
 


### PR DESCRIPTION
## What is the current behavior?

The `HasAttribute` member flag only includes `String | Number | Boolean | Any` types, which means that props with `Unknown` types (complex objects) are not considered to have attributes. This creates an inconsistency with the `Prop` flag definition, which includes `Unknown` types.

## What is the new behavior?

The `HasAttribute` member flag now includes `Unknown` types (`String | Number | Boolean | Any | Unknown`), making it consistent with the `Prop` flag definition. This allows complex object props to properly support attribute-based initialization through JSON string parsing. The added test demonstrates that complex object props can now be correctly initialized via HTML attributes using JSON strings.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

Added