### PR TITLE
feat: v5 improve collection handling / rebundling

### DIFF
--- a/packages/core/src/compiler/build/build.ts
+++ b/packages/core/src/compiler/build/build.ts
@@ -6,6 +6,7 @@ import { catchError, isString, join, readPackageJson } from '../../utils';
 import { generateOutputTargets } from '../output-targets';
 import { emptyOutputTargets } from '../output-targets/empty-dir';
 import { generateGlobalStyles } from '../style/global-styles';
+import { ingestConfigCollections } from '../transformers/collection/add-external-import';
 import { resetDeprecatedApiWarning } from '../transformers/decorators-to-static/component-decorator';
 import { runTsProgram, validateTypesAfterGeneration } from '../transpile/run-program';
 import { buildAbort, buildFinish } from './build-finish';
@@ -50,6 +51,9 @@ export const build = async (
 
     await readPackageJson(config, compilerCtx, buildCtx);
     if (buildCtx.hasError) return buildAbort(buildCtx);
+
+    // proactively ingest any collections declared in config.collections
+    ingestConfigCollections(config, compilerCtx, buildCtx);
 
     // run typescript program
     const tsTimeSpan = buildCtx.createTimeSpan('transpile started');

--- a/packages/core/src/compiler/config/validate-config.ts
+++ b/packages/core/src/compiler/config/validate-config.ts
@@ -191,6 +191,10 @@ export const validateConfig = (
     validatedConfig.excludeComponents = [];
   }
 
+  if (!Array.isArray(validatedConfig.collections)) {
+    validatedConfig.collections = [];
+  }
+
   // validate how many workers we can use
   validateWorkers(validatedConfig);
 

--- a/packages/core/src/compiler/transformers/collection/add-external-import.ts
+++ b/packages/core/src/compiler/transformers/collection/add-external-import.ts
@@ -1,26 +1,29 @@
 import { dirname } from 'path';
 import type * as d from '@stencil/core';
 
-import { isString, normalizePath, parsePackageJson } from '../../../utils';
+import { isString, join, normalizePath, parsePackageJson } from '../../../utils';
 import { tsResolveModuleNamePackageJsonPath } from '../../sys/typescript/typescript-resolve-module';
 import { parseCollection } from './parse-collection-module';
 
-export const addExternalImport = (
+/**
+ * Resolve a package by moduleId, check if it's a Stencil collection, and ingest it into the
+ * build context (including transitive collection dependencies).
+ * @param config the Stencil configuration associated with the project being compiled
+ * @param compilerCtx the current compiler context
+ * @param buildCtx the current build context
+ * @param containingFile the file path of the module that contains the import being resolved
+ * @param moduleId the bare module ID being imported (e.g. 'my-lib' or '@my-scope/my-lib')
+ * @param resolveCollections whether to resolve and ingest collections found, or just check if the import is a collection without ingesting it
+ */
+const resolveAndIngestCollection = (
   config: d.ValidatedConfig,
   compilerCtx: d.CompilerCtx,
   buildCtx: d.BuildCtx,
-  moduleFile: d.Module,
   containingFile: string,
   moduleId: string,
   resolveCollections: boolean,
 ) => {
-  if (!moduleFile.externalImports.includes(moduleId)) {
-    moduleFile.externalImports.push(moduleId);
-    moduleFile.externalImports.sort();
-  }
-
   if (!resolveCollections || compilerCtx.resolvedCollections.has(moduleId)) {
-    // we've already handled this collection moduleId before
     return;
   }
 
@@ -95,7 +98,6 @@ export const addExternalImport = (
   });
 
   if (alreadyHasCollection) {
-    // we already have this collection in our build context
     return;
   }
 
@@ -107,15 +109,80 @@ export const addExternalImport = (
     // let's keep digging down and discover all of them
     collection.dependencies.forEach((dependencyModuleId) => {
       const resolveFromDir = dirname(pkgJsonFilePath);
-      addExternalImport(
+      resolveAndIngestCollection(
         config,
         compilerCtx,
         buildCtx,
-        moduleFile,
         resolveFromDir,
         dependencyModuleId,
         resolveCollections,
       );
     });
+  }
+};
+
+/**
+ * Add an external import to a module, and if it's a Stencil collection, ingest it into the build context
+ * @param config the Stencil configuration associated with the project being compiled
+ * @param compilerCtx the current compiler context
+ * @param buildCtx the current build context
+ * @param moduleFile the module file object representing the module that contains the import being resolved
+ * @param containingFile the file path of the module that contains the import being resolved
+ * @param moduleId the bare module ID being imported (e.g. 'my-lib' or '@my-scope/my-lib')
+ * @param resolveCollections whether to resolve and ingest collections found, or just check if the import is a collection without ingesting it
+ * @param isSideEffectImport whether this is a side-effect-only import (e.g. `import '@pkg'`) or not (e.g. `import { x } from '@pkg'`)
+ */
+export const addExternalImport = (
+  config: d.ValidatedConfig,
+  compilerCtx: d.CompilerCtx,
+  buildCtx: d.BuildCtx,
+  moduleFile: d.Module,
+  containingFile: string,
+  moduleId: string,
+  resolveCollections: boolean,
+  isSideEffectImport = false,
+) => {
+  if (!moduleFile.externalImports.includes(moduleId)) {
+    moduleFile.externalImports.push(moduleId);
+    moduleFile.externalImports.sort();
+  }
+
+  // Only ingest a collection if:
+  // a) it's a bare side-effect import (`import '@pkg'`), or
+  // b) the package is explicitly listed in config.collections
+  const isExplicitCollection = config.collections?.includes(moduleId) ?? false;
+  if (!isSideEffectImport && !isExplicitCollection) {
+    return;
+  }
+
+  resolveAndIngestCollection(
+    config,
+    compilerCtx,
+    buildCtx,
+    containingFile,
+    moduleId,
+    resolveCollections,
+  );
+};
+
+/**
+ * Proactively ingest all collections listed in `config.collections` into the build context.
+ * Called before transpilation so collection components are available during the TS program run.
+ * @param config the Stencil configuration associated with the project being compiled
+ * @param compilerCtx the current compiler context
+ * @param buildCtx the current build context
+ */
+export const ingestConfigCollections = (
+  config: d.ValidatedConfig,
+  compilerCtx: d.CompilerCtx,
+  buildCtx: d.BuildCtx,
+) => {
+  if (!config.collections?.length) {
+    return;
+  }
+  // Resolve packages relative to the project root
+  const containingFile = join(config.rootDir, 'package.json');
+  for (const moduleId of config.collections) {
+    resolveAndIngestCollection(config, compilerCtx, buildCtx, containingFile, moduleId, true);
   }
 };

--- a/packages/core/src/compiler/transformers/static-to-meta/import.ts
+++ b/packages/core/src/compiler/transformers/static-to-meta/import.ts
@@ -39,6 +39,7 @@ export const parseModuleImport = (
         moduleFile.sourceFilePath,
         importPath,
         resolveCollections,
+        !importNode.importClause,
       );
     }
   }

