### PR TITLE
fix(compiler): silence INVALID_ANNOTATION and SOURCEMAP_BROKEN warnings from workerPlugin

### DIFF
--- a/src/compiler/bundle/worker-plugin.ts
+++ b/src/compiler/bundle/worker-plugin.ts
@@ -19,7 +19,10 @@ export const workerPlugin = (
       name: 'workerPlugin',
       transform(_, id) {
         if (id.endsWith('?worker') || id.endsWith('?worker-inline')) {
-          return getMockedWorkerMain();
+          return {
+            code: getMockedWorkerMain(),
+            map: { mappings: '' },
+          };
         }
         return null;
       },
@@ -77,6 +80,7 @@ export const workerPlugin = (
         dependencies.forEach((id) => this.addWatchFile(id));
         return {
           code: getWorkerMain(referenceId, workerName, workerMsgId),
+          map: { mappings: '' },
           moduleSideEffects: false,
         };
       } else if (id.endsWith('?worker-inline')) {
@@ -98,6 +102,7 @@ export const workerPlugin = (
         dependencies.forEach((id) => this.addWatchFile(id));
         return {
           code: getInlineWorker(referenceId, workerName, workerMsgId),
+          map: { mappings: '' },
           moduleSideEffects: false,
         };
       }
@@ -110,11 +115,13 @@ export const workerPlugin = (
           if (inlineWorkers) {
             return {
               code: getInlineWorkerProxy(workerEntryPath, worker.workerMsgId, worker.exports),
+              map: { mappings: '' },
               moduleSideEffects: false,
             };
           } else {
             return {
               code: getWorkerProxy(workerEntryPath, worker.exports),
+              map: { mappings: '' },
               moduleSideEffects: false,
             };
           }

--- a/src/compiler/bundle/worker-plugin.ts
+++ b/src/compiler/bundle/worker-plugin.ts
@@ -405,7 +405,7 @@ const getWorkerMain = (referenceId: string, workerName: string, workerMsgId: str
 import { createWorker } from '${WORKER_HELPER_ID}';
 export const workerName = '${workerName}';
 export const workerMsgId = '${workerMsgId}';
-export const workerPath = /*@__PURE__*/import.meta.ROLLUP_FILE_URL_${referenceId};
+export const workerPath = import.meta.ROLLUP_FILE_URL_${referenceId};
 export const worker = /*@__PURE__*/createWorker(workerPath, workerName, workerMsgId);
 `;
 };
@@ -415,7 +415,7 @@ const getInlineWorker = (referenceId: string, workerName: string, workerMsgId: s
 import { createWorker } from '${WORKER_HELPER_ID}';
 export const workerName = '${workerName}';
 export const workerMsgId = '${workerMsgId}';
-export const workerPath = /*@__PURE__*/import.meta.ROLLUP_FILE_URL_${referenceId};
+export const workerPath = import.meta.ROLLUP_FILE_URL_${referenceId};
 export let worker;
 try {
   // first try directly starting the worker with the URL


### PR DESCRIPTION
## What is the current behavior?

Every project that bundles a `*.worker.ts` (or `*.worker.tsx`) entry emits two bundling warnings on every build:

```
[ WARN  ]  Bundling Warning INVALID_ANNOTATION
           src/<name>.worker.ts?worker (4:19): A comment "/*@__PURE__*/" in "src/<name>.worker.ts?worker"
           contains an annotation that Rollup cannot interpret due to the position of the comment.
           The comment will be removed to avoid issues.

[ WARN  ]  Bundling Warning SOURCEMAP_BROKEN
           [plugin workerPlugin] Sourcemap is likely to be incorrect: a plugin (workerPlugin) was used
           to transform files, but didn't generate a sourcemap for the transformation. Consult the
           plugin documentation for help.
```

The `SOURCEMAP_BROKEN` variant has been tracked as a validated bug for over three years (#3476, opened against v2.17.1, labels `Bug: Validated`, `Help Wanted`). A minimal reproduction repo is linked from that issue: https://github.com/Scan0815/stencil-source-map-error. Both warnings originate from `src/compiler/bundle/worker-plugin.ts`. There is no user-facing way to suppress them: `validateRollupConfig` (`src/compiler/config/validate-rollup-config.ts`) whitelists only `context`, `moduleContext`, `treeshake`, `external`, `maxParallelFileOps` from `rollupConfig.inputOptions`, so an `onwarn` override on `stencil.config.ts` is dropped before reaching Rollup. The hardcoded `ignoreWarnCodes` set in `src/utils/logger/logger-rollup.ts` does not include either code.

Fixes #3476

## What is the new behavior?

Two independent fixes in `src/compiler/bundle/worker-plugin.ts`:

**1. `INVALID_ANNOTATION` — `/*@__PURE__*/` is meaningful only in front of call or `new` expressions.** In `getWorkerMain` and `getInlineWorker` the marker was placed in front of `import.meta.ROLLUP_FILE_URL_*`, a property access. Rollup cannot apply pure-side-effect analysis there and strips the comment with the warning above. The two stale markers on `workerPath` are removed. The remaining `/*@__PURE__*/` markers on the actual `createWorker(...)` / `createWorkerProxy(...)` calls are unchanged and still effective.

**2. `SOURCEMAP_BROKEN` (#3476) — the `transform` hook returned synthetic wrapper code without a sourcemap.** The Rollup [plugin convention](https://rollupjs.org/plugin-development/#source-code-transformations) for transforms that produce code with no useful source-position mapping is to return `map: { mappings: '' }`. All five `transform` return paths now do so: the mocked hydrate/worker-platform branch and the four real-bundle branches (`?worker`, `?worker-inline`, proxy + inline-proxy).

Neither change alters runtime behavior. The two commits are kept separate so each fix is independently revertable.

## Documentation

N/A — no public API surface change.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

- `npx tsc --noEmit` passes after each commit.
- ESLint reports no new errors on `src/compiler/bundle/worker-plugin.ts` (a pre-existing `simple-import-sort/imports` finding on `main` is left untouched to keep this PR focused).
- Full project build (`npm run build`) and end-to-end verification against the #3476 reproduction repo have **not** been performed locally and are deferred to CI / reviewer verification. Steps to reproduce remain those in the original issue.
- No new unit tests added: the touched helpers are non-exported template-string builders and the bundling transforms return synthetic wrapper code; both fixes are warning-suppressing only and have no behavioral surface that a Jest spec could meaningfully assert beyond duplicating the snippet. Happy to add a targeted spec if reviewers prefer.

## Other information

The two affected helpers (`getWorkerMain`, `getInlineWorker`) and the four `transform` return branches were unchanged in behavior across recent history, so this is purely a hygiene fix on long-standing output. Disclosure: I'm the original reporter of #3476.