### PR TITLE
fix(styles): support rendering across documents

### DIFF
--- a/test/wdio/cross-document-constructed-styles/cmp.test.tsx
+++ b/test/wdio/cross-document-constructed-styles/cmp.test.tsx
@@ -1,0 +1,15 @@
+import { h, render } from '@stencil/core';
+import { $, browser, expect } from '@wdio/globals';
+
+describe('cross-document-style', () => {
+  before(async () => {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    render(<cross-document-style></cross-document-style>, iframe.contentDocument.body);
+  });
+
+  it('should render in across frames', async () => {
+    await browser.switchFrame($('iframe'));
+    await expect($('cross-document-style')).toHaveStyle({ color: 'rgb(255,0,0)' });
+  });
+});

--- a/test/wdio/cross-document-constructed-styles/cmp.tsx
+++ b/test/wdio/cross-document-constructed-styles/cmp.tsx
@@ -1,0 +1,20 @@
+import { Component, h } from '@stencil/core';
+
+@Component({
+  tag: 'cross-document-style',
+  styles: `
+    :host {
+      color: rgb(255, 0, 0);
+    }
+  `,
+  shadow: true,
+})
+export class CrossDocumentStyleTestCmp {
+  render() {
+    return (
+      <section>
+        <div>I am rendered in red!</div>
+      </section>
+    );
+  }
+}


### PR DESCRIPTION
Constructed stylesheets cannot be shared across documents (e.g. within an iframe). Check in which document the component is and use its own CSSStyleSheet.

fixes: #6479

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Rendering doesn't work across documents.
Constructed stylesheets are created from the original window's CSSStyleSheet constructor, which can't be adopted into another window.

GitHub Issue Number: #6479 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Added tracking of which styles have already been added to the constructed stylesheets flow.
Clone stylesheets when needed to the actual window before adopting them.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

Tested on the repro repo:
https://github.com/emandirola/stenciljs-cross-document-adopted-stylesheet-error-repro

- `npm install`
- `npm run start-broken`
- Click "Show Modal"
- Modal opens