### PR TITLE
fix: jsx types

### DIFF
--- a/packages/core/src/declarations/stencil-public-runtime.ts
+++ b/packages/core/src/declarations/stencil-public-runtime.ts
@@ -847,7 +847,7 @@ export interface FunctionalUtilities {
 }
 
 export interface FunctionalComponent<T = {}> {
-  (props: T, children: VNode[], utils: FunctionalUtilities): VNode | VNode[] | null;
+  (props: T, children: VNode[], utils: FunctionalUtilities): VNode | null;
 }
 
 /**
@@ -873,12 +873,12 @@ export interface ChildNode {
  *
  * For further information: https://stenciljs.com/docs/host-element
  */
-export declare const Host: FunctionalComponent<HostAttributes>;
+export declare const Host: (props: HostAttributes) => VNode;
 
 /**
  * Fragment
  */
-export declare const Fragment: FunctionalComponent<{}>;
+export declare const Fragment: (props: {}) => VNode;
 
 /* eslint-disable jsdoc/require-param, jsdoc/require-returns -- we don't want to JSDoc these overloads at this time */
 /**
@@ -905,6 +905,7 @@ export declare namespace h {
   ): VNode;
 
   export namespace JSX {
+    type Element = VNode;
     interface IntrinsicElements extends LocalJSX.IntrinsicElements, JSXBase.IntrinsicElements {
       [tagName: string]: any;
     }

--- a/packages/core/src/runtime/_test_/jsx.spec.tsx
+++ b/packages/core/src/runtime/_test_/jsx.spec.tsx
@@ -1,5 +1,4 @@
 import { Component, Fragment, h, Host, Prop, State } from '@stencil/core';
-import { FunctionalComponent } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
 
@@ -65,10 +64,7 @@ describe('jsx', () => {
       first?: string;
       last?: string;
     }
-    const FunctionalCmp: FunctionalComponent<FunctionalCmpProps> = ({
-      first = 'Kim',
-      last = 'Doe',
-    }) => (
+    const FunctionalCmp = ({ first = 'Kim', last = 'Doe' }: FunctionalCmpProps) => (
       <div>
         Hi, my name is {first} {last}.
       </div>
@@ -77,7 +73,11 @@ describe('jsx', () => {
     @Component({ tag: 'cmp-a' })
     class CmpA {
       render() {
-        return <FunctionalCmp />;
+        return (
+          <>
+            <FunctionalCmp />
+          </>
+        );
       }
     }
 

--- a/packages/core/src/runtime/_test_/render-vdom.spec.tsx
+++ b/packages/core/src/runtime/_test_/render-vdom.spec.tsx
@@ -262,7 +262,7 @@ describe('render-vdom', () => {
       class CmpA {
         render() {
           const H = () => {
-            return;
+            return null;
           };
           return <H />;
         }
@@ -288,7 +288,7 @@ describe('render-vdom', () => {
         render() {
           const Tunnel = {
             Provider: () => {
-              return;
+              return null;
             },
           };
           return <Tunnel.Provider />;

--- a/packages/core/src/runtime/vdom/_test_/h.spec.ts
+++ b/packages/core/src/runtime/vdom/_test_/h.spec.ts
@@ -416,7 +416,7 @@ describe('h()', () => {
     });
 
     it('replaceAttributes should return the attributes for the node', () => {
-      const FunctionalCmp: d.FunctionalComponent = (_nodeData, children, util) => {
+      const FunctionalCmp = (_nodeData: any, children: d.VNode[], util: d.FunctionalUtilities) => {
         return util.map(children, (child) => {
           return {
             ...child,
@@ -461,7 +461,7 @@ describe('h()', () => {
       const ReplacementCmp: d.FunctionalComponent = (nodeData, children) => {
         return h('article', nodeData, h('p', null, ...children));
       };
-      const FunctionalCmp: d.FunctionalComponent = (_nodeData, children, util) => {
+      const FunctionalCmp = (_nodeData, children, util) => {
         return util.map(children, (child) => {
           return {
             ...child,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes: #5306
Closes: #5307

TypeScript now correctly resolves Stencil's JSX element type. 
Previously, `JSX.Element` was undefined in the h namespace, causing TypeScript to silently fall back to `any` for JSX expressions — surfaced as `no-unsafe-return` errors in strict `@typescript-eslint` setups.

Three type-level changes:

`h.JSX.Element` is now `VNode`
`Host` and `Fragment` are typed as `(props) => VNode instead of FunctionalComponent<...>`
`FunctionalComponent<T>` return type narrowed from `VNode | VNode[] | null` to `VNode | null`


## Migration

No runtime changes — types only.

If you have a `FunctionalComponent<T>` that returns an array (via utils.map or similar), wrap the result in a fragment instead:

```
// Before
const MyList: FunctionalComponent<Props> = (props, children, utils) =>
  utils.map(children, transform);
```

```
// After
const MyList: FunctionalComponent<Props> = (props, children, utils) => (
  <>{utils.map(children, transform)}</>
);
```

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
