### PR TITLE
feat: v5 inject stencil hydrate css into global-style

### DIFF
--- a/V5_PLANNING.md
+++ b/V5_PLANNING.md
@@ -127,6 +127,7 @@ Modernize Stencil after 10 years: shed tech debt, embrace modern tooling, simpli
 - **Multiple `global-style` outputs supported** - build separate CSS bundles from different input files, each with independent `inject` settings
 - **`www` can now use standalone loader**
 - **`@Component` now supports `globalStyleUrl` and `globalStyle`** — co-locate document-level styles with the component. Styles are collected at build time and injected wherever `@import "stencil-globals"` appears in a global stylesheet. Works for all encapsulation types (shadow, scoped, none). No mode variants — CSS handles runtime variants via selectors or custom properties. Changes to `globalStyleUrl` files invalidate the global style build cache and trigger HMR correctly.
+- **`@import "stencil-hydrate"` virtual placeholder** — add to any `global-style` input to inject static FOUC-prevention CSS at build time instead of relying on the dynamic `<style>` tag inserted by the loader. The compiler replaces the placeholder with the sorted component selectors + configured hydration CSS (e.g. `my-cmp,other-cmp{visibility:hidden}.hydrated{visibility:inherit}`). When detected, `BUILD.staticHydrationStyles = true` suppresses the loader's dynamic injection. For `standalone` builds (which have no loader), `stencil-hydrate.css` is auto-generated alongside the bundle.
 
 ---
 

--- a/packages/core/src/app-data/index.ts
+++ b/packages/core/src/app-data/index.ts
@@ -90,6 +90,7 @@ export const BUILD: BuildConditionals = {
   hydratedAttribute: false,
   hydratedClass: true,
   invisiblePrehydration: true,
+  staticHydrationStyles: false,
   propBoolean: true,
   propNumber: true,
   propString: true,

--- a/packages/core/src/compiler/output-targets/_test_/build-conditionals.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/build-conditionals.spec.ts
@@ -151,6 +151,18 @@ describe('build-conditionals', () => {
       const bc = getLazyBuildConditionals(config, cmps);
       expect(bc.hydratedSelectorName).toBe('boooop');
     });
+
+    it('staticHydrationStyles defaults to false', () => {
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+      const bc = getLazyBuildConditionals(config, cmps);
+      expect(bc.staticHydrationStyles).toBe(false);
+    });
+
+    it('staticHydrationStyles is true when passed as true', () => {
+      const { config } = validateConfig(userConfig, mockLoadConfigInit());
+      const bc = getLazyBuildConditionals(config, cmps, true);
+      expect(bc.staticHydrationStyles).toBe(true);
+    });
   });
 
   describe('getSsrBuildConditionals', () => {

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-standalone.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-standalone.spec.ts
@@ -23,6 +23,7 @@ import {
   bundleStandalone,
   generateEntryPoint,
   getBundleOptions,
+  isHydrateInlinedByGlobalStyle,
   outputStandalone,
 } from '../standalone';
 
@@ -409,6 +410,66 @@ export const defineCustomElements = (opts) => {
         expect(bundleOptions.inputs['loader']).toBeUndefined();
         expect(bundleOptions.loader['\0loader']).toBeUndefined();
       });
+    });
+  });
+
+  describe('isHydrateInlinedByGlobalStyle', () => {
+    it('returns false when no global-style output targets are configured', async () => {
+      const { config, compilerCtx } = setup();
+      config.outputTargets = [{ type: 'standalone' }];
+      expect(await isHydrateInlinedByGlobalStyle(config, compilerCtx)).toBe(false);
+    });
+
+    it('returns false when global-style has no input', async () => {
+      const { config, compilerCtx } = setup();
+      config.outputTargets = [{ type: 'standalone' }, { type: 'global-style' }];
+      expect(await isHydrateInlinedByGlobalStyle(config, compilerCtx)).toBe(false);
+    });
+
+    it('returns false when global-style input does not contain stencil-hydrate', async () => {
+      const { config, compilerCtx } = setup();
+      config.outputTargets = [
+        { type: 'standalone' },
+        { type: 'global-style', input: '/src/global.css' },
+      ];
+      vi.spyOn(compilerCtx.fs, 'readFile').mockResolvedValue(':root { color: red; }');
+      expect(await isHydrateInlinedByGlobalStyle(config, compilerCtx)).toBe(false);
+    });
+
+    it('returns true when global-style input contains @import "stencil-hydrate"', async () => {
+      const { config, compilerCtx } = setup();
+      config.outputTargets = [
+        { type: 'standalone' },
+        { type: 'global-style', input: '/src/global.css' },
+      ];
+      vi.spyOn(compilerCtx.fs, 'readFile').mockResolvedValue(
+        '@import "stencil-hydrate";\n:root {}',
+      );
+      expect(await isHydrateInlinedByGlobalStyle(config, compilerCtx)).toBe(true);
+    });
+
+    it('returns true when at least one global-style input contains stencil-hydrate', async () => {
+      const { config, compilerCtx } = setup();
+      config.outputTargets = [
+        { type: 'standalone' },
+        { type: 'global-style', input: '/src/a.css' },
+        { type: 'global-style', input: '/src/b.css' },
+      ];
+      vi.spyOn(compilerCtx.fs, 'readFile').mockImplementation(async (path) => {
+        if (path === '/src/b.css') return '@import "stencil-hydrate";';
+        return ':root {}';
+      });
+      expect(await isHydrateInlinedByGlobalStyle(config, compilerCtx)).toBe(true);
+    });
+
+    it('returns false when readFile throws for all inputs', async () => {
+      const { config, compilerCtx } = setup();
+      config.outputTargets = [
+        { type: 'standalone' },
+        { type: 'global-style', input: '/src/global.css' },
+      ];
+      vi.spyOn(compilerCtx.fs, 'readFile').mockRejectedValue(new Error('file not found'));
+      expect(await isHydrateInlinedByGlobalStyle(config, compilerCtx)).toBe(false);
     });
   });
 });