--- a/packages/core/src/declarations/stencil-public-compiler.ts
+++ b/packages/core/src/declarations/stencil-public-compiler.ts
@@ -306,6 +306,25 @@ export interface StencilConfig {
    * Set whether unused dependencies should be excluded from the built output.
    */
   excludeUnusedDependencies?: boolean;
+
+  /**
+   * Explicitly declare which npm packages are Stencil collections to be re-bundled into this project.
+   *
+   * Without this option, collection ingestion is triggered only by a side-effect import:
+   * ```ts
+   * import '@ionic/core';
+   * ```
+   * @example
+   * ```ts
+   * export const config: Config = {
+   *   collections: ['@ionic/core', '@my-org/design-system'],
+   * };
+   * ```
+   *
+   * @default []
+   */
+  collections?: string[];
+
   stencilCoreResolvedId?: string;
 }
 

--- a/test/runtime/src/global.ts
+++ b/test/runtime/src/global.ts
@@ -1,10 +1,6 @@
 import { setMode } from '@stencil/core';
 
 import { setupApp } from './index';
-// this imports the build from the `../fixtures/external-base-classes` project.
-// The ability to use a Stencil component defined in a 'external' project is tested in the
-// `stencil-sibling` test suite
-import '@stencil-core-tests/runtime-external';
 
 declare global {
   interface Window {

--- a/test/runtime/stencil.config.ts
+++ b/test/runtime/stencil.config.ts
@@ -5,6 +5,9 @@ export const config: Config = {
   namespace: 'TestApp',
   tsconfig: 'tsconfig.stencil.json',
   excludeComponents: ['excluded-component', 'exclude-*'],
+  collections: ['@stencil-core-tests/runtime-external'],
+  globalScript: 'src/global.ts',
+  globalStyle: 'src/global.css',
   outputTargets: [
     {
       type: 'loader-bundle',
@@ -25,8 +28,6 @@ export const config: Config = {
       silenceDeprecations: ['import'],
     }),
   ],
-  globalScript: 'src/global.ts',
-  globalStyle: 'src/global.css',
   extras: {
     lifecycleDOMEvents: true,
     additionalTagTransformers: true,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number:  #6641 

importing *any* module / type from another stencil lib will re-bundle the whole thing


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

1) Only a sideEffect import will now re-bundle e.g. `import "@my-thing/lib"`
2) A new explicit `collections: ["@my-thing/lib"]` property has been added to stencil.config

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

Users *expecting* any import to re-bundle a 3rd party lib must migrate to use one of the mentioned methods

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
