### PR TITLE
fix(types): add referrerPolicy to ImgHTMLAttributes

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1206,6 +1206,7 @@ export namespace JSXBase {
     importance?: 'low' | 'auto' | 'high';
     height?: number | string;
     loading?: 'lazy' | 'auto' | 'eager';
+    referrerPolicy?: ReferrerPolicy;
     sizes?: string;
     src?: string;
     srcSet?: string;


### PR DESCRIPTION
## What is the current behavior?

`JSXBase.ImgHTMLAttributes` is missing the `referrerPolicy` attribute, so this fails type-checking:

```tsx
<img src="https://example.com/icon.png" referrerPolicy="no-referrer" />
// Property 'referrerPolicy' does not exist on type
// 'ImgHTMLAttributes<HTMLImageElement>'.
```

Consumers have to cast as `any` to compile, which is noisy and obscures intent. The attribute already exists on the sibling JSX types `AnchorHTMLAttributes` and `IframeHTMLAttributes`.

GitHub Issue Number: #6692

## What is the new behavior?

Adds `referrerPolicy?: ReferrerPolicy;` to `ImgHTMLAttributes` in `src/declarations/stencil-public-runtime.ts`, mirroring the existing declarations on `AnchorHTMLAttributes` (line 1056) and `IframeHTMLAttributes` (line 1191). The `ReferrerPolicy` type is provided by the TypeScript DOM lib; no additional imports and no runtime impact, since this only affects JSX type checking.

This brings `<img>` in line with the [HTML spec](https://html.spec.whatwg.org/multipage/embedded-content.html#attr-img-referrerpolicy) and matches prior fixes for the same gap on sibling elements:

- `<iframe>`: #2003 (2020) — `fix(jsx): add referrerPolicy for iframe interface`
- `<a>`: #3006 (2021) — `fix(types): add referrerPolicy to AnchorHTMLAttributes`

## Documentation

N/A — JSX type addition.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

- `npm run build` succeeds.
- Following the precedent of #2003 and #3006, no test was added — both prior PRs were single-line declaration additions with no accompanying tests, since the change has no runtime behavior to exercise.

## Other information

Real-world motivation: a CRM web-components library needs `referrerpolicy="no-referrer"` on rendered `<img>` to suppress the `Referer` header when the image source is a third-party favicon service, so the originating CRM page URL doesn't leak to the third party.