--- a/packages/core/src/compiler/output-targets/dist-lazy/lazy-build-conditionals.ts
+++ b/packages/core/src/compiler/output-targets/dist-lazy/lazy-build-conditionals.ts
@@ -6,6 +6,7 @@ import { getBuildFeatures, updateBuildConditionals } from '../../app-core/app-da
 export const getLazyBuildConditionals = (
   config: d.ValidatedConfig,
   cmps: d.ComponentCompilerMeta[],
+  staticHydrationStyles = false,
 ): d.BuildConditionals => {
   const build = getBuildFeatures(cmps) as d.BuildConditionals;
 
@@ -14,6 +15,7 @@ export const getLazyBuildConditionals = (
   build.asyncQueue = config.taskQueue === 'congestionAsync';
   build.taskQueue = config.taskQueue !== 'immediate';
   build.initializeNextTick = config.extras.initializeNextTick;
+  build.staticHydrationStyles = staticHydrationStyles;
 
   const hasSsrOutputTargets = config.outputTargets.some(isOutputTargetSsr);
   build.hydrateClientSide = hasSsrOutputTargets;

--- a/packages/core/src/compiler/output-targets/dist-lazy/lazy-output.ts
+++ b/packages/core/src/compiler/output-targets/dist-lazy/lazy-output.ts
@@ -5,8 +5,10 @@ import type * as d from '@stencil/core';
 import {
   catchError,
   isOutputTargetAssets,
+  isOutputTargetGlobalStyle,
   isOutputTargetLoaderBundle,
   isOutputTargetDistLazy,
+  normalizePath,
   relative,
   sortBy,
 } from '../../../utils';
@@ -61,7 +63,27 @@ export const outputLazy = async (
     const browserTarget = outputTargets.find((o) => o.isBrowserBuild && o.esmDir);
     const externalTarget = outputTargets.find((o) => !o.isBrowserBuild && o.esmDir);
 
-    const conditionals = getLazyBuildConditionals(config, buildCtx.components);
+    // Pre-scan global-style inputs to detect @import "stencil-hydrate" before bundling.
+    // When found, the BUILD flag suppresses the dynamic <style> injection in bootstrap-loader.
+    let staticHydrationStyles = false;
+    for (const target of config.outputTargets.filter(isOutputTargetGlobalStyle)) {
+      if (!target.input) continue;
+      try {
+        const content = await compilerCtx.fs.readFile(normalizePath(target.input));
+        if (content?.includes('stencil-hydrate')) {
+          staticHydrationStyles = true;
+          break;
+        }
+      } catch {
+        // file not readable yet — will be caught properly during actual style build
+      }
+    }
+
+    const conditionals = getLazyBuildConditionals(
+      config,
+      buildCtx.components,
+      staticHydrationStyles,
+    );
     mergeCollectionBuildFlags(conditionals, compilerCtx.collections);
 
     const bundleOpts: BundleOptions = {

--- a/packages/core/src/compiler/output-targets/standalone/index.ts
+++ b/packages/core/src/compiler/output-targets/standalone/index.ts
@@ -24,6 +24,7 @@ import {
   USER_INDEX_ENTRY_ID,
 } from '../../bundle/entry-alias-ids';
 import { optimizeModule } from '../../optimize/optimize-module';
+import { generateHydrateCss } from '../../style/component-global-styles';
 import { addTagTransform } from '../../transformers/add-tag-transform';
 import { addDefineCustomElementFunctions } from '../../transformers/component-native/add-define-custom-element-function';
 import { proxyCustomElement } from '../../transformers/component-native/proxy-custom-element-function';
@@ -198,6 +199,19 @@ export const bundleStandalone = async (
         }
       });
       await Promise.all(files);
+
+      // Generate stencil-hydrate.css as a static FOUC-prevention stylesheet.
+      // Standalone builds have no dynamic loader to inject hydration styles, so
+      // users can link this file in their HTML instead.
+      // Written to the assets dir (same location as global-style CSS), falling back to the standalone dir.
+      if (config.hydratedFlag && config.invisiblePrehydration !== false) {
+        const hydrateCss = generateHydrateCss(config, buildCtx);
+        if (hydrateCss) {
+          const assetsTarget = config.outputTargets.find(isOutputTargetAssets);
+          const cssDir = assetsTarget?.dir ?? outputTargetDir;
+          await compilerCtx.fs.writeFile(join(cssDir, 'stencil-hydrate.css'), hydrateCss);
+        }
+      }
     }
   } catch (e: any) {
     catchError(buildCtx.diagnostics, e);

--- a/packages/core/src/compiler/output-targets/standalone/index.ts
+++ b/packages/core/src/compiler/output-targets/standalone/index.ts
@@ -10,9 +10,11 @@ import {
   hasError,
   isBoolean,
   isOutputTargetAssets,
+  isOutputTargetGlobalStyle,
   isOutputTargetStandalone,
   isString,
   join,
+  normalizePath,
   relative,
   rolldownToStencilSourceMap,
 } from '../../../utils';
@@ -35,6 +37,28 @@ import { updateStencilCoreImports } from '../../transformers/update-stencil-core
 import { generateLoaderModule } from './generate-loader-module';
 import { getStandaloneBuildConditionals } from './standalone-build-conditionals';
 import type { BundleOptions } from '../../bundle/bundle-interface';
+
+/**
+ * Returns true if any `global-style` output target's input file contains `@import "stencil-hydrate"`,
+ * meaning the FOUC prevention CSS is already embedded in that stylesheet.
+ * @param config the Stencil configuration
+ * @param compilerCtx the compiler context, used to read the global style input files
+ * @returns a promise which resolves to true if the FOUC prevention styles are already inlined in a global style, false otherwise
+ */
+export const isHydrateInlinedByGlobalStyle = async (
+  config: d.ValidatedConfig,
+  compilerCtx: d.CompilerCtx,
+): Promise<boolean> =>
+  Promise.any(
+    config.outputTargets
+      .filter(isOutputTargetGlobalStyle)
+      .filter((t) => t.input)
+      .map(async (t) => {
+        const content = await compilerCtx.fs.readFile(normalizePath(t.input!));
+        if (content?.includes('stencil-hydrate')) return true;
+        throw new Error();
+      }),
+  ).catch(() => false);
 
 /**
  * Main output target function for `standalone` (standalone component modules). This function just
@@ -200,11 +224,9 @@ export const bundleStandalone = async (
       });
       await Promise.all(files);
 
-      // Generate stencil-hydrate.css as a static FOUC-prevention stylesheet.
-      // Standalone builds have no dynamic loader to inject hydration styles, so
-      // users can link this file in their HTML instead.
-      // Written to the assets dir (same location as global-style CSS), falling back to the standalone dir.
-      if (config.hydratedFlag && config.invisiblePrehydration !== false) {
+      const hydrateAlreadyInlined = await isHydrateInlinedByGlobalStyle(config, compilerCtx);
+
+      if (!hydrateAlreadyInlined && config.hydratedFlag && config.invisiblePrehydration !== false) {
         const hydrateCss = generateHydrateCss(config, buildCtx);
         if (hydrateCss) {
           const assetsTarget = config.outputTargets.find(isOutputTargetAssets);

--- a/packages/core/src/compiler/style/_test_/component-global-styles.spec.ts
+++ b/packages/core/src/compiler/style/_test_/component-global-styles.spec.ts
@@ -4,8 +4,11 @@ import type * as d from '@stencil/core';
 
 import {
   collectAndBuildComponentGlobalStyles,
+  generateHydrateCss,
   hasStencilGlobalsImport,
+  hasStencilHydrateImport,
   resolveStencilGlobalsImport,
+  resolveStencilHydrateImport,
 } from '../component-global-styles';
 
 describe('component-global-styles', () => {
@@ -153,6 +156,122 @@ describe('component-global-styles', () => {
       );
       expect(result).not.toContain('@import "stencil-globals"');
       expect(result).toContain(':root {}');
+      expect(result).toContain('body {}');
+    });
+  });
+
+  describe('hasStencilHydrateImport', () => {
+    it('detects double-quote import', () => {
+      expect(hasStencilHydrateImport(`@import "stencil-hydrate";`)).toBe(true);
+    });
+
+    it('detects single-quote import', () => {
+      expect(hasStencilHydrateImport(`@import 'stencil-hydrate';`)).toBe(true);
+    });
+
+    it('detects url() form', () => {
+      expect(hasStencilHydrateImport(`@import url("stencil-hydrate");`)).toBe(true);
+    });
+
+    it('returns false when not present', () => {
+      expect(hasStencilHydrateImport(`:root { color: red; }`)).toBe(false);
+    });
+  });
+
+  describe('generateHydrateCss', () => {
+    it('returns empty string when hydratedFlag is null', () => {
+      config.hydratedFlag = null;
+      buildCtx.components = [mockCmp({ tagName: 'my-cmp' })];
+      expect(generateHydrateCss(config, buildCtx)).toBe('');
+    });
+
+    it('returns empty string when there are no components', () => {
+      buildCtx.components = [];
+      expect(generateHydrateCss(config, buildCtx)).toBe('');
+    });
+
+    it('generates FOUC css with default hydratedFlag', () => {
+      config.hydratedFlag = {
+        selector: 'class',
+        name: 'hydrated',
+        property: 'visibility',
+        initialValue: 'hidden',
+        hydratedValue: 'inherit',
+      };
+      buildCtx.components = [mockCmp({ tagName: 'my-cmp' })];
+      const result = generateHydrateCss(config, buildCtx);
+      expect(result).toBe('my-cmp{visibility:hidden}.hydrated{visibility:inherit}');
+    });
+
+    it('sorts and joins multiple component tags', () => {
+      config.hydratedFlag = {
+        selector: 'class',
+        name: 'hydrated',
+        property: 'visibility',
+        initialValue: 'hidden',
+        hydratedValue: 'inherit',
+      };
+      buildCtx.components = [
+        mockCmp({ tagName: 'cmp-z' }),
+        mockCmp({ tagName: 'cmp-a' }),
+        mockCmp({ tagName: 'cmp-m' }),
+      ];
+      const result = generateHydrateCss(config, buildCtx);
+      expect(result).toMatch(/^cmp-a,cmp-m,cmp-z/);
+    });
+
+    it('uses attribute selector when configured', () => {
+      config.hydratedFlag = {
+        selector: 'attribute',
+        name: 'hydrated',
+        property: 'visibility',
+        initialValue: 'hidden',
+        hydratedValue: 'inherit',
+      };
+      buildCtx.components = [mockCmp({ tagName: 'my-cmp' })];
+      const result = generateHydrateCss(config, buildCtx);
+      expect(result).toContain('[hydrated]');
+    });
+  });
+
+  describe('resolveStencilHydrateImport', () => {
+    it('replaces @import "stencil-hydrate" with FOUC css', () => {
+      config.hydratedFlag = {
+        selector: 'class',
+        name: 'hydrated',
+        property: 'visibility',
+        initialValue: 'hidden',
+        hydratedValue: 'inherit',
+      };
+      buildCtx.components = [mockCmp({ tagName: 'my-cmp' })];
+      const css = `:root {}\n@import "stencil-hydrate";\nbody {}`;
+      const result = resolveStencilHydrateImport(css, config, buildCtx);
+      expect(result).not.toContain('@import "stencil-hydrate"');
+      expect(result).toContain('my-cmp{visibility:hidden}.hydrated{visibility:inherit}');
+      expect(result).toContain(':root {}');
+      expect(result).toContain('body {}');
+    });
+
+    it('replaces all occurrences', () => {
+      config.hydratedFlag = {
+        selector: 'class',
+        name: 'hydrated',
+        property: 'visibility',
+        initialValue: 'hidden',
+        hydratedValue: 'inherit',
+      };
+      buildCtx.components = [mockCmp({ tagName: 'my-cmp' })];
+      const css = `@import "stencil-hydrate";\nbody {}\n@import "stencil-hydrate";`;
+      const result = resolveStencilHydrateImport(css, config, buildCtx);
+      expect((result.match(/@import "stencil-hydrate"/g) ?? []).length).toBe(0);
+    });
+
+    it('produces empty replacement when hydratedFlag is null', () => {
+      config.hydratedFlag = null;
+      buildCtx.components = [mockCmp({ tagName: 'my-cmp' })];
+      const css = `body {}\n@import "stencil-hydrate";`;
+      const result = resolveStencilHydrateImport(css, config, buildCtx);
+      expect(result).not.toContain('@import "stencil-hydrate"');
       expect(result).toContain('body {}');
     });
   });

--- a/packages/core/src/compiler/style/_test_/css-imports.spec.ts
+++ b/packages/core/src/compiler/style/_test_/css-imports.spec.ts
@@ -753,6 +753,43 @@ describe('css-imports', () => {
         ]);
       });
     });
+
+    describe('virtual imports', () => {
+      const filePath = normalizePath(path.join(root, 'src', 'global.css'));
+
+      it('skips @import "stencil-globals" — not resolved as a file', async () => {
+        const content = `@import "stencil-globals";`;
+        const results = await getCssImports(config, compilerCtx, buildCtx, filePath, content);
+        expect(results).toHaveLength(0);
+      });
+
+      it('skips @import "stencil-hydrate" — not resolved as a file', async () => {
+        const content = `@import "stencil-hydrate";`;
+        const results = await getCssImports(config, compilerCtx, buildCtx, filePath, content);
+        expect(results).toHaveLength(0);
+      });
+
+      it('skips virtual imports but resolves real adjacent imports', async () => {
+        const realCssPath = normalizePath(path.join(root, 'src', 'theme.css'));
+        readFileMock.mockResolvedValueOnce(':root { color: red; }');
+        const content = `@import "stencil-globals";\n@import "stencil-hydrate";\n@import "./theme.css";`;
+        const results = await getCssImports(config, compilerCtx, buildCtx, filePath, content);
+        expect(results).toHaveLength(1);
+        expect(results[0].filePath).toBe(realCssPath);
+      });
+
+      it('skips url() form of stencil-globals', async () => {
+        const content = `@import url("stencil-globals");`;
+        const results = await getCssImports(config, compilerCtx, buildCtx, filePath, content);
+        expect(results).toHaveLength(0);
+      });
+
+      it('skips url() form of stencil-hydrate', async () => {
+        const content = `@import url("stencil-hydrate");`;
+        const results = await getCssImports(config, compilerCtx, buildCtx, filePath, content);
+        expect(results).toHaveLength(0);
+      });
+    });
   });
 
   describe('parseCssImports', () => {

--- a/packages/core/src/compiler/style/component-global-styles.ts
+++ b/packages/core/src/compiler/style/component-global-styles.ts
@@ -5,8 +5,49 @@ import { runPluginTransforms } from '../plugin/plugin';
 import { optimizeCss } from './optimize-css';
 
 const STENCIL_GLOBALS_RE = /@import\s+(?:url\()?\s*['"]stencil-globals['"]\s*\)?\s*;?/g;
+const STENCIL_HYDRATE_RE = /@import\s+(?:url\()?\s*['"]stencil-hydrate['"]\s*\)?\s*;?/g;
 
 export const hasStencilGlobalsImport = (css: string): boolean => css.includes('stencil-globals');
+export const hasStencilHydrateImport = (css: string): boolean => css.includes('stencil-hydrate');
+
+/**
+ * Generate the FOUC-prevention CSS for all components in the build.
+ * Mirrors the CSS injected dynamically by bootstrap-loader, but produced at build time
+ * so it can be embedded in a static stylesheet via `@import "stencil-hydrate"`.
+ * @param config the Stencil configuration
+ * @param buildCtx the current build context, used to get the list of components in the build
+ * @returns the generated CSS string to replace `@import "stencil-hydrate"` with
+ */
+export const generateHydrateCss = (config: d.ValidatedConfig, buildCtx: d.BuildCtx): string => {
+  const h = config.hydratedFlag;
+  if (!h) return ''; // hydratedFlag: null means explicitly disabled
+
+  const tags = buildCtx.components.map((c) => c.tagName).sort();
+  if (!tags.length) return '';
+
+  const selector = h.selector === 'attribute' ? `[${h.name}]` : `.${h.name}`;
+  const initial =
+    h.initialValue === '' || h.initialValue == null ? '' : `{${h.property}:${h.initialValue}}`;
+  const hydrated =
+    h.hydratedValue === '' || h.hydratedValue == null
+      ? ''
+      : `${selector}{${h.property}:${h.hydratedValue}}`;
+
+  return tags.join(',') + initial + hydrated;
+};
+
+/**
+ * Replace `@import "stencil-hydrate"` in CSS with the generated FOUC-prevention styles.
+ * @param css the CSS string to process
+ * @param config the Stencil configuration
+ * @param buildCtx the current build context, used to get the list of components in the build
+ * @returns the CSS string with `@import "stencil-hydrate"` replaced by generated styles
+ */
+export const resolveStencilHydrateImport = (
+  css: string,
+  config: d.ValidatedConfig,
+  buildCtx: d.BuildCtx,
+): string => css.replace(STENCIL_HYDRATE_RE, generateHydrateCss(config, buildCtx));
 
 /**
  * Collect and build all component-level globalStyle/globalStyleUrl CSS from the current build.

--- a/packages/core/src/compiler/style/css-imports.ts
+++ b/packages/core/src/compiler/style/css-imports.ts
@@ -198,8 +198,8 @@ export const getCssImports = async (
       continue;
     }
 
-    if (cssImportData.url === 'stencil-globals') {
-      // virtual import resolved by Stencil at build time — leave it in the CSS unchanged
+    if (cssImportData.url === 'stencil-globals' || cssImportData.url === 'stencil-hydrate') {
+      // virtual imports resolved by Stencil at build time — leave them in the CSS unchanged
       continue;
     }
 

--- a/packages/core/src/compiler/style/global-styles.ts
+++ b/packages/core/src/compiler/style/global-styles.ts
@@ -2,7 +2,12 @@ import type * as d from '@stencil/core';
 
 import { catchError, normalizePath } from '../../utils';
 import { runPluginTransforms } from '../plugin/plugin';
-import { hasStencilGlobalsImport, resolveStencilGlobalsImport } from './component-global-styles';
+import {
+  hasStencilGlobalsImport,
+  hasStencilHydrateImport,
+  resolveStencilGlobalsImport,
+  resolveStencilHydrateImport,
+} from './component-global-styles';
 import { getCssImports } from './css-imports';
 import { optimizeCss } from './optimize-css';
 
@@ -98,6 +103,10 @@ export const buildGlobalStyleFromInput = async (
           buildCtx,
           normalizedPath,
         );
+      }
+
+      if (hasStencilHydrateImport(cssCode)) {
+        cssCode = resolveStencilHydrateImport(cssCode, config, buildCtx);
       }
 
       const optimizedCss = await optimizeCss(

--- a/packages/core/src/declarations/stencil-private.ts
+++ b/packages/core/src/declarations/stencil-private.ts
@@ -187,6 +187,8 @@ export interface BuildConditionals extends Partial<BuildFeatures> {
   hydratedAttribute?: boolean;
   hydratedClass?: boolean;
   hydratedSelectorName?: string;
+  /** True when a global-style input contains `@import "stencil-hydrate"` — suppresses dynamic style injection in the loader. */
+  staticHydrationStyles?: boolean;
   initializeNextTick?: boolean;
   asyncQueue?: boolean;
   additionalTagTransformers?: boolean | 'prod';

--- a/packages/core/src/runtime/_test_/bootstrap-loader.spec.ts
+++ b/packages/core/src/runtime/_test_/bootstrap-loader.spec.ts
@@ -65,6 +65,16 @@ describe('bootstrapLazy - CSS style injection', () => {
     expect(win.document.head.querySelector('[data-styles]')).toBeNull();
   });
 
+  it('does not inject a style element when staticHydrationStyles is enabled', () => {
+    BUILD.invisiblePrehydration = true;
+    BUILD.hydratedClass = true;
+    BUILD.staticHydrationStyles = true;
+
+    bootstrapLazy(minimalBundle('test-cmp'));
+
+    expect(win.document.head.querySelector('[data-styles]')).toBeNull();
+  });
+
   it('applies a nonce from plt.$nonce$ to the style element', () => {
     BUILD.invisiblePrehydration = true;
     BUILD.hydratedClass = true;

--- a/packages/core/src/runtime/bootstrap-loader.ts
+++ b/packages/core/src/runtime/bootstrap-loader.ts
@@ -265,7 +265,11 @@ export const bootstrapLazy = (
   // Only bother generating CSS if we have components
   if (cmpTags.length > 0) {
     // Add hydration styles
-    if (BUILD.invisiblePrehydration && (BUILD.hydratedClass || BUILD.hydratedAttribute)) {
+    if (
+      BUILD.invisiblePrehydration &&
+      !BUILD.staticHydrationStyles &&
+      (BUILD.hydratedClass || BUILD.hydratedAttribute)
+    ) {
       dataStyles.textContent += cmpTags.sort() + HYDRATED_CSS;
     }
 

--- a/packages/core/src/testing/reset-build-conditionals.ts
+++ b/packages/core/src/testing/reset-build-conditionals.ts
@@ -46,6 +46,7 @@ export function resetBuildConditionals(b: d.BuildConditionals) {
   b.hydratedAttribute = false;
   b.hydratedClass = true;
   b.invisiblePrehydration = true;
+  b.staticHydrationStyles = false;
   b.lightDomPatches = false;
   b.slotChildNodes = false;
   b.slotCloneNode = false;

--- a/test/build/build-size/kitchen-sink/src/global-style.css
+++ b/test/build/build-size/kitchen-sink/src/global-style.css
@@ -1,0 +1,1 @@
+@import 'stencil-hydrate';

--- a/test/build/build-size/kitchen-sink/stencil.config.ts
+++ b/test/build/build-size/kitchen-sink/stencil.config.ts
@@ -14,6 +14,10 @@ export const config: Config = {
     {
       type: 'ssr',
     },
+    {
+      type: 'global-style',
+      input: 'src/global-style.css',
+    },
   ],
   enableCache: false,
 };

--- a/test/build/build-size/light/src/global-style.css
+++ b/test/build/build-size/light/src/global-style.css
@@ -1,0 +1,1 @@
+@import 'stencil-hydrate';

--- a/test/build/build-size/light/stencil.config.ts
+++ b/test/build/build-size/light/stencil.config.ts
@@ -8,6 +8,10 @@ export const config: Config = {
       type: 'standalone',
       externalRuntime: false,
     },
+    {
+      type: 'global-style',
+      input: 'src/global-style.css',
+    },
   ],
   enableCache: false,
 };

--- a/test/build/build-size/shadow/src/global-style.css
+++ b/test/build/build-size/shadow/src/global-style.css
@@ -1,0 +1,1 @@
+@import 'stencil-hydrate';

--- a/test/build/build-size/shadow/stencil.config.ts
+++ b/test/build/build-size/shadow/stencil.config.ts
@@ -8,6 +8,10 @@ export const config: Config = {
       type: 'standalone',
       externalRuntime: false,
     },
+    {
+      type: 'global-style',
+      input: 'src/global-style.css',
+    },
   ],
   enableCache: false,
 };

--- a/test/build/global-style/src/global.css
+++ b/test/build/global-style/src/global.css
@@ -1,3 +1,6 @@
+/* FOUC prevention — replaced at build time with component visibility rules */
+@import 'stencil-hydrate';
+
 /* Base page styles */
 :root {
   --color-primary: #0070f3;

--- a/test/build/global-style/stencil.config.ts
+++ b/test/build/global-style/stencil.config.ts
@@ -12,5 +12,8 @@ export const config: Config = {
     {
       type: 'loader-bundle',
     },
+    {
+      type: 'standalone',
+    },
   ],
 };

--- a/test/build/global-style/validate.js
+++ b/test/build/global-style/validate.js
@@ -50,4 +50,18 @@ assert(
   'Missing hydrated selector rule from stencil-hydrate',
 );
 
+// stencil-hydrate.css must NOT be generated when @import "stencil-hydrate" is present
+// in a global-style input — the standalone output target should detect this and skip it.
+const hydrateCssPath = path.resolve(__dirname, 'dist', 'assets', 'stencil-hydrate.css');
+let hydrateFileExists = true;
+try {
+  await fs.access(hydrateCssPath);
+} catch {
+  hydrateFileExists = false;
+}
+assert(
+  !hydrateFileExists,
+  'stencil-hydrate.css should NOT be generated when @import "stencil-hydrate" is already in a global-style input',
+);
+
 console.log('✅ All assertions passed');

--- a/test/build/global-style/validate.js
+++ b/test/build/global-style/validate.js
@@ -28,10 +28,26 @@ assert(
   'Missing cmp-b display rule',
 );
 
-// The virtual import is fully resolved — not present in output
+// Both virtual imports are fully resolved — not present in output
 assert(
   !css.includes('stencil-globals'),
   'stencil-globals virtual import should be resolved, not present in output',
+);
+assert(
+  !css.includes('stencil-hydrate'),
+  'stencil-hydrate virtual import should be resolved, not present in output',
+);
+
+// FOUC prevention CSS is injected by @import "stencil-hydrate"
+// Component tags are sorted alphabetically and followed by the .hydrated rule
+assert(css.includes('cmp-a') && css.includes('cmp-b'), 'Missing component tags in FOUC CSS');
+assert(
+  css.includes('visibility:hidden') || css.includes('visibility: hidden'),
+  'Missing visibility:hidden rule from stencil-hydrate',
+);
+assert(
+  css.includes('.hydrated') || css.includes('[hydrated]'),
+  'Missing hydrated selector rule from stencil-hydrate',
 );
 
 console.log('✅ All assertions passed');


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

**`@import "stencil-hydrate"` virtual placeholder** - add to any `global-style` input to inject static FOUC-prevention CSS at build time instead of relying on the dynamic `<style>` tag inserted by the loader. The compiler replaces the placeholder with the sorted component selectors + configured hydration CSS (e.g. `my-cmp,other-cmp{visibility:hidden}.hydrated{visibility:inherit}`). When detected, `BUILD.staticHydrationStyles = true` suppresses the loader's dynamic injection. For `standalone` builds (which have no loader), `stencil-hydrate.css` is auto-generated alongside the bundle.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
