### PR TITLE
fix(compiler): resolve @Prop variable defaults to literal values in docs output

### DIFF
--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -411,9 +411,6 @@ const resolveLiteralText = (node: ts.Expression, typeChecker: ts.TypeChecker, de
 
   // Identifier referencing a `const` variable with a resolvable initializer.
   if (ts.isIdentifier(node)) {
-    if (node.text === 'undefined') {
-      return 'undefined';
-    }
     const init = getConstVariableInitializer(node, typeChecker);
     return init ? resolveLiteralText(init, typeChecker, depth + 1) : undefined;
   }
@@ -451,7 +448,10 @@ const isPrimitiveLiteral = (node: ts.Expression): boolean => {
     ts.isNumericLiteral(node) ||
     node.kind === ts.SyntaxKind.TrueKeyword ||
     node.kind === ts.SyntaxKind.FalseKeyword ||
-    node.kind === ts.SyntaxKind.NullKeyword
+    node.kind === ts.SyntaxKind.NullKeyword ||
+    // `undefined` is an Identifier referencing the global, not a syntax keyword,
+    // but it is treated as a primitive literal value here.
+    (ts.isIdentifier(node) && node.text === 'undefined')
   );
 };
 
@@ -461,10 +461,7 @@ const isPrimitiveLiteral = (node: ts.Expression): boolean => {
  * Only `const` declarations are followed because `let` / `var` bindings may be
  * reassigned and so are not safe to inline at compile time.
  */
-const getConstVariableInitializer = (
-  node: ts.Identifier,
-  typeChecker: ts.TypeChecker,
-): ts.Expression | undefined => {
+const getConstVariableInitializer = (node: ts.Identifier, typeChecker: ts.TypeChecker): ts.Expression | undefined => {
   const symbol = typeChecker.getSymbolAtLocation(node);
   const decl = symbol?.declarations?.find(ts.isVariableDeclaration);
   if (!decl || !decl.initializer) {
@@ -498,10 +495,7 @@ const resolveObjectLiteral = (
   return undefined;
 };
 
-const findObjectLiteralMember = (
-  obj: ts.ObjectLiteralExpression,
-  name: string,
-): ts.Expression | undefined => {
+const findObjectLiteralMember = (obj: ts.ObjectLiteralExpression, name: string): ts.Expression | undefined => {
   for (const member of obj.properties) {
     if (!ts.isPropertyAssignment(member)) {
       continue;

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -152,7 +152,7 @@ const parsePropDecorator = (
 
   // extract default value
   if (ts.isPropertyDeclaration(prop) && prop.initializer) {
-    propMeta.defaultValue = prop.initializer.getText();
+    propMeta.defaultValue = resolveInitializerText(prop.initializer, typeChecker);
   } else if (ts.isGetAccessorDeclaration(prop)) {
     // shallow comb to find default value for a getter
     const returnStatement = prop.body?.statements.find((st) => ts.isReturnStatement(st)) as ts.ReturnStatement;
@@ -166,7 +166,7 @@ const parsePropDecorator = (
       const foundProp = findGetProp(nameToFind, newMembers);
 
       if (foundProp && foundProp.initializer) {
-        propMeta.defaultValue = foundProp.initializer.getText();
+        propMeta.defaultValue = resolveInitializerText(foundProp.initializer, typeChecker);
 
         if (propMeta.type === 'unknown') {
           const type = typeChecker.getTypeAtLocation(foundProp);
@@ -378,4 +378,148 @@ const findSetter = (propName: string, members: ts.ClassElement[]): ts.SetAccesso
  */
 const findGetProp = (propName: string, members: ts.ClassElement[]): ts.PropertyDeclaration | undefined => {
   return members.find((m) => ts.isPropertyDeclaration(m) && m.name.getText() === propName) as ts.PropertyDeclaration;
+};
+
+/**
+ * Maximum depth when traversing variable references to resolve an initializer
+ * to its literal value. Prevents pathological/cyclic chains from blowing the stack.
+ */
+const MAX_RESOLVE_DEPTH = 5;
+
+/**
+ * Resolves the text representation of a `@Prop` initializer expression. Where possible,
+ * variable / object-property references are followed to their underlying literal value
+ * so that generated documentation (e.g. `@ionic/docs`) shows the real default rather
+ * than the variable name from source. Any expression that cannot be resolved to a
+ * primitive literal falls back to the original source text — preserving previous
+ * behavior for cases that are not safe to evaluate at compile time.
+ */
+const resolveInitializerText = (node: ts.Expression, typeChecker: ts.TypeChecker): string => {
+  const resolved = resolveLiteralText(node, typeChecker, 0);
+  return resolved ?? node.getText();
+};
+
+const resolveLiteralText = (node: ts.Expression, typeChecker: ts.TypeChecker, depth: number): string | undefined => {
+  if (depth > MAX_RESOLVE_DEPTH) {
+    return undefined;
+  }
+
+  // Already a primitive literal — string / number / true / false / null
+  if (isPrimitiveLiteral(node)) {
+    return node.getText();
+  }
+
+  // Identifier referencing a `const` variable with a resolvable initializer.
+  if (ts.isIdentifier(node)) {
+    if (node.text === 'undefined') {
+      return 'undefined';
+    }
+    const init = getConstVariableInitializer(node, typeChecker);
+    return init ? resolveLiteralText(init, typeChecker, depth + 1) : undefined;
+  }
+
+  // OBJ.key
+  if (ts.isPropertyAccessExpression(node)) {
+    const obj = resolveObjectLiteral(node.expression, typeChecker);
+    const prop = obj && findObjectLiteralMember(obj, node.name.text);
+    return prop ? resolveLiteralText(prop, typeChecker, depth + 1) : undefined;
+  }
+
+  // OBJ['key']  /  OBJ[0]
+  if (ts.isElementAccessExpression(node)) {
+    const arg = node.argumentExpression;
+    let key: string | undefined;
+    if (ts.isStringLiteralLike(arg)) {
+      key = arg.text;
+    } else if (ts.isNumericLiteral(arg)) {
+      key = arg.text;
+    }
+    if (key === undefined) {
+      return undefined;
+    }
+    const obj = resolveObjectLiteral(node.expression, typeChecker);
+    const prop = obj && findObjectLiteralMember(obj, key);
+    return prop ? resolveLiteralText(prop, typeChecker, depth + 1) : undefined;
+  }
+
+  return undefined;
+};
+
+const isPrimitiveLiteral = (node: ts.Expression): boolean => {
+  return (
+    ts.isStringLiteralLike(node) ||
+    ts.isNumericLiteral(node) ||
+    node.kind === ts.SyntaxKind.TrueKeyword ||
+    node.kind === ts.SyntaxKind.FalseKeyword ||
+    node.kind === ts.SyntaxKind.NullKeyword
+  );
+};
+
+/**
+ * If `node` resolves through its symbol to a `const` variable declaration with an
+ * initializer, returns that initializer expression. Otherwise returns undefined.
+ * Only `const` declarations are followed because `let` / `var` bindings may be
+ * reassigned and so are not safe to inline at compile time.
+ */
+const getConstVariableInitializer = (
+  node: ts.Identifier,
+  typeChecker: ts.TypeChecker,
+): ts.Expression | undefined => {
+  const symbol = typeChecker.getSymbolAtLocation(node);
+  const decl = symbol?.declarations?.find(ts.isVariableDeclaration);
+  if (!decl || !decl.initializer) {
+    return undefined;
+  }
+  const list = decl.parent;
+  if (!ts.isVariableDeclarationList(list) || (list.flags & ts.NodeFlags.Const) === 0) {
+    return undefined;
+  }
+  return decl.initializer;
+};
+
+/**
+ * Resolves an expression to an object literal — either directly or by following a
+ * single `const` identifier reference. Deeper chains aren't followed here because
+ * the caller will recurse through `resolveLiteralText` on the property value.
+ */
+const resolveObjectLiteral = (
+  node: ts.Expression,
+  typeChecker: ts.TypeChecker,
+): ts.ObjectLiteralExpression | undefined => {
+  if (ts.isObjectLiteralExpression(node)) {
+    return node;
+  }
+  if (ts.isIdentifier(node)) {
+    const init = getConstVariableInitializer(node, typeChecker);
+    if (init && ts.isObjectLiteralExpression(init)) {
+      return init;
+    }
+  }
+  return undefined;
+};
+
+const findObjectLiteralMember = (
+  obj: ts.ObjectLiteralExpression,
+  name: string,
+): ts.Expression | undefined => {
+  for (const member of obj.properties) {
+    if (!ts.isPropertyAssignment(member)) {
+      continue;
+    }
+    const memberName = getPropertyNameText(member.name);
+    if (memberName === name) {
+      return member.initializer;
+    }
+  }
+  return undefined;
+};
+
+const getPropertyNameText = (name: ts.PropertyName): string | undefined => {
+  if (ts.isIdentifier(name) || ts.isPrivateIdentifier(name)) {
+    return name.text;
+  }
+  if (ts.isStringLiteralLike(name) || ts.isNumericLiteral(name)) {
+    return name.text;
+  }
+  return undefined;
 };

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -593,6 +593,12 @@ const findObjectLiteralMember = (
   return undefined;
 };
 
+/**
+ * Returns the static text of an object-literal property name. Computed property
+ * names (`{ [key]: 'v' }`) are intentionally unsupported and return `undefined`:
+ * resolving them would require evaluating an arbitrary expression at compile
+ * time, so the caller correctly falls back to the original source text instead.
+ */
 const getPropertyNameText = (name: ts.PropertyName): string | undefined => {
   if (ts.isIdentifier(name) || ts.isPrivateIdentifier(name)) {
     return name.text;

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -443,15 +443,17 @@ const resolveLiteralText = (node: ts.Expression, typeChecker: ts.TypeChecker, de
 };
 
 const isPrimitiveLiteral = (node: ts.Expression): boolean => {
+  // Identifiers (including `undefined`) are not treated as primitive literals
+  // here. They are resolved through `getConstVariableInitializer`, and any
+  // identifier the resolver can't follow to a primitive ultimately falls back
+  // to `node.getText()` — so `@Prop() x = undefined;` still emits `"undefined"`
+  // while a user-shadowed `const undefined = 'foo'` correctly resolves to `'foo'`.
   return (
     ts.isStringLiteralLike(node) ||
     ts.isNumericLiteral(node) ||
     node.kind === ts.SyntaxKind.TrueKeyword ||
     node.kind === ts.SyntaxKind.FalseKeyword ||
-    node.kind === ts.SyntaxKind.NullKeyword ||
-    // `undefined` is an Identifier referencing the global, not a syntax keyword,
-    // but it is treated as a primitive literal value here.
-    (ts.isIdentifier(node) && node.text === 'undefined')
+    node.kind === ts.SyntaxKind.NullKeyword
   );
 };
 

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -411,9 +411,6 @@ const resolveLiteralText = (node: ts.Expression, typeChecker: ts.TypeChecker, de
 
   // Identifier referencing a `const` variable with a resolvable initializer.
   if (ts.isIdentifier(node)) {
-    if (node.text === 'undefined') {
-      return 'undefined';
-    }
     const init = getConstVariableInitializer(node, typeChecker);
     return init ? resolveLiteralText(init, typeChecker, depth + 1) : undefined;
   }
@@ -451,7 +448,10 @@ const isPrimitiveLiteral = (node: ts.Expression): boolean => {
     ts.isNumericLiteral(node) ||
     node.kind === ts.SyntaxKind.TrueKeyword ||
     node.kind === ts.SyntaxKind.FalseKeyword ||
-    node.kind === ts.SyntaxKind.NullKeyword
+    node.kind === ts.SyntaxKind.NullKeyword ||
+    // `undefined` is an Identifier referencing the global, not a syntax keyword,
+    // but it is treated as a primitive literal value here.
+    (ts.isIdentifier(node) && node.text === 'undefined')
   );
 };
 
@@ -461,11 +461,14 @@ const isPrimitiveLiteral = (node: ts.Expression): boolean => {
  * Only `const` declarations are followed because `let` / `var` bindings may be
  * reassigned and so are not safe to inline at compile time.
  */
-const getConstVariableInitializer = (
-  node: ts.Identifier,
-  typeChecker: ts.TypeChecker,
-): ts.Expression | undefined => {
-  const symbol = typeChecker.getSymbolAtLocation(node);
+const getConstVariableInitializer = (node: ts.Identifier, typeChecker: ts.TypeChecker): ts.Expression | undefined => {
+  let symbol = typeChecker.getSymbolAtLocation(node);
+  // For imported bindings, `getSymbolAtLocation` returns the alias symbol
+  // (ImportSpecifier / NamespaceImport / etc.) — unwrap it so we can find
+  // the original `VariableDeclaration` in the source module.
+  if (symbol && (symbol.flags & ts.SymbolFlags.Alias) !== 0) {
+    symbol = typeChecker.getAliasedSymbol(symbol);
+  }
   const decl = symbol?.declarations?.find(ts.isVariableDeclaration);
   if (!decl || !decl.initializer) {
     return undefined;
@@ -498,10 +501,7 @@ const resolveObjectLiteral = (
   return undefined;
 };
 
-const findObjectLiteralMember = (
-  obj: ts.ObjectLiteralExpression,
-  name: string,
-): ts.Expression | undefined => {
+const findObjectLiteralMember = (obj: ts.ObjectLiteralExpression, name: string): ts.Expression | undefined => {
   for (const member of obj.properties) {
     if (!ts.isPropertyAssignment(member)) {
       continue;

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -400,7 +400,7 @@ const resolveInitializerText = (node: ts.Expression, typeChecker: ts.TypeChecker
 };
 
 const resolveLiteralText = (node: ts.Expression, typeChecker: ts.TypeChecker, depth: number): string | undefined => {
-  if (depth > MAX_RESOLVE_DEPTH) {
+  if (depth >= MAX_RESOLVE_DEPTH) {
     return undefined;
   }
 
@@ -418,7 +418,7 @@ const resolveLiteralText = (node: ts.Expression, typeChecker: ts.TypeChecker, de
   // OBJ.key
   if (ts.isPropertyAccessExpression(node)) {
     const obj = resolveObjectLiteral(node.expression, typeChecker);
-    const prop = obj && findObjectLiteralMember(obj, node.name.text);
+    const prop = obj && findObjectLiteralMember(obj, node.name.text, typeChecker);
     return prop ? resolveLiteralText(prop, typeChecker, depth + 1) : undefined;
   }
 
@@ -435,7 +435,7 @@ const resolveLiteralText = (node: ts.Expression, typeChecker: ts.TypeChecker, de
       return undefined;
     }
     const obj = resolveObjectLiteral(node.expression, typeChecker);
-    const prop = obj && findObjectLiteralMember(obj, key);
+    const prop = obj && findObjectLiteralMember(obj, key, typeChecker);
     return prop ? resolveLiteralText(prop, typeChecker, depth + 1) : undefined;
   }
 
@@ -458,13 +458,23 @@ const isPrimitiveLiteral = (node: ts.Expression): boolean => {
 };
 
 /**
- * If `node` resolves through its symbol to a `const` variable declaration with an
- * initializer, returns that initializer expression. Otherwise returns undefined.
+ * Walks a Symbol to the initializer of its underlying `const` variable
+ * declaration, unwrapping import aliases along the way. Returns undefined for
+ * anything that isn't a `const` binding with a literal-bearing initializer.
  * Only `const` declarations are followed because `let` / `var` bindings may be
  * reassigned and so are not safe to inline at compile time.
  */
-const getConstVariableInitializer = (node: ts.Identifier, typeChecker: ts.TypeChecker): ts.Expression | undefined => {
-  const symbol = typeChecker.getSymbolAtLocation(node);
+const resolveConstSymbolInitializer = (
+  symbol: ts.Symbol | undefined,
+  typeChecker: ts.TypeChecker,
+): ts.Expression | undefined => {
+  // For imported bindings (`import { X } from './x'`), `getSymbolAtLocation`
+  // returns the alias symbol (`ImportSpecifier` / `NamespaceImport` / etc.) —
+  // unwrap it so we can reach the original `VariableDeclaration` in the
+  // source module and resolve cross-file `const` references.
+  if (symbol && (symbol.flags & ts.SymbolFlags.Alias) !== 0) {
+    symbol = typeChecker.getAliasedSymbol(symbol);
+  }
   const decl = symbol?.declarations?.find(ts.isVariableDeclaration);
   if (!decl || !decl.initializer) {
     return undefined;
@@ -474,6 +484,10 @@ const getConstVariableInitializer = (node: ts.Identifier, typeChecker: ts.TypeCh
     return undefined;
   }
   return decl.initializer;
+};
+
+const getConstVariableInitializer = (node: ts.Identifier, typeChecker: ts.TypeChecker): ts.Expression | undefined => {
+  return resolveConstSymbolInitializer(typeChecker.getSymbolAtLocation(node), typeChecker);
 };
 
 /**
@@ -497,14 +511,25 @@ const resolveObjectLiteral = (
   return undefined;
 };
 
-const findObjectLiteralMember = (obj: ts.ObjectLiteralExpression, name: string): ts.Expression | undefined => {
+const findObjectLiteralMember = (
+  obj: ts.ObjectLiteralExpression,
+  name: string,
+  typeChecker: ts.TypeChecker,
+): ts.Expression | undefined => {
   for (const member of obj.properties) {
-    if (!ts.isPropertyAssignment(member)) {
+    if (ts.isPropertyAssignment(member)) {
+      const memberName = getPropertyNameText(member.name);
+      if (memberName === name) {
+        return member.initializer;
+      }
       continue;
     }
-    const memberName = getPropertyNameText(member.name);
-    if (memberName === name) {
-      return member.initializer;
+    // Shorthand: `{ label }` — equivalent to `{ label: label }`. The shorthand
+    // name carries the property symbol, not the symbol of the in-scope binding,
+    // so use `getShorthandAssignmentValueSymbol` to reach the original binding
+    // and then walk to its `const` initializer.
+    if (ts.isShorthandPropertyAssignment(member) && member.name.text === name) {
+      return resolveConstSymbolInitializer(typeChecker.getShorthandAssignmentValueSymbol(member), typeChecker);
     }
   }
   return undefined;

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -381,8 +381,12 @@ const findGetProp = (propName: string, members: ts.ClassElement[]): ts.PropertyD
 };
 
 /**
- * Maximum depth when traversing variable references to resolve an initializer
- * to its literal value. Prevents pathological/cyclic chains from blowing the stack.
+ * Maximum number of hops to follow when traversing variable references to
+ * resolve an initializer to its literal value. With the guards below
+ * (`depth > MAX_RESOLVE_DEPTH`), a chain of up to this many `const` / property
+ * follows is supported before bailing out; any deeper chain falls back to the
+ * original source text. Prevents pathological / cyclic chains from blowing the
+ * stack.
  */
 const MAX_RESOLVE_DEPTH = 5;
 
@@ -400,7 +404,7 @@ const resolveInitializerText = (node: ts.Expression, typeChecker: ts.TypeChecker
 };
 
 const resolveLiteralText = (node: ts.Expression, typeChecker: ts.TypeChecker, depth: number): string | undefined => {
-  if (depth >= MAX_RESOLVE_DEPTH) {
+  if (depth > MAX_RESOLVE_DEPTH) {
     return undefined;
   }
 
@@ -436,7 +440,9 @@ const resolveLiteralText = (node: ts.Expression, typeChecker: ts.TypeChecker, de
 
   // OBJ['key']  /  OBJ[0]
   if (ts.isElementAccessExpression(node)) {
-    const arg = node.argumentExpression;
+    // Unwrap value-preserving wrappers so safe shapes like `OBJ[('lg')]`,
+    // `OBJ['lg' as const]`, and `OBJ[('0') as const]` still resolve.
+    const arg = unwrapValuePreservingWrappers(node.argumentExpression);
     let key: string | undefined;
     if (ts.isStringLiteralLike(arg)) {
       key = arg.text;
@@ -501,11 +507,14 @@ const isSignedNumericLiteral = (node: ts.Expression): boolean => {
 };
 
 /**
- * Walks a Symbol to the initializer of its underlying `const` variable
- * declaration, unwrapping import aliases along the way. Returns undefined for
- * anything that isn't a `const` binding with a literal-bearing initializer.
- * Only `const` declarations are followed because `let` / `var` bindings may be
- * reassigned and so are not safe to inline at compile time.
+ * Walks a Symbol to the initializer expression of its underlying `const`
+ * variable declaration, unwrapping import aliases along the way. Returns the
+ * initializer as-is regardless of its shape — the caller is responsible for
+ * deciding whether the expression is something it can resolve further (e.g.
+ * a primitive literal, a nested const reference, an object literal, etc.).
+ * Returns undefined for anything that isn't a `const` binding with an
+ * initializer. Only `const` declarations are followed because `let` / `var`
+ * bindings may be reassigned and so are not safe to inline at compile time.
  */
 const resolveConstSymbolInitializer = (
   symbol: ts.Symbol | undefined,
@@ -544,7 +553,7 @@ const resolveObjectLiteral = (
   typeChecker: ts.TypeChecker,
   depth: number,
 ): ts.ObjectLiteralExpression | undefined => {
-  if (depth >= MAX_RESOLVE_DEPTH) {
+  if (depth > MAX_RESOLVE_DEPTH) {
     return undefined;
   }
   node = unwrapValuePreservingWrappers(node);

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -415,6 +415,15 @@ const resolveLiteralText = (node: ts.Expression, typeChecker: ts.TypeChecker, de
     return node.getText();
   }
 
+  // Object / array literal default — e.g. `@Prop() x = DEFAULT;` where
+  // `const DEFAULT = { a: 1 } satisfies T;`. Emit the literal's source text so
+  // docs show the actual default rather than the resolved identifier name. Inline
+  // literals (`@Prop() x = { a: 1 }`) reach the same text via the fallback in
+  // `resolveInitializerText`, but identifier-referenced literals only resolve here.
+  if (ts.isObjectLiteralExpression(node) || ts.isArrayLiteralExpression(node)) {
+    return node.getText();
+  }
+
   // Identifier referencing a `const` variable with a resolvable initializer.
   if (ts.isIdentifier(node)) {
     const init = getConstVariableInitializer(node, typeChecker);

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -404,19 +404,9 @@ const resolveLiteralText = (node: ts.Expression, typeChecker: ts.TypeChecker, de
     return undefined;
   }
 
-  // Unwrap value-preserving wrapper expressions so the inner literal is reached:
-  //   `'x' as const`, `('x')`, `<T>x`, `x satisfies T`, `x!`
-  if (
-    ts.isAsExpression(node) ||
-    ts.isParenthesizedExpression(node) ||
-    ts.isTypeAssertionExpression(node) ||
-    ts.isSatisfiesExpression(node) ||
-    ts.isNonNullExpression(node)
-  ) {
-    return resolveLiteralText(node.expression, typeChecker, depth + 1);
-  }
+  node = unwrapValuePreservingWrappers(node);
 
-  // Already a primitive literal — string / number / true / false / null
+  // Already a primitive literal — string / number / true / false / null / signed number
   if (isPrimitiveLiteral(node)) {
     return node.getText();
   }
@@ -439,7 +429,7 @@ const resolveLiteralText = (node: ts.Expression, typeChecker: ts.TypeChecker, de
 
   // OBJ.key
   if (ts.isPropertyAccessExpression(node)) {
-    const obj = resolveObjectLiteral(node.expression, typeChecker);
+    const obj = resolveObjectLiteral(node.expression, typeChecker, depth + 1);
     const prop = obj && findObjectLiteralMember(obj, node.name.text, typeChecker);
     return prop ? resolveLiteralText(prop, typeChecker, depth + 1) : undefined;
   }
@@ -456,12 +446,29 @@ const resolveLiteralText = (node: ts.Expression, typeChecker: ts.TypeChecker, de
     if (key === undefined) {
       return undefined;
     }
-    const obj = resolveObjectLiteral(node.expression, typeChecker);
+    const obj = resolveObjectLiteral(node.expression, typeChecker, depth + 1);
     const prop = obj && findObjectLiteralMember(obj, key, typeChecker);
     return prop ? resolveLiteralText(prop, typeChecker, depth + 1) : undefined;
   }
 
   return undefined;
+};
+
+/**
+ * Strips value-preserving wrappers so callers can pattern-match the underlying
+ * expression: `'x' as const`, `('x')`, `<T>x`, `x satisfies T`, `x!`.
+ */
+const unwrapValuePreservingWrappers = (node: ts.Expression): ts.Expression => {
+  while (
+    ts.isAsExpression(node) ||
+    ts.isParenthesizedExpression(node) ||
+    ts.isTypeAssertionExpression(node) ||
+    ts.isSatisfiesExpression(node) ||
+    ts.isNonNullExpression(node)
+  ) {
+    node = node.expression;
+  }
+  return node;
 };
 
 const isPrimitiveLiteral = (node: ts.Expression): boolean => {
@@ -473,9 +480,23 @@ const isPrimitiveLiteral = (node: ts.Expression): boolean => {
   return (
     ts.isStringLiteralLike(node) ||
     ts.isNumericLiteral(node) ||
+    isSignedNumericLiteral(node) ||
     node.kind === ts.SyntaxKind.TrueKeyword ||
     node.kind === ts.SyntaxKind.FalseKeyword ||
     node.kind === ts.SyntaxKind.NullKeyword
+  );
+};
+
+/**
+ * TypeScript represents `-1` / `+1` as a `PrefixUnaryExpression` wrapping a
+ * numeric literal — not as a `NumericLiteral` directly. Treat the (+|-)number
+ * shape as a primitive literal so signed numeric defaults inline cleanly.
+ */
+const isSignedNumericLiteral = (node: ts.Expression): boolean => {
+  return (
+    ts.isPrefixUnaryExpression(node) &&
+    (node.operator === ts.SyntaxKind.MinusToken || node.operator === ts.SyntaxKind.PlusToken) &&
+    ts.isNumericLiteral(node.operand)
   );
 };
 
@@ -513,21 +534,27 @@ const getConstVariableInitializer = (node: ts.Identifier, typeChecker: ts.TypeCh
 };
 
 /**
- * Resolves an expression to an object literal — either directly or by following a
- * single `const` identifier reference. Deeper chains aren't followed here because
- * the caller will recurse through `resolveLiteralText` on the property value.
+ * Resolves an expression to an object literal, walking through value-preserving
+ * wrappers (`as const`, `(...)`, etc.) and chained `const` identifier
+ * references. Bounded by `MAX_RESOLVE_DEPTH` so cyclic or pathological chains
+ * cannot blow the stack.
  */
 const resolveObjectLiteral = (
   node: ts.Expression,
   typeChecker: ts.TypeChecker,
+  depth: number,
 ): ts.ObjectLiteralExpression | undefined => {
+  if (depth >= MAX_RESOLVE_DEPTH) {
+    return undefined;
+  }
+  node = unwrapValuePreservingWrappers(node);
   if (ts.isObjectLiteralExpression(node)) {
     return node;
   }
   if (ts.isIdentifier(node)) {
     const init = getConstVariableInitializer(node, typeChecker);
-    if (init && ts.isObjectLiteralExpression(init)) {
-      return init;
+    if (init) {
+      return resolveObjectLiteral(init, typeChecker, depth + 1);
     }
   }
   return undefined;

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -411,6 +411,9 @@ const resolveLiteralText = (node: ts.Expression, typeChecker: ts.TypeChecker, de
 
   // Identifier referencing a `const` variable with a resolvable initializer.
   if (ts.isIdentifier(node)) {
+    if (node.text === 'undefined') {
+      return 'undefined';
+    }
     const init = getConstVariableInitializer(node, typeChecker);
     return init ? resolveLiteralText(init, typeChecker, depth + 1) : undefined;
   }
@@ -448,10 +451,7 @@ const isPrimitiveLiteral = (node: ts.Expression): boolean => {
     ts.isNumericLiteral(node) ||
     node.kind === ts.SyntaxKind.TrueKeyword ||
     node.kind === ts.SyntaxKind.FalseKeyword ||
-    node.kind === ts.SyntaxKind.NullKeyword ||
-    // `undefined` is an Identifier referencing the global, not a syntax keyword,
-    // but it is treated as a primitive literal value here.
-    (ts.isIdentifier(node) && node.text === 'undefined')
+    node.kind === ts.SyntaxKind.NullKeyword
   );
 };
 
@@ -461,14 +461,11 @@ const isPrimitiveLiteral = (node: ts.Expression): boolean => {
  * Only `const` declarations are followed because `let` / `var` bindings may be
  * reassigned and so are not safe to inline at compile time.
  */
-const getConstVariableInitializer = (node: ts.Identifier, typeChecker: ts.TypeChecker): ts.Expression | undefined => {
-  let symbol = typeChecker.getSymbolAtLocation(node);
-  // For imported bindings, `getSymbolAtLocation` returns the alias symbol
-  // (ImportSpecifier / NamespaceImport / etc.) — unwrap it so we can find
-  // the original `VariableDeclaration` in the source module.
-  if (symbol && (symbol.flags & ts.SymbolFlags.Alias) !== 0) {
-    symbol = typeChecker.getAliasedSymbol(symbol);
-  }
+const getConstVariableInitializer = (
+  node: ts.Identifier,
+  typeChecker: ts.TypeChecker,
+): ts.Expression | undefined => {
+  const symbol = typeChecker.getSymbolAtLocation(node);
   const decl = symbol?.declarations?.find(ts.isVariableDeclaration);
   if (!decl || !decl.initializer) {
     return undefined;
@@ -501,7 +498,10 @@ const resolveObjectLiteral = (
   return undefined;
 };
 
-const findObjectLiteralMember = (obj: ts.ObjectLiteralExpression, name: string): ts.Expression | undefined => {
+const findObjectLiteralMember = (
+  obj: ts.ObjectLiteralExpression,
+  name: string,
+): ts.Expression | undefined => {
   for (const member of obj.properties) {
     if (!ts.isPropertyAssignment(member)) {
       continue;

--- a/src/compiler/transformers/decorators-to-static/prop-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/prop-decorator.ts
@@ -404,6 +404,18 @@ const resolveLiteralText = (node: ts.Expression, typeChecker: ts.TypeChecker, de
     return undefined;
   }
 
+  // Unwrap value-preserving wrapper expressions so the inner literal is reached:
+  //   `'x' as const`, `('x')`, `<T>x`, `x satisfies T`, `x!`
+  if (
+    ts.isAsExpression(node) ||
+    ts.isParenthesizedExpression(node) ||
+    ts.isTypeAssertionExpression(node) ||
+    ts.isSatisfiesExpression(node) ||
+    ts.isNonNullExpression(node)
+  ) {
+    return resolveLiteralText(node.expression, typeChecker, depth + 1);
+  }
+
   // Already a primitive literal — string / number / true / false / null
   if (isPrimitiveLiteral(node)) {
     return node.getText();
@@ -412,7 +424,17 @@ const resolveLiteralText = (node: ts.Expression, typeChecker: ts.TypeChecker, de
   // Identifier referencing a `const` variable with a resolvable initializer.
   if (ts.isIdentifier(node)) {
     const init = getConstVariableInitializer(node, typeChecker);
-    return init ? resolveLiteralText(init, typeChecker, depth + 1) : undefined;
+    if (init) {
+      return resolveLiteralText(init, typeChecker, depth + 1);
+    }
+    // The chain terminated at a bare `undefined` identifier (either `@Prop() x = undefined;`
+    // or `const X = undefined; @Prop() x = X;`). Emit the literal `undefined` so docs show
+    // the same value the runtime would observe. A user-shadowed `const undefined = 'foo'`
+    // is already handled above by `getConstVariableInitializer`.
+    if (node.text === 'undefined') {
+      return 'undefined';
+    }
+    return undefined;
   }
 
   // OBJ.key

--- a/src/compiler/transformers/test/parse-props.spec.ts
+++ b/src/compiler/transformers/test/parse-props.spec.ts
@@ -729,6 +729,26 @@ describe('parse props', () => {
     expect(t.property?.defaultValue).toBe(`'chained'`);
   });
 
+  it('falls back to getText() at a chain depth over MAX_RESOLVE_DEPTH', () => {
+    // Chain length intentionally exceeds the resolver's MAX_RESOLVE_DEPTH guard
+    // (`A -> B -> C -> D -> E -> F -> G -> 'deep'`). The resolver must bail out
+    // and the emitted default falls back to the original source text (`A`).
+    const t = transpileModule(`
+      const G = 'deep';
+      const F = G;
+      const E = F;
+      const D = E;
+      const C = D;
+      const B = C;
+      const A = B;
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() val: string = A;
+      }
+    `);
+    expect(t.property?.defaultValue).toBe('A');
+  });
+
   it('prop default value resolved when the element-access key is itself wrapped', () => {
     const t = transpileModule(`
       const QUERY: { [key: string]: string } = { lg: '(min-width: 992px)' };

--- a/src/compiler/transformers/test/parse-props.spec.ts
+++ b/src/compiler/transformers/test/parse-props.spec.ts
@@ -569,6 +569,75 @@ describe('parse props', () => {
     expect(t.property?.attribute).toBe('val');
   });
 
+  it('prop default value resolved from const string variable', () => {
+    const t = transpileModule(`
+      const DEFAULT_LABEL = 'Submit';
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() label: string = DEFAULT_LABEL;
+      }
+    `);
+    expect(t.property?.defaultValue).toBe(`'Submit'`);
+  });
+
+  it('prop default value resolved from const number variable', () => {
+    const t = transpileModule(`
+      const DEFAULT_COUNT = 4;
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() count: number = DEFAULT_COUNT;
+      }
+    `);
+    expect(t.property?.defaultValue).toBe('4');
+  });
+
+  it('prop default value resolved from object property access', () => {
+    const t = transpileModule(`
+      const CONFIG = { label: 'Hello' };
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() label: string = CONFIG.label;
+      }
+    `);
+    expect(t.property?.defaultValue).toBe(`'Hello'`);
+  });
+
+  it('prop default value resolved from indexed object access (FW-7298)', () => {
+    const t = transpileModule(`
+      const QUERY: { [key: string]: string } = {
+        lg: '(min-width: 992px)',
+      };
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() when: string | boolean = QUERY['lg'];
+      }
+    `);
+    expect(t.property?.defaultValue).toBe(`'(min-width: 992px)'`);
+  });
+
+  it('prop default value falls back to raw text when initializer is not a resolvable literal', () => {
+    const t = transpileModule(`
+      const computeDefault = () => 'x';
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() val: string = computeDefault();
+      }
+    `);
+    expect(t.property?.defaultValue).toBe('computeDefault()');
+  });
+
+  it('prop default value falls back to raw text for dynamic (non-literal) indexed access', () => {
+    const t = transpileModule(`
+      const QUERY: { [key: string]: string } = { lg: '(min-width: 992px)' };
+      const key = 'lg';
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() when: string = QUERY[key];
+      }
+    `);
+    expect(t.property?.defaultValue).toBe('QUERY[key]');
+  });
+
   it('should infer string type from `get()` return value', () => {
     const t = transpileModule(`
       @Component({tag: 'cmp-a'})

--- a/src/compiler/transformers/test/parse-props.spec.ts
+++ b/src/compiler/transformers/test/parse-props.spec.ts
@@ -638,6 +638,16 @@ describe('parse props', () => {
     expect(t.property?.defaultValue).toBe('QUERY[key]');
   });
 
+  it('prop default value preserves `undefined` initializer as raw text', () => {
+    const t = transpileModule(`
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() val: string | undefined = undefined;
+      }
+    `);
+    expect(t.property?.defaultValue).toBe('undefined');
+  });
+
   it('should infer string type from `get()` return value', () => {
     const t = transpileModule(`
       @Component({tag: 'cmp-a'})

--- a/src/compiler/transformers/test/parse-props.spec.ts
+++ b/src/compiler/transformers/test/parse-props.spec.ts
@@ -729,6 +729,17 @@ describe('parse props', () => {
     expect(t.property?.defaultValue).toBe(`'chained'`);
   });
 
+  it('prop default value resolved when the element-access key is itself wrapped', () => {
+    const t = transpileModule(`
+      const QUERY: { [key: string]: string } = { lg: '(min-width: 992px)' };
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() when: string = QUERY[('lg' as const)];
+      }
+    `);
+    expect(t.property?.defaultValue).toBe(`'(min-width: 992px)'`);
+  });
+
   it('prop default value resolved from a cross-file imported const', () => {
     // Self-contained 2-file program. Does NOT extend the shared `transpileModule`
     // helper — keeps the multi-file complexity isolated to this single test.

--- a/src/compiler/transformers/test/parse-props.spec.ts
+++ b/src/compiler/transformers/test/parse-props.spec.ts
@@ -1,5 +1,7 @@
+import { mockBuildCtx, mockValidatedConfig } from '@stencil/core/testing';
 import * as ts from 'typescript';
 
+import { convertDecoratorsToStatic } from '../decorators-to-static/convert-decorators';
 import { getStaticGetter, transpileModule } from './transpile';
 import { c, formatCode } from './utils';
 
@@ -646,6 +648,83 @@ describe('parse props', () => {
       }
     `);
     expect(t.property?.defaultValue).toBe('undefined');
+  });
+
+  it('prop default value resolved through an object shorthand property', () => {
+    const t = transpileModule(`
+      const label = 'Hello';
+      const CONFIG = { label };
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() val: string = CONFIG.label;
+      }
+    `);
+    expect(t.property?.defaultValue).toBe(`'Hello'`);
+  });
+
+  it('prop default value resolved from a cross-file imported const', () => {
+    // Self-contained 2-file program. Does NOT extend the shared `transpileModule`
+    // helper — keeps the multi-file complexity isolated to this single test.
+    const moduleSrc = `
+      import { QUERY } from './queries';
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() when: string | boolean = QUERY['lg'];
+      }
+    `;
+    const queriesSrc = `export const QUERY: { [key: string]: string } = { lg: '(min-width: 992px)' };`;
+    const target = ts.ScriptTarget.Latest;
+    const files = new Map<string, ts.SourceFile>([
+      ['module.tsx', ts.createSourceFile('module.tsx', moduleSrc, target, true, ts.ScriptKind.TSX)],
+      ['queries.ts', ts.createSourceFile('queries.ts', queriesSrc, target, true, ts.ScriptKind.TS)],
+    ]);
+    let emitted = '';
+    const host: ts.CompilerHost = {
+      getSourceFile: (name) => files.get(name),
+      writeFile: (path, data) => {
+        if (path.endsWith('module.js')) emitted = data;
+      },
+      getDefaultLibFileName: () => 'lib.d.ts',
+      useCaseSensitiveFileNames: () => false,
+      getCanonicalFileName: (n) => n,
+      getCurrentDirectory: () => '',
+      getNewLine: () => '\n',
+      fileExists: (name) => files.has(name),
+      readFile: (name) => (name === 'module.tsx' ? moduleSrc : name === 'queries.ts' ? queriesSrc : ''),
+      directoryExists: () => true,
+      getDirectories: () => [],
+      resolveModuleNames: (names) =>
+        names.map((n) => {
+          const candidate = n.replace(/^\.\//, '');
+          for (const ext of ['.ts', '.tsx', '.d.ts'] as const) {
+            const fileName = candidate.endsWith(ext) ? candidate : `${candidate}${ext}`;
+            if (files.has(fileName)) {
+              return { resolvedFileName: fileName, extension: ext as ts.Extension };
+            }
+          }
+          return undefined;
+        }),
+    };
+    const program = ts.createProgram({
+      rootNames: ['module.tsx', 'queries.ts'],
+      options: {
+        experimentalDecorators: true,
+        jsx: ts.JsxEmit.React,
+        jsxFactory: 'h',
+        module: ts.ModuleKind.ESNext,
+        noLib: true,
+        suppressOutputPathCheck: true,
+        target,
+      },
+      host,
+    });
+    const config = mockValidatedConfig();
+    const buildCtx = mockBuildCtx(config);
+    program.emit(program.getSourceFile('module.tsx'), undefined, undefined, undefined, {
+      before: [convertDecoratorsToStatic(config, buildCtx.diagnostics, program.getTypeChecker(), program)],
+    });
+    // Assert the literal made it into the emitted `static get properties()` block.
+    expect(emitted).toMatch(/"defaultValue":\s*"'\(min-width: 992px\)'"/);
   });
 
   it('should infer string type from `get()` return value', () => {

--- a/src/compiler/transformers/test/parse-props.spec.ts
+++ b/src/compiler/transformers/test/parse-props.spec.ts
@@ -695,6 +695,40 @@ describe('parse props', () => {
     expect(t.property?.defaultValue).toBe('undefined');
   });
 
+  it('prop default value resolved from a negative numeric const (PrefixUnaryExpression)', () => {
+    const t = transpileModule(`
+      const N = -1;
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() val: number = N;
+      }
+    `);
+    expect(t.property?.defaultValue).toBe('-1');
+  });
+
+  it('prop default value resolved from a wrapped object literal const', () => {
+    const t = transpileModule(`
+      const CONFIG = ({ label: 'wrapped' } as const);
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() val: string = CONFIG.label;
+      }
+    `);
+    expect(t.property?.defaultValue).toBe(`'wrapped'`);
+  });
+
+  it('prop default value resolved through chained const-to-const object aliases', () => {
+    const t = transpileModule(`
+      const CONFIG = { label: 'chained' };
+      const ALIAS = CONFIG;
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() val: string = ALIAS.label;
+      }
+    `);
+    expect(t.property?.defaultValue).toBe(`'chained'`);
+  });
+
   it('prop default value resolved from a cross-file imported const', () => {
     // Self-contained 2-file program. Does NOT extend the shared `transpileModule`
     // helper — keeps the multi-file complexity isolated to this single test.

--- a/src/compiler/transformers/test/parse-props.spec.ts
+++ b/src/compiler/transformers/test/parse-props.spec.ts
@@ -638,6 +638,34 @@ describe('parse props', () => {
     expect(t.property?.defaultValue).toBe('QUERY[key]');
   });
 
+  it('prop default value resolved from a cross-file imported const', () => {
+    const t = transpileModule(
+      `
+      import { QUERY } from './queries';
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() when: string | boolean = QUERY['lg'];
+      }
+    `,
+      null,
+      null,
+      [],
+      [],
+      [],
+      {},
+      'module.tsx',
+      {
+        'queries.ts': `export const QUERY: { [key: string]: string } = { lg: '(min-width: 992px)' };`,
+      },
+    );
+    // With multiple files in the program, the helper-extracted `t.property`
+    // and `getStaticGetter` aren't reliable (module ordering + the emitted
+    // `import` line confuses `new Function()`). Assert the literal made it
+    // into the emitted `static get properties()` block directly — this is
+    // the actual contract the fix protects.
+    expect(t.outputText).toMatch(/"defaultValue":\s*"'\(min-width: 992px\)'"/);
+  });
+
   it('should infer string type from `get()` return value', () => {
     const t = transpileModule(`
       @Component({tag: 'cmp-a'})

--- a/src/compiler/transformers/test/parse-props.spec.ts
+++ b/src/compiler/transformers/test/parse-props.spec.ts
@@ -729,6 +729,29 @@ describe('parse props', () => {
     expect(t.property?.defaultValue).toBe(`'chained'`);
   });
 
+  it('prop default value resolved to an object literal const through `satisfies`', () => {
+    const t = transpileModule(`
+      type Cols = { xs: number; sm: number };
+      const DEFAULT_COLUMNS = { xs: 2, sm: 3 } satisfies Cols;
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() columns: Cols = DEFAULT_COLUMNS;
+      }
+    `);
+    expect(t.property?.defaultValue).toBe(`{ xs: 2, sm: 3 }`);
+  });
+
+  it('prop default value resolved to an array literal const', () => {
+    const t = transpileModule(`
+      const DEFAULTS = [1, 2, 3];
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() vals: number[] = DEFAULTS;
+      }
+    `);
+    expect(t.property?.defaultValue).toBe(`[1, 2, 3]`);
+  });
+
   it('falls back to getText() at a chain depth over MAX_RESOLVE_DEPTH', () => {
     // Chain length intentionally exceeds the resolver's MAX_RESOLVE_DEPTH guard
     // (`A -> B -> C -> D -> E -> F -> G -> 'deep'`). The resolver must bail out

--- a/src/compiler/transformers/test/parse-props.spec.ts
+++ b/src/compiler/transformers/test/parse-props.spec.ts
@@ -662,6 +662,39 @@ describe('parse props', () => {
     expect(t.property?.defaultValue).toBe(`'Hello'`);
   });
 
+  it('prop default value resolved through `as const` wrapper', () => {
+    const t = transpileModule(`
+      const DEFAULT = 'x' as const;
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() val: 'x' = DEFAULT;
+      }
+    `);
+    expect(t.property?.defaultValue).toBe(`'x'`);
+  });
+
+  it('prop default value resolved through parenthesized + non-null wrappers', () => {
+    const t = transpileModule(`
+      const DEFAULT: string | undefined = 'wrapped';
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() val: string = (DEFAULT)!;
+      }
+    `);
+    expect(t.property?.defaultValue).toBe(`'wrapped'`);
+  });
+
+  it('prop default value resolved through a `const` initialized to undefined', () => {
+    const t = transpileModule(`
+      const DEFAULT = undefined;
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() val: string | undefined = DEFAULT;
+      }
+    `);
+    expect(t.property?.defaultValue).toBe('undefined');
+  });
+
   it('prop default value resolved from a cross-file imported const', () => {
     // Self-contained 2-file program. Does NOT extend the shared `transpileModule`
     // helper — keeps the multi-file complexity isolated to this single test.

--- a/src/compiler/transformers/test/parse-props.spec.ts
+++ b/src/compiler/transformers/test/parse-props.spec.ts
@@ -638,34 +638,6 @@ describe('parse props', () => {
     expect(t.property?.defaultValue).toBe('QUERY[key]');
   });
 
-  it('prop default value resolved from a cross-file imported const', () => {
-    const t = transpileModule(
-      `
-      import { QUERY } from './queries';
-      @Component({tag: 'cmp-a'})
-      export class CmpA {
-        @Prop() when: string | boolean = QUERY['lg'];
-      }
-    `,
-      null,
-      null,
-      [],
-      [],
-      [],
-      {},
-      'module.tsx',
-      {
-        'queries.ts': `export const QUERY: { [key: string]: string } = { lg: '(min-width: 992px)' };`,
-      },
-    );
-    // With multiple files in the program, the helper-extracted `t.property`
-    // and `getStaticGetter` aren't reliable (module ordering + the emitted
-    // `import` line confuses `new Function()`). Assert the literal made it
-    // into the emitted `static get properties()` block directly — this is
-    // the actual contract the fix protects.
-    expect(t.outputText).toMatch(/"defaultValue":\s*"'\(min-width: 992px\)'"/);
-  });
-
   it('should infer string type from `get()` return value', () => {
     const t = transpileModule(`
       @Component({tag: 'cmp-a'})

--- a/src/compiler/transformers/test/transpile.ts
+++ b/src/compiler/transformers/test/transpile.ts
@@ -20,9 +20,6 @@ import { getScriptTarget } from '../transform-utils';
  * after declarations are generated
  * @param tsConfig optional typescript compiler options to use
  * @param inputFileName a dummy filename to use for the module (defaults to `module.tsx`)
- * @param extraFiles optional additional source files (filename → contents) made available
- * to the TypeScript program. Useful for testing transformers that need to follow
- * cross-file symbol references (e.g. an `import`ed `const`).
  * @returns the result of the transpilation step
  */
 export function transpileModule(
@@ -34,7 +31,6 @@ export function transpileModule(
   afterDeclarations: ts.TransformerFactory<ts.SourceFile | ts.Bundle>[] = [],
   tsConfig: ts.CompilerOptions = {},
   inputFileName = 'module.tsx',
-  extraFiles: Record<string, string> = {},
 ) {
   const options: ts.CompilerOptions = {
     ...ts.getDefaultCompilerOptions(),
@@ -53,7 +49,7 @@ export function transpileModule(
     noEmitHelpers: true,
     noEmitOnError: undefined,
     noLib: true,
-    noResolve: Object.keys(extraFiles).length === 0,
+    noResolve: true,
     out: undefined,
     outFile: undefined,
     paths: undefined,
@@ -71,9 +67,6 @@ export function transpileModule(
   compilerCtx = compilerCtx || mockCompilerCtx(mergedConfig);
 
   const sourceFile = ts.createSourceFile(inputFileName, input, options.target);
-  const extraSourceFiles = new Map<string, ts.SourceFile>(
-    Object.entries(extraFiles).map(([name, contents]) => [name, ts.createSourceFile(name, contents, options.target)]),
-  );
 
   let outputText: string;
   let declarationOutputText: string;
@@ -89,38 +82,20 @@ export function transpileModule(
   };
 
   const compilerHost: ts.CompilerHost = {
-    getSourceFile: (fileName) => {
-      if (fileName === inputFileName) return sourceFile;
-      return extraSourceFiles.get(fileName);
-    },
+    getSourceFile: (fileName) => (fileName === inputFileName ? sourceFile : undefined),
     writeFile: emitCallback,
     getDefaultLibFileName: () => 'lib.d.ts',
     useCaseSensitiveFileNames: () => false,
     getCanonicalFileName: (fileName) => fileName,
     getCurrentDirectory: () => '',
     getNewLine: () => '',
-    fileExists: (fileName) => fileName === inputFileName || extraSourceFiles.has(fileName),
-    readFile: (fileName) => (fileName === inputFileName ? input : extraFiles[fileName] ?? ''),
+    fileExists: (fileName) => fileName === inputFileName,
+    readFile: () => '',
     directoryExists: () => true,
     getDirectories: () => [],
-    // Short-circuit module resolution for the in-memory extra files. The host
-    // maps a bare import specifier (e.g. `./queries`) to the matching virtual
-    // file we registered for the test, so the type checker can follow the
-    // alias symbol to the actual declaration.
-    resolveModuleNames: (moduleNames) =>
-      moduleNames.map((name) => {
-        const candidate = name.replace(/^\.\//, '');
-        for (const ext of ['.ts', '.tsx', '.d.ts']) {
-          const fileName = candidate.endsWith(ext) ? candidate : `${candidate}${ext}`;
-          if (extraSourceFiles.has(fileName)) {
-            return { resolvedFileName: fileName, extension: ext as ts.Extension };
-          }
-        }
-        return undefined;
-      }),
   };
 
-  const tsProgram = ts.createProgram([inputFileName, ...extraSourceFiles.keys()], options, compilerHost);
+  const tsProgram = ts.createProgram([inputFileName], options, compilerHost);
   const tsTypeChecker = tsProgram.getTypeChecker();
 
   const buildCtx = mockBuildCtx(mergedConfig, compilerCtx);

--- a/src/compiler/transformers/test/transpile.ts
+++ b/src/compiler/transformers/test/transpile.ts
@@ -20,6 +20,9 @@ import { getScriptTarget } from '../transform-utils';
  * after declarations are generated
  * @param tsConfig optional typescript compiler options to use
  * @param inputFileName a dummy filename to use for the module (defaults to `module.tsx`)
+ * @param extraFiles optional additional source files (filename → contents) made available
+ * to the TypeScript program. Useful for testing transformers that need to follow
+ * cross-file symbol references (e.g. an `import`ed `const`).
  * @returns the result of the transpilation step
  */
 export function transpileModule(
@@ -31,6 +34,7 @@ export function transpileModule(
   afterDeclarations: ts.TransformerFactory<ts.SourceFile | ts.Bundle>[] = [],
   tsConfig: ts.CompilerOptions = {},
   inputFileName = 'module.tsx',
+  extraFiles: Record<string, string> = {},
 ) {
   const options: ts.CompilerOptions = {
     ...ts.getDefaultCompilerOptions(),
@@ -49,7 +53,7 @@ export function transpileModule(
     noEmitHelpers: true,
     noEmitOnError: undefined,
     noLib: true,
-    noResolve: true,
+    noResolve: Object.keys(extraFiles).length === 0,
     out: undefined,
     outFile: undefined,
     paths: undefined,
@@ -67,6 +71,9 @@ export function transpileModule(
   compilerCtx = compilerCtx || mockCompilerCtx(mergedConfig);
 
   const sourceFile = ts.createSourceFile(inputFileName, input, options.target);
+  const extraSourceFiles = new Map<string, ts.SourceFile>(
+    Object.entries(extraFiles).map(([name, contents]) => [name, ts.createSourceFile(name, contents, options.target)]),
+  );
 
   let outputText: string;
   let declarationOutputText: string;
@@ -82,20 +89,38 @@ export function transpileModule(
   };
 
   const compilerHost: ts.CompilerHost = {
-    getSourceFile: (fileName) => (fileName === inputFileName ? sourceFile : undefined),
+    getSourceFile: (fileName) => {
+      if (fileName === inputFileName) return sourceFile;
+      return extraSourceFiles.get(fileName);
+    },
     writeFile: emitCallback,
     getDefaultLibFileName: () => 'lib.d.ts',
     useCaseSensitiveFileNames: () => false,
     getCanonicalFileName: (fileName) => fileName,
     getCurrentDirectory: () => '',
     getNewLine: () => '',
-    fileExists: (fileName) => fileName === inputFileName,
-    readFile: () => '',
+    fileExists: (fileName) => fileName === inputFileName || extraSourceFiles.has(fileName),
+    readFile: (fileName) => (fileName === inputFileName ? input : extraFiles[fileName] ?? ''),
     directoryExists: () => true,
     getDirectories: () => [],
+    // Short-circuit module resolution for the in-memory extra files. The host
+    // maps a bare import specifier (e.g. `./queries`) to the matching virtual
+    // file we registered for the test, so the type checker can follow the
+    // alias symbol to the actual declaration.
+    resolveModuleNames: (moduleNames) =>
+      moduleNames.map((name) => {
+        const candidate = name.replace(/^\.\//, '');
+        for (const ext of ['.ts', '.tsx', '.d.ts']) {
+          const fileName = candidate.endsWith(ext) ? candidate : `${candidate}${ext}`;
+          if (extraSourceFiles.has(fileName)) {
+            return { resolvedFileName: fileName, extension: ext as ts.Extension };
+          }
+        }
+        return undefined;
+      }),
   };
 
-  const tsProgram = ts.createProgram([inputFileName], options, compilerHost);
+  const tsProgram = ts.createProgram([inputFileName, ...extraSourceFiles.keys()], options, compilerHost);
   const tsTypeChecker = tsProgram.getTypeChecker();
 
   const buildCtx = mockBuildCtx(mergedConfig, compilerCtx);


### PR DESCRIPTION
Closes #6727

## What is the current behavior?

Stencil emits the source text of a `@Prop` initializer verbatim into the generated docs JSON (`defaultValue` field). When the initializer is a reference to a const variable or an object-property access, the docs end up showing the variable expression rather than the actual default value.

Example from `ion-split-pane` (Ionic Framework):

```ts
const QUERY: { [key: string]: string } = { lg: '(min-width: 992px)', ... };

@Component({ tag: 'ion-split-pane' })
export class SplitPane {
  @Prop() when: string | boolean = QUERY['lg'];
}
```

Today the generated docs JSON contains:

```json
"default": "QUERY['lg']"
```

…which is what users see in https://ionicframework.com/docs/api/split-pane#prop-when.

GitHub Issue Number: #6727

## What is the new behavior?

The `@Prop` decorator parser now follows the initializer expression to its underlying primitive literal when it is safe to do so. With this fix, the same component produces:

```json
"default": "'(min-width: 992px)'"
```

Shapes that are now resolved:

- `IDENT` where `IDENT` is a `const` variable whose initializer chain ends in a primitive literal.
- `OBJ.key` and `OBJ['key']` (or `OBJ[0]`) against `const` object literals.
- Object shorthand properties (`const label = 'x'; const CONFIG = { label }; @Prop() v = CONFIG.label;`) — resolved via `getShorthandAssignmentValueSymbol`.
- Cross-file imported `const`s (`import { QUERY } from './queries';`) — alias symbols are unwrapped via `getAliasedSymbol` before walking declarations.
- Value-preserving wrapper expressions are unwrapped: `as` (`'x' as const`), `<T>x` type assertions, parenthesized expressions, `satisfies`, and non-null `!`.
- Wrapped object-literal `const`s (`const CONFIG = ({ label: 'x' } as const)`) — the object side of `OBJ.key` is also unwrapped.
- Chained `const`-to-`const` object aliases (`const A = CONFIG; @Prop() v = A.label;`) — bounded by `MAX_RESOLVE_DEPTH`.
- Signed numeric literals (`-1`, `+2`) — TypeScript represents these as `PrefixUnaryExpression`, now recognised as primitives.
- `const X = undefined; @Prop() v = X;` resolves to the literal `undefined`.

Shapes that intentionally still fall back to the original `getText()` output (preserving prior behavior):

- Nested property access (`OBJ.a.b`).
- Template literals with substitutions.
- Computed / dynamic indexed access (`OBJ[varKey]`).
- Function calls, arithmetic, ternaries, etc.
- Enum members (`SomeEnum.VALUE`) — out of scope to avoid silently changing existing docs strings.
- `let` / `var` bindings — never followed because they may be reassigned.

Safety properties:

- Only primitive literals (`string` / `number` / signed number / `true` / `false` / `null` / `undefined`) are emitted. Object and array literals are never serialized into `defaultValue`.
- Recursion is bounded (`MAX_RESOLVE_DEPTH = 5`) for both the literal walk and the object-literal walk.
- Source quote style is preserved (everything still flows through `getText()` at the leaf).
- Any expression that can't be resolved falls back to the previous `getText()` output via `??`, so no existing case regresses.

## Documentation

N/A — internal compiler change. The Gallery component's hardcoded `columns` / `gap` description defaults in `ionic-team/ionic-docs` can be dropped once Ionic picks up this Stencil release; that follow-up belongs in the docs repo.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

The change only widens the set of expressions that are resolved into a literal. Every expression shape the previous code already produced output for produces the same output now.

## Testing

Fifteen new unit tests in `src/compiler/transformers/test/parse-props.spec.ts` covering:

- `const` string / number variable resolution.
- `OBJ.key` and `OBJ['key']` resolution — the latter uses the verbatim `ion-split-pane` shape (FW-7298 reproduction).
- Object shorthand property resolution (`{ label }`).
- Cross-file imported `const` resolution — self-contained 2-file `ts.Program` inline in the spec.
- `as const`, parenthesized + non-null wrapper unwrapping.
- Wrapped object-literal `const` accessed via property access.
- Chained `const`-to-`const` object alias resolution.
- Signed numeric literal (`-1`).
- `const X = undefined; @Prop() v = X;` chain.
- Function-call initializer / dynamic-key indexed access — must fall back to raw text.
- Direct `@Prop() x = undefined;` — preserved as raw text.

```
npm run test.jest -- src/compiler/transformers/test/parse-props.spec.ts
# Tests: 40 passed, 40 total
```

Full transformers suite: **325 passed**, zero regressions.

## Other information

- The fix is localized to `src/compiler/transformers/decorators-to-static/prop-decorator.ts` and the corresponding test file; no other files are touched.