### PR TITLE
fix(Mixin): export `MixinFactory` type for ease of use

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -414,7 +414,7 @@ export type MixinFactory = <TBase extends abstract new (...args: any[]) => any>(
  * Example:
  * ```
  * import { Mixin, MixinFactory } from '@stencil/core';
- * 
+ *
  * const AWrap: MixinFactory = (Base) => {class A extends Base { propA = A }; return A;}
  * const BWrap: MixinFactory = (Base) => {class B extends Base { propB = B }; return B;}
  * const CWrap: MixinFactory = (Base) => {class C extends Base { propC = C }; return C;}

--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -403,7 +403,7 @@ export declare function readTask(task: RafCallback): void;
  */
 export declare const setErrorHandler: (handler: ErrorHandler) => void;
 
-export type MixinFactory = <TBase extends abstract new (...args: any[]) => any>(
+export type MixinFactory = <TBase extends new (...args: any[]) => any>(
   base: TBase,
 ) => abstract new (...args: ConstructorParameters<TBase>) => any;
 

--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -6,10 +6,6 @@ declare type CustomMethodDecorator<T> = (
 
 type UnionToIntersection<U> = (U extends any ? (x: U) => void : never) extends (x: infer I) => void ? I : never;
 
-type MixinFactory = <TBase extends abstract new (...args: any[]) => any>(
-  base: TBase,
-) => abstract new (...args: ConstructorParameters<TBase>) => any;
-
 export interface ComponentDecorator {
   (opts?: ComponentOptions): ClassDecorator;
 }
@@ -407,15 +403,21 @@ export declare function readTask(task: RafCallback): void;
  */
 export declare const setErrorHandler: (handler: ErrorHandler) => void;
 
+export type MixinFactory = <TBase extends abstract new (...args: any[]) => any>(
+  base: TBase,
+) => abstract new (...args: ConstructorParameters<TBase>) => any;
+
 /**
  * Compose multiple mixin classes into a single constructor.
  * The resulting class has the combined instance types of all mixed-in classes.
  *
  * Example:
  * ```
- * const AWrap = (Base) => {class A extends Base { propA = A }; return A;}
- * const BWrap = (Base) => {class B extends Base { propB = B }; return B;}
- * const CWrap = (Base) => {class C extends Base { propC = C }; return C;}
+ * import { Mixin, MixinFactory } from '@stencil/core';
+ * 
+ * const AWrap: MixinFactory = (Base) => {class A extends Base { propA = A }; return A;}
+ * const BWrap: MixinFactory = (Base) => {class B extends Base { propB = B }; return B;}
+ * const CWrap: MixinFactory = (Base) => {class C extends Base { propC = C }; return C;}
  *
  * class X extends Mixin(AWrap, BWrap, CWrap) {
  *   render() { return <div>{this.propA} {this.propB} {this.propC}</div>; }

--- a/src/internal/stencil-core/index.d.ts
+++ b/src/internal/stencil-core/index.d.ts
@@ -40,6 +40,7 @@ export {
   Listen,
   Method,
   Mixin,
+  MixinFactory,
   Prop,
   readTask,
   render,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Devs have no steer regarding the typing of mixin factory functions for use with the new `Mixin()` utility

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The `MixinFactory` type has been exported for devs to use: 

```
import { Method, Prop, type MixinFactory } from '@stencil/core';

export const WithMixinThing: MixinFactory = (Base) => {
  class MixinThing extends Base {
    @Prop() mixinThing = 'mixing ???';

    @Method()
    async mixinMethod() {
      console.log('Mixin method called');
      return 'Mixin method result';
    }
  }
  return MixinThing;
}
```


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
