### PR TITLE
feat(runtime): v5 support scoped custom element registries

### DIFF
--- a/V5_PLANNING.md
+++ b/V5_PLANNING.md
@@ -130,6 +130,20 @@ Modernize Stencil after 10 years: shed tech debt, embrace modern tooling, simpli
 - **`@Component` now supports `globalStyleUrl` and `globalStyle`**  co-locate document-level styles with the component. Styles are collected at build time and injected wherever `@import "stencil-globals"` appears in a global stylesheet. Works for all encapsulation types (shadow, scoped, none). No mode variants  CSS handles runtime variants via selectors or custom properties. Changes to `globalStyleUrl` files invalidate the global style build cache and trigger HMR correctly.
 - **`@import "stencil-hydrate"` virtual placeholder**  add to any `global-style` input to inject static FOUC-prevention CSS at build time instead of relying on the dynamic `<style>` tag inserted by the loader. The compiler replaces the placeholder with the sorted component selectors + configured hydration CSS (e.g. `my-cmp,other-cmp{visibility:hidden}.hydrated{visibility:inherit}`). When detected, `BUILD.staticHydrationStyles = true` suppresses the loader's dynamic injection. For `standalone` builds (which have no loader), `stencil-hydrate.css` is auto-generated alongside the bundle.
 - **`loader-bundle` now supports `externalRuntime`**  set `externalRuntime: true` on the `loader-bundle` output target to mark `@stencil/core` as an external dependency in the ESM/CJS distribution output. Only affects the bundler variant; the browser/CDN build always includes the runtime. Useful when consumers already depend on `@stencil/core` and want to avoid bundling a second copy.
+
+- **Scoped Custom Element Registries** — always available, no config flag required. Pass a `CustomElementRegistry` instance and Stencil defines all components in it instead of `window.customElements`. What you do with that registry (attaching it to shadow roots, scoped DOM subtrees, etc.) is up to you.
+  - **Standalone per-component**: `defineCustomElement({ registry })` — stamps `._registry` on the class and registers in the scoped registry.
+  - **Standalone auto-loader / lazy loader**: pre-configure with `setRegistry(registry)` before the bundle loads. All components will be defined in the provided registry.
+  - **Shadow components**: `attachShadow({ customElementRegistry: registry })` is set automatically so nested components inside a shadow root resolve from the same registry.
+
+  Requires native SCER support (Chrome ≥ 100, Safari ≥ 2025-01) or the `@webcomponents/scoped-custom-element-registry` polyfill. Example:
+  ```js
+  import { setRegistry, defineCustomElements } from 'my-lib/loader';
+  const registry = new CustomElementRegistry();
+  setRegistry(registry);
+  await defineCustomElements();
+  ```
+- **`setTagTransformer` auto-exported** — now auto-injected into generated library entry points (same as `setNonce`), so library authors no longer need to manually re-export it from their `index.ts`.
 - **Signals** — opt-in signal-backed reactivity via `extras.signalBacking: true`. Zero API changes for component authors; `@State` and `@Prop` are backed by `@preact/signals-core` signals internally. New `@stencil/core/signals` subpath exports `signal`, `computed`, `effect`, `batch`, `untracked`, `@Effect()`, `getSignal<T>()`, and `STENCIL_SIGNALS_SYMBOL` for cross-framework interop. Signal values are valid JSX children and attributes — DOM updates bypass the vdom diff entirely. `@Prop`-only signals are exposed on the host element via `Symbol.for('stencil.signals')` for framework adapters without requiring a `@stencil/core` import.
 
 ---

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-standalone.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-standalone.spec.ts
@@ -93,7 +93,7 @@ describe('Custom Elements output target', () => {
       });
 
       expect(entryPoint).toEqual(`import { globalScripts } from '${STENCIL_APP_GLOBALS_ID}';
-export { setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';
+export { setNonce, setRegistry, setTagTransformer, setPlatformOptions } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';
 export * from '${USER_INDEX_ENTRY_ID}';
 
 globalScripts();
@@ -107,7 +107,7 @@ globalScripts();
       });
 
       expect(entryPoint)
-        .toEqual(`export { setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';
+        .toEqual(`export { setNonce, setRegistry, setTagTransformer, setPlatformOptions } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';
 export * from '${USER_INDEX_ENTRY_ID}';
 `);
     });
@@ -198,7 +198,7 @@ export * from '${USER_INDEX_ENTRY_ID}';
         );
         expect(bundleOptions.loader['\0core']).toEqual(
           `import { globalScripts } from '${STENCIL_APP_GLOBALS_ID}';
-export { setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';
+export { setNonce, setRegistry, setTagTransformer, setPlatformOptions } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';
 export * from '${USER_INDEX_ENTRY_ID}';
 
 globalScripts();
@@ -236,7 +236,7 @@ globalScripts();
         );
         expect(bundleOptions.loader['\0core']).toEqual(
           `import { globalScripts } from '${STENCIL_APP_GLOBALS_ID}';
-export { setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';
+export { setNonce, setRegistry, setTagTransformer, setPlatformOptions } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';
 export * from '${USER_INDEX_ENTRY_ID}';
 export { StubCmp, defineCustomElement as defineCustomElementStubCmp } from '\0StubCmp';
 export { MyBestComponent, defineCustomElement as defineCustomElementMyBestComponent } from '\0MyBestComponent';
@@ -268,7 +268,7 @@ globalScripts();
         );
         expect(bundleOptions.loader['\0core']).toEqual(
           `import { globalScripts } from '${STENCIL_APP_GLOBALS_ID}';
-export { setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';
+export { setNonce, setRegistry, setTagTransformer, setPlatformOptions } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';
 export * from '${USER_INDEX_ENTRY_ID}';
 export { ComponentWithJsx, defineCustomElement as defineCustomElementComponentWithJsx } from '\0ComponentWithJsx';
 
@@ -309,7 +309,7 @@ globalScripts();
 import { transformTag } from '@stencil/core/runtime/client/standalone';
 import { StubCmp } from '\0StubCmp';
 import { MyBestComponent } from '\0MyBestComponent';
-export { setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';
+export { setNonce, setRegistry, setTagTransformer, setPlatformOptions } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';
 export * from '${USER_INDEX_ENTRY_ID}';
 
 globalScripts();
@@ -352,7 +352,7 @@ export const defineCustomElements = (opts) => {
         // Check loader module content
         const loaderContent = bundleOptions.loader['\0loader'];
         expect(loaderContent).toContain(
-          `import { transformTag } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}'`,
+          `import { transformTag, getRegistry } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}'`,
         );
         expect(loaderContent).toContain("'stub-cmp'");
         expect(loaderContent).toContain(

--- a/packages/core/src/compiler/output-targets/dist-lazy/_test_/lazy-output.spec.ts
+++ b/packages/core/src/compiler/output-targets/dist-lazy/_test_/lazy-output.spec.ts
@@ -38,7 +38,9 @@ describe('outputLazy', () => {
       await outputLazy(config, compilerCtx, buildCtx);
 
       const entry = getLoaderEntry(vi.mocked(bundleOutput).mock.calls[0], LAZY_EXTERNAL_ENTRY_ID);
-      expect(entry).toContain(`export { setNonce } from '${STENCIL_CORE_ID}';`);
+      expect(entry).toContain(
+        `export { setNonce, setRegistry, setTagTransformer } from '${STENCIL_CORE_ID}';`,
+      );
       expect(entry).toContain('export const defineCustomElements');
     });
 

--- a/packages/core/src/compiler/output-targets/dist-lazy/lazy-output.ts
+++ b/packages/core/src/compiler/output-targets/dist-lazy/lazy-output.ts
@@ -266,7 +266,7 @@ function createEntryModule(cmps: d.ComponentCompilerMeta[]): d.EntryModule {
 
 const getLazyEntry = (isBrowser: boolean, assetPath?: string, externalRuntime = false): string => {
   const s = new MagicString(``);
-  s.append(`export { setNonce } from '${STENCIL_CORE_ID}';\n`);
+  s.append(`export { setNonce, setRegistry, setTagTransformer } from '${STENCIL_CORE_ID}';\n`);
   s.append(`import { bootstrapLazy } from '${STENCIL_CORE_ID}';\n`);
 
   if (isBrowser) {

--- a/packages/core/src/compiler/output-targets/standalone/generate-loader-module.ts
+++ b/packages/core/src/compiler/output-targets/standalone/generate-loader-module.ts
@@ -39,7 +39,7 @@ export const generateLoaderModule = (
     : '';
 
   return /* js */ `
-import { transformTag } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';
+import { transformTag, getRegistry } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';
 ${assetPathImport}${assetPathInit}
 
 /**
@@ -58,6 +58,13 @@ const lookup = Object.fromEntries(tags.map(t => [transformTag(t), t]));
  * Prevents duplicate loading attempts.
  */
 const defined = new Set();
+
+/**
+ * The registry to define components in. Captured once at start() time from
+ * getRegistry() so all components in this library share the same registry
+ * regardless of subsequent setRegistry() calls by other libraries.
+ */
+let reg = customElements;
 
 /**
  * MutationObserver instance for watching DOM changes.
@@ -125,7 +132,7 @@ async function load(root) {
         // upgraded (constructor + connectedCallback have run synchronously),
         // at which point __s_ghr and $onReadyPromise$ are set.
         ancestor['s-p'].push(
-          customElements.whenDefined(tag).then(() => el['s-rp'])
+          reg.whenDefined(tag).then(() => el['s-rp'])
         );
         break;
       }
@@ -144,7 +151,7 @@ async function load(root) {
  */
 async function register(transformedTag) {
   // Skip if already defined or being defined
-  if (defined.has(transformedTag) || customElements.get(transformedTag)) {
+  if (defined.has(transformedTag) || reg.get(transformedTag)) {
     defined.add(transformedTag);
     return;
   }
@@ -160,7 +167,7 @@ ${switchCases}
       default: return;
     }
     // Call defineCustomElement if exported (handles component + dependencies)
-    if (typeof module.defineCustomElement === 'function') module.defineCustomElement();
+    if (typeof module.defineCustomElement === 'function') module.defineCustomElement({ registry: reg });
   } catch (e) {
     console.error(\`[Stencil Loader] Failed to load <\${transformedTag}>\`, e);
     // Remove from defined set to allow retry
@@ -170,12 +177,18 @@ ${switchCases}
 
 /**
  * Start the auto-loader, scanning the DOM and watching for changes.
+ * Captures the active registry (set via setRegistry()) at start time so all
+ * components in this library are defined in the same registry.
  * @param root - The root element to observe (default: document.body)
  */
 export function start(root = document.body) {
+  // Capture registry once so all lazy loads in this session use the same one
+  reg = getRegistry();
+
   // Disconnect any existing observer
   if (observer) {
     observer.disconnect();
+    defined.clear();
   }
 
   // Create MutationObserver to watch for new elements

--- a/packages/core/src/compiler/output-targets/standalone/index.ts
+++ b/packages/core/src/compiler/output-targets/standalone/index.ts
@@ -359,7 +359,7 @@ export const generateEntryPoint = (
 
   // Exports that are always present
   exports.push(
-    `export { setNonce, setPlatformOptions } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';`,
+    `export { setNonce, setRegistry, setTagTransformer, setPlatformOptions } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';`,
     `export * from '${USER_INDEX_ENTRY_ID}';`,
   );
 

--- a/packages/core/src/compiler/transformers/_test_/add-define-custom-element-function.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/add-define-custom-element-function.spec.ts
@@ -1,0 +1,145 @@
+import * as d from '@stencil/core';
+import { mockCompilerCtx, mockModule } from '@stencil/core/testing';
+import * as ts from 'typescript';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import type { MockInstance } from 'vitest';
+
+import { stubComponentCompilerMeta } from '../../types/_tests_/ComponentCompilerMeta.stub';
+import { addDefineCustomElementFunctions } from '../component-native/add-define-custom-element-function';
+import * as TransformUtils from '../transform-utils';
+import { transpileModule } from './transpile';
+import { formatCode } from './utils';
+
+describe('addDefineCustomElementFunctions', () => {
+  const componentClassName = 'CmpA';
+  const tagName = 'cmp-a';
+  let compilerCtx: d.CompilerCtx;
+  let getModuleFromSourceFileSpy: MockInstance<typeof TransformUtils.getModuleFromSourceFile>;
+
+  const outputTarget: d.OutputTargetStandalone = { type: 'standalone' };
+
+  beforeEach(() => {
+    compilerCtx = mockCompilerCtx();
+    getModuleFromSourceFileSpy = vi.spyOn(TransformUtils, 'getModuleFromSourceFile');
+    getModuleFromSourceFileSpy.mockImplementation(() =>
+      mockModule({ cmps: [stubComponentCompilerMeta({ componentClassName, tagName })] }),
+    );
+  });
+
+  afterEach(() => {
+    getModuleFromSourceFileSpy.mockRestore();
+  });
+
+  const buildTransformer = (
+    components: d.ComponentCompilerMeta[] = [],
+    target: d.OutputTargetStandalone = outputTarget,
+    devMode = false,
+  ): ts.TransformerFactory<ts.SourceFile> =>
+    addDefineCustomElementFunctions(compilerCtx, components, target, devMode);
+
+  const transpile = (transformer: ts.TransformerFactory<ts.SourceFile>) => {
+    const code = `export const ${componentClassName} = class extends HTMLElement {};`;
+    return transpileModule(code, null, compilerCtx, [], [transformer]);
+  };
+
+  describe('generated defineCustomElement shape', () => {
+    it('has an optional opts parameter', () => {
+      const { outputText } = transpile(buildTransformer());
+      expect(outputText).toContain('defineCustomElement(opts?)');
+    });
+
+    it('resolves the registry from opts falling back to the stored registry', async () => {
+      const { outputText } = transpile(buildTransformer());
+      const formatted = await formatCode(outputText);
+      expect(formatted).toContain(await formatCode(`const _storeReg = __stencil_getRegistry();`));
+      expect(formatted).toContain(await formatCode(`const _reg = opts?.registry ?? _storeReg;`));
+      expect(formatted).not.toContain('_storeRoot');
+      expect(formatted).not.toContain('_regRoot');
+    });
+
+    it('returns early when _reg is undefined', () => {
+      const { outputText } = transpile(buildTransformer());
+      expect(outputText).toContain(`typeof _reg === "undefined"`);
+    });
+
+    it('calls _reg.define instead of customElements.define', () => {
+      const { outputText } = transpile(buildTransformer());
+      expect(outputText).toContain('_reg.define');
+      expect(outputText).not.toContain('customElements.define');
+    });
+
+    it('stamps _registry on the component class', () => {
+      const { outputText } = transpile(buildTransformer());
+      expect(outputText).toContain(`${componentClassName}._registry = _reg`);
+    });
+
+    it('calls __stencil_getRegistry to get the stored registry', () => {
+      const { outputText } = transpile(buildTransformer());
+      expect(outputText).toContain('__stencil_getRegistry');
+    });
+  });
+
+  describe('dependencies', () => {
+    it('threads opts through to dependency defineCustomElement calls', () => {
+      const dep = stubComponentCompilerMeta({
+        componentClassName: 'CmpB',
+        tagName: 'cmp-b',
+      });
+      getModuleFromSourceFileSpy.mockImplementation(() =>
+        mockModule({
+          cmps: [
+            stubComponentCompilerMeta({
+              componentClassName,
+              tagName,
+              dependencies: ['cmp-b'],
+            }),
+          ],
+        }),
+      );
+
+      const { outputText } = transpile(buildTransformer([dep]));
+      expect(outputText).toContain('$CmpBDefineCustomElement(opts)');
+    });
+  });
+
+  describe('auto-define-custom-elements behavior', () => {
+    it('appends a no-arg defineCustomElement() call', () => {
+      const target: d.OutputTargetStandalone = {
+        type: 'standalone',
+        customElementsExportBehavior: 'auto-define-custom-elements',
+      };
+      const { outputText } = transpile(buildTransformer([], target));
+      expect(outputText).toContain('defineCustomElement()');
+    });
+
+    it('does not pass the component class as an argument', () => {
+      const target: d.OutputTargetStandalone = {
+        type: 'standalone',
+        customElementsExportBehavior: 'auto-define-custom-elements',
+      };
+      const { outputText } = transpile(buildTransformer([], target));
+      expect(outputText).not.toContain(`defineCustomElement(${componentClassName})`);
+    });
+  });
+
+  describe('devMode', () => {
+    it('stamps __stencil_module__ with import.meta.url in dev mode', () => {
+      const { outputText } = transpile(buildTransformer([], outputTarget, true));
+      expect(outputText).toContain('__stencil_module__');
+      expect(outputText).toContain('import.meta.url');
+    });
+
+    it('does not emit __stencil_module__ in production mode', () => {
+      const { outputText } = transpile(buildTransformer([], outputTarget, false));
+      expect(outputText).not.toContain('__stencil_module__');
+    });
+  });
+
+  describe('no component in module', () => {
+    it('does not append defineCustomElement when the module has no components', () => {
+      getModuleFromSourceFileSpy.mockImplementation(() => mockModule({ cmps: [] }));
+      const { outputText } = transpile(buildTransformer());
+      expect(outputText).not.toContain('defineCustomElement');
+    });
+  });
+});

--- a/packages/core/src/compiler/transformers/component-native/add-define-custom-element-function.ts
+++ b/packages/core/src/compiler/transformers/component-native/add-define-custom-element-function.ts
@@ -2,7 +2,7 @@ import ts from 'typescript';
 import type * as d from '@stencil/core';
 
 import { dashToPascalCase } from '../../../utils';
-import { addCoreRuntimeApi, RUNTIME_APIS, TRANSFORM_TAG } from '../core-runtime-apis';
+import { addCoreRuntimeApi, GET_REGISTRY, RUNTIME_APIS, TRANSFORM_TAG } from '../core-runtime-apis';
 import { createImportStatement, getModuleFromSourceFile } from '../transform-utils';
 
 /**
@@ -29,31 +29,15 @@ export const addDefineCustomElementFunctions = (
 
       if (moduleFile.cmps.length) {
         addCoreRuntimeApi(moduleFile, RUNTIME_APIS.transformTag);
+        addCoreRuntimeApi(moduleFile, RUNTIME_APIS.getRegistry);
 
         const principalComponent = moduleFile.cmps[0];
         tagNames.push(principalComponent.tagName);
 
-        // define the current component - `customElements.define(transformTag(tagName), MyProxiedComponent);`
-        const customElementsDefineCallExpression = ts.factory.createCallExpression(
-          ts.factory.createPropertyAccessExpression(
-            ts.factory.createIdentifier('customElements'),
-            'define',
-          ),
-          undefined,
-          [
-            ts.factory.createCallExpression(
-              ts.factory.createIdentifier(TRANSFORM_TAG),
-              [],
-              [ts.factory.createIdentifier('tagName')],
-            ),
-            ts.factory.createIdentifier(principalComponent.componentClassName),
-          ],
-        );
-        // create a `case` block that defines the current component. We'll add them to our switch statement later.
         caseStatements.push(
-          createCustomElementsDefineCase(
+          createDefineCase(
             principalComponent.tagName,
-            customElementsDefineCallExpression,
+            createScopedDefineExpression(principalComponent.componentClassName),
           ),
         );
 
@@ -61,15 +45,9 @@ export const addDefineCustomElementFunctions = (
         addDefineCustomElementFunction(tagNames, newStatements, caseStatements);
 
         if (outputTarget.customElementsExportBehavior === 'auto-define-custom-elements') {
-          const conditionalDefineCustomElementCall = createAutoDefinitionExpression(
-            principalComponent.componentClassName,
-          );
-          newStatements.push(conditionalDefineCustomElementCall);
+          newStatements.push(createAutoDefinitionExpression());
         }
 
-        // In dev builds, stamp each component class with its own module URL so the
-        // HMR runtime can re-import the exact file that needs to be replaced.
-        // Emits: MyComponent.__stencil_module__ = import.meta.url;
         if (devMode) {
           newStatements.push(
             ts.factory.createExpressionStatement(
@@ -102,12 +80,42 @@ export const addDefineCustomElementFunctions = (
 };
 
 /**
- * Adds dependent component import statements and sets up and case blocks
- * @param moduleFile current components' module
- * @param components all current components within the stencil buildCtx
- * @param newStatements new top level statement array to add to that will get added to the AST
- * @param caseStatements an array of case statement blocks to add to. Will get added to `defineCustomElement` later
- * @param tagNames array of all related component tag-names to add to
+ * Creates `(ComponentClass._registry = _reg, _reg.define(transformTag(tagName), ComponentClass))`.
+ * The comma expression lets both the _registry stamp and the define call fit inside the single
+ * if-body block that createDefineCase wraps around the action expression.
+ * @param componentClassName the component class identifier name
+ * @returns a TS comma-list expression for the scoped-registry define
+ */
+const createScopedDefineExpression = (componentClassName: string): ts.Expression =>
+  ts.factory.createCommaListExpression([
+    ts.factory.createAssignment(
+      ts.factory.createPropertyAccessExpression(
+        ts.factory.createIdentifier(componentClassName),
+        '_registry',
+      ),
+      ts.factory.createIdentifier('_reg'),
+    ),
+    ts.factory.createCallExpression(
+      ts.factory.createPropertyAccessExpression(ts.factory.createIdentifier('_reg'), 'define'),
+      undefined,
+      [
+        ts.factory.createCallExpression(
+          ts.factory.createIdentifier(TRANSFORM_TAG),
+          [],
+          [ts.factory.createIdentifier('tagName')],
+        ),
+        ts.factory.createIdentifier(componentClassName),
+      ],
+    ),
+  ]);
+
+/**
+ * Adds dependent component imports and case blocks for all transitive dependencies.
+ * @param moduleFile current component's module
+ * @param components all components in the build
+ * @param newStatements top-level statement array to append imports to
+ * @param caseStatements switch case array to append dependency cases to
+ * @param tagNames tag name list to append dependency tag names to
  */
 const setupComponentDependencies = (
   moduleFile: d.Module,
@@ -123,62 +131,49 @@ const setupComponentDependencies = (
       const importAs = `$${exportName}DefineCustomElement`;
       tagNames.push(foundDep.tagName);
 
-      // Will add `import { defineCustomElement as $ComponentDefineCustomElement } from 'my-nested-component.tsx';`
       newStatements.push(
         createImportStatement([`defineCustomElement as ${importAs}`], foundDep.sourceFilePath),
       );
 
-      // define a dependent component by recursively calling their own `defineCustomElement()`
+      // Delegate to the dep's own defineCustomElement, threading opts so it resolves the same registry.
       const callExpression = ts.factory.createCallExpression(
         ts.factory.createIdentifier(importAs),
         undefined,
-        [],
+        [ts.factory.createIdentifier('opts')],
       );
-      // `case` blocks that define the dependent components. We'll add them to our switch statement later.
-      caseStatements.push(createCustomElementsDefineCase(foundDep.tagName, callExpression));
+      caseStatements.push(createDefineCase(foundDep.tagName, callExpression));
     });
   });
 };
 
 /**
- * Creates a case block which will be used to define components. e.g.
- * ``` javascript
- * case "my-component":
- *   if (!customElements.get(transformTag(tagName))) {
- *     customElements.define(transformTag(tagName), MyProxiedComponent);
- *     // OR for dependent components
- *     defineCustomElement(tagName);
- *   }
- *   break;
- * } });
-  ```
- * @param tagName the components' tagName saved within stencil.
- * @param actionExpression the actual expression to call to define the customElement
- * @returns ts AST CaseClause
+ * Creates a switch case that guards the action behind a registry.get() check.
+ *
+ * @param tagName the component's original tag name (before transformation)
+ * @param actionExpression the define or delegate call expression
+ * @returns a TS CaseClause for the switch statement
  */
-const createCustomElementsDefineCase = (
-  tagName: string,
-  actionExpression: ts.Expression,
-): ts.CaseClause => {
+const createDefineCase = (tagName: string, actionExpression: ts.Expression): ts.CaseClause => {
+  const registryIdent = ts.factory.createIdentifier('_reg');
+
+  const getCheck = ts.factory.createPrefixUnaryExpression(
+    ts.SyntaxKind.ExclamationToken,
+    ts.factory.createCallExpression(
+      ts.factory.createPropertyAccessExpression(registryIdent, 'get'),
+      undefined,
+      [
+        ts.factory.createCallExpression(
+          ts.factory.createIdentifier(TRANSFORM_TAG),
+          [],
+          [ts.factory.createIdentifier('tagName')],
+        ),
+      ],
+    ),
+  );
+
   return ts.factory.createCaseClause(ts.factory.createStringLiteral(tagName), [
     ts.factory.createIfStatement(
-      ts.factory.createPrefixUnaryExpression(
-        ts.SyntaxKind.ExclamationToken,
-        ts.factory.createCallExpression(
-          ts.factory.createPropertyAccessExpression(
-            ts.factory.createIdentifier('customElements'),
-            'get',
-          ),
-          undefined,
-          [
-            ts.factory.createCallExpression(
-              ts.factory.createIdentifier(TRANSFORM_TAG),
-              [],
-              [ts.factory.createIdentifier('tagName')],
-            ),
-          ],
-        ),
-      ),
+      getCheck,
       ts.factory.createBlock([ts.factory.createExpressionStatement(actionExpression)]),
     ),
     ts.factory.createBreakStatement(),
@@ -186,118 +181,160 @@ const createCustomElementsDefineCase = (
 };
 
 /**
- * Add the main `defineCustomElement` function e.g.
- * ```javascript
- * function defineCustomElement() {
- *  if (typeof customElements === 'undefined') {
- *    return;
- *  }
- *  const components = ['my-component'];
- *   components.forEach(tagName => {
- *     switch (tagName) {
- *       case "my-component":
- *         if (!customElements.get(transformTag(tagName))) {
- *           customElements.define(transformTag(tagName), MyProxiedComponent);
- *           // OR for dependent components
- *           defineCustomElement(tagName);
- *         }
- *         break;
- *     }
- *   });
+ * Adds the exported `defineCustomElement` function declaration.
+ *
+ * Global path:
+ * ```js
+ * export function defineCustomElement() {
+ *   if (typeof customElements === 'undefined') return;
+ *   ['my-comp', ...].forEach(tagName => { switch (tagName) { ... } });
  * }
- ```
- * @param tagNames all components that will be defined
- * @param newStatements new top level statement array that will get added to the AST
- * @param caseStatements an array of case statement blocks. Will get added to `defineCustomElement` later
+ * ```
+ *
+ * Scoped path:
+ * ```js
+ * export function defineCustomElement(opts) {
+ *   const _storeReg = __stencil_getRegistry();
+ *   const _reg = opts?.registry ?? _storeReg;
+ *   if (typeof _reg === 'undefined') return;
+ *   ['my-comp', ...].forEach(tagName => { switch (tagName) { ... } });
+ * }
+ * ```
+ */
+/**
+ * @param tagNames all tag names (principal + dependencies) to include in the forEach
+ * @param newStatements top-level statement array to append the function declaration to
+ * @param caseStatements switch case clauses to embed in the forEach body
  */
 const addDefineCustomElementFunction = (
   tagNames: string[],
   newStatements: ts.Statement[],
   caseStatements: ts.CaseClause[],
 ) => {
-  const newExpression = ts.factory.createFunctionDeclaration(
-    [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
-    undefined,
-    ts.factory.createIdentifier('defineCustomElement'),
-    undefined,
-    [],
-    undefined,
-    ts.factory.createBlock(
-      [
-        ts.factory.createIfStatement(
-          ts.factory.createStrictEquality(
-            ts.factory.createTypeOfExpression(ts.factory.createIdentifier('customElements')),
-            ts.factory.createStringLiteral('undefined'),
-          ),
-          ts.factory.createBlock([ts.factory.createReturnStatement()]),
-        ),
-        ts.factory.createVariableStatement(
-          undefined,
-          ts.factory.createVariableDeclarationList(
-            [
-              ts.factory.createVariableDeclaration(
-                'components',
-                undefined,
-                undefined,
-                ts.factory.createArrayLiteralExpression(
-                  tagNames.map((tagName) => ts.factory.createStringLiteral(tagName)),
-                ),
-              ),
-            ],
-            ts.NodeFlags.Const,
-          ),
-        ),
-        ts.factory.createExpressionStatement(
-          ts.factory.createCallExpression(
-            ts.factory.createPropertyAccessExpression(
-              ts.factory.createIdentifier('components'),
-              'forEach',
-            ),
+  const forEachStmt = buildForEachStatement(tagNames, caseStatements);
+
+  const bodyStatements: ts.Statement[] = [
+    // const _storeReg = __stencil_getRegistry();
+    ts.factory.createVariableStatement(
+      undefined,
+      ts.factory.createVariableDeclarationList(
+        [
+          ts.factory.createVariableDeclaration(
+            '_storeReg',
             undefined,
-            [
-              ts.factory.createArrowFunction(
-                undefined,
-                undefined,
-                [
-                  ts.factory.createParameterDeclaration(
-                    undefined,
-                    undefined,
-                    ts.factory.createIdentifier('tagName'),
-                    undefined,
-                    undefined,
-                  ),
-                ],
-                undefined,
-                ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
-                ts.factory.createBlock([
-                  ts.factory.createSwitchStatement(
-                    ts.factory.createIdentifier('tagName'),
-                    ts.factory.createCaseBlock(caseStatements),
-                  ),
-                ]),
-              ),
-            ],
+            undefined,
+            ts.factory.createCallExpression(
+              ts.factory.createIdentifier(GET_REGISTRY),
+              undefined,
+              [],
+            ),
           ),
-        ),
-      ],
-      true,
+        ],
+        ts.NodeFlags.Const,
+      ),
+    ),
+    // const _reg = opts?.registry ?? _storeReg;
+    ts.factory.createVariableStatement(
+      undefined,
+      ts.factory.createVariableDeclarationList(
+        [
+          ts.factory.createVariableDeclaration(
+            '_reg',
+            undefined,
+            undefined,
+            ts.factory.createBinaryExpression(
+              ts.factory.createPropertyAccessChain(
+                ts.factory.createIdentifier('opts'),
+                ts.factory.createToken(ts.SyntaxKind.QuestionDotToken),
+                ts.factory.createIdentifier('registry'),
+              ),
+              ts.factory.createToken(ts.SyntaxKind.QuestionQuestionToken),
+              ts.factory.createIdentifier('_storeReg'),
+            ),
+          ),
+        ],
+        ts.NodeFlags.Const,
+      ),
+    ),
+    // if (typeof _reg === 'undefined') return;
+    ts.factory.createIfStatement(
+      ts.factory.createStrictEquality(
+        ts.factory.createTypeOfExpression(ts.factory.createIdentifier('_reg')),
+        ts.factory.createStringLiteral('undefined'),
+      ),
+      ts.factory.createBlock([ts.factory.createReturnStatement()]),
+    ),
+    forEachStmt,
+  ];
+
+  const params = [
+    ts.factory.createParameterDeclaration(
+      undefined,
+      undefined,
+      'opts',
+      ts.factory.createToken(ts.SyntaxKind.QuestionToken),
+    ),
+  ];
+
+  newStatements.push(
+    ts.factory.createFunctionDeclaration(
+      [ts.factory.createModifier(ts.SyntaxKind.ExportKeyword)],
+      undefined,
+      ts.factory.createIdentifier('defineCustomElement'),
+      undefined,
+      params,
+      undefined,
+      ts.factory.createBlock(bodyStatements, true),
     ),
   );
-  newStatements.push(newExpression);
 };
 
 /**
- * Create a call to `defineCustomElement` for the principle web component.
- * ```typescript
- * defineCustomElement(MyPrincipalComponent);
- * ```
- * @param componentName the component's class name to use as the first argument to `defineCustomElement`
- * @returns the expression statement described above
+ * Builds `['tag1', 'tag2'].forEach(tagName => { switch (tagName) { ... } })`.
+ * Inlining the array literal avoids a separate `const components` statement.
+ * @param tagNames tag names to iterate over
+ * @param caseStatements switch cases to embed in the arrow function body
+ * @returns a TS expression statement for the forEach call
  */
-function createAutoDefinitionExpression(componentName: string): ts.ExpressionStatement {
+const buildForEachStatement = (tagNames: string[], caseStatements: ts.CaseClause[]): ts.Statement =>
+  ts.factory.createExpressionStatement(
+    ts.factory.createCallExpression(
+      ts.factory.createPropertyAccessExpression(
+        ts.factory.createArrayLiteralExpression(
+          tagNames.map((t) => ts.factory.createStringLiteral(t)),
+        ),
+        'forEach',
+      ),
+      undefined,
+      [
+        ts.factory.createArrowFunction(
+          undefined,
+          undefined,
+          [ts.factory.createParameterDeclaration(undefined, undefined, 'tagName')],
+          undefined,
+          ts.factory.createToken(ts.SyntaxKind.EqualsGreaterThanToken),
+          ts.factory.createBlock([
+            ts.factory.createSwitchStatement(
+              ts.factory.createIdentifier('tagName'),
+              ts.factory.createCaseBlock(caseStatements),
+            ),
+          ]),
+        ),
+      ],
+    ),
+  );
+
+/**
+ * Creates `defineCustomElement(MyPrincipalComponent)` for auto-define-custom-elements behavior.
+ * @param componentName the component class identifier name
+ * @returns the expression statement calling defineCustomElement
+ */
+function createAutoDefinitionExpression(): ts.ExpressionStatement {
   return ts.factory.createExpressionStatement(
-    ts.factory.createCallExpression(ts.factory.createIdentifier('defineCustomElement'), undefined, [
-      ts.factory.createIdentifier(componentName),
-    ]),
+    ts.factory.createCallExpression(
+      ts.factory.createIdentifier('defineCustomElement'),
+      undefined,
+      [],
+    ),
   );
 }

--- a/packages/core/src/compiler/transformers/core-runtime-apis.ts
+++ b/packages/core/src/compiler/transformers/core-runtime-apis.ts
@@ -10,6 +10,7 @@ export const REGISTER_INSTANCE = '__stencil_registerInstance';
 const REGISTER_HOST = '__stencil_registerHost';
 export const H = '__stencil_h';
 export const TRANSFORM_TAG = '__stencil_transformTag';
+export const GET_REGISTRY = '__stencil_getRegistry';
 
 export const RUNTIME_APIS = {
   createEvent: `createEvent as ${CREATE_EVENT}`,
@@ -23,6 +24,7 @@ export const RUNTIME_APIS = {
   registerHost: `registerHost as ${REGISTER_HOST}`,
   registerInstance: `registerInstance as ${REGISTER_INSTANCE}`,
   transformTag: `transformTag as ${TRANSFORM_TAG}`,
+  getRegistry: `getRegistry as ${GET_REGISTRY}`,
 };
 
 /**

--- a/packages/core/src/compiler/types/generate-types.ts
+++ b/packages/core/src/compiler/types/generate-types.ts
@@ -115,6 +115,24 @@ export declare function defineCustomElements(win?: Window, opts?: CustomElements
  * will result in the same behavior.
  */
 export declare function setNonce(nonce: string): void;
+
+/**
+ * Pre-configure the scoped CustomElementRegistry used by the lazy loader.
+ * Call this before the bundle executes (i.e. before defineCustomElements()).
+ * After all components are defined the loader calls registry.initialize(root ?? document)
+ * so that existing light-DOM elements in the subtree are upgraded.
+ */
+export declare function setRegistry(registry: CustomElementRegistry, root?: Node): void;
+
+/** A function that transforms a custom-element tag name before it is registered or looked up. */
+export type TagTransformer = (tag: string) => string;
+
+/**
+ * Install a tag-name transformer. Every component tag name is passed through
+ * this function before being registered with the registry or matched in the DOM.
+ * Useful for namespacing (e.g. \`my-button\` → \`acme-button\`) in multi-library pages.
+ */
+export declare function setTagTransformer(transformer: TagTransformer): void;
 `;
 
   const loaderDtsPath = join(typesDir, 'loader.d.ts');
@@ -140,6 +158,24 @@ const generateStandaloneApiTypes = async (
  * will result in the same behavior.
  */
 export declare const setNonce: (nonce: string) => void;
+
+/**
+ * Pre-configure the scoped CustomElementRegistry before the standalone bundle runs.
+ * Call this before any component modules are imported. Components subsequently defined
+ * via defineCustomElement() will use this registry (and call registry.initialize(root)
+ * to upgrade existing light-DOM elements when root is provided).
+ */
+export declare const setRegistry: (registry: CustomElementRegistry, root?: Node) => void;
+
+/** A function that transforms a custom-element tag name before it is registered or looked up. */
+export type TagTransformer = (tag: string) => string;
+
+/**
+ * Install a tag-name transformer. Every component tag name is passed through
+ * this function before being registered with the registry or matched in the DOM.
+ * Useful for namespacing (e.g. \`my-button\` → \`acme-button\`) in multi-library pages.
+ */
+export declare const setTagTransformer: (transformer: TagTransformer) => void;
 
 export interface SetPlatformOptions {
   raf?: (c: FrameRequestCallback) => number;

--- a/packages/core/src/compiler/types/generate-types.ts
+++ b/packages/core/src/compiler/types/generate-types.ts
@@ -119,8 +119,6 @@ export declare function setNonce(nonce: string): void;
 /**
  * Pre-configure the scoped CustomElementRegistry used by the lazy loader.
  * Call this before the bundle executes (i.e. before defineCustomElements()).
- * After all components are defined the loader calls registry.initialize(root ?? document)
- * so that existing light-DOM elements in the subtree are upgraded.
  */
 export declare function setRegistry(registry: CustomElementRegistry, root?: Node): void;
 
@@ -162,8 +160,7 @@ export declare const setNonce: (nonce: string) => void;
 /**
  * Pre-configure the scoped CustomElementRegistry before the standalone bundle runs.
  * Call this before any component modules are imported. Components subsequently defined
- * via defineCustomElement() will use this registry (and call registry.initialize(root)
- * to upgrade existing light-DOM elements when root is provided).
+ * via defineCustomElement() will use this registry.
  */
 export declare const setRegistry: (registry: CustomElementRegistry, root?: Node) => void;
 

--- a/packages/core/src/declarations/stencil-public-runtime.ts
+++ b/packages/core/src/declarations/stencil-public-runtime.ts
@@ -2236,6 +2236,8 @@ export interface JSXAttributes<T = Element> {
 export interface CustomElementsDefineOptions {
   exclude?: string[];
   syncQueue?: boolean;
+  /** Scoped custom element registry to define components in. Defaults to the global registry. */
+  registry?: CustomElementRegistry;
   jmp?: (c: Function) => any;
   raf?: (c: FrameRequestCallback) => number;
   ael?: (

--- a/packages/core/src/runtime/bootstrap-loader.ts
+++ b/packages/core/src/runtime/bootstrap-loader.ts
@@ -28,6 +28,8 @@ import { appDidLoad } from './update-component';
 import { addHostEventListeners } from '.';
 import type * as d from '../declarations';
 export { setNonce } from 'virtual:platform';
+export { setRegistry } from './registry';
+import { getRegistry } from './registry';
 
 export const bootstrapLazy = (
   lazyBundles: d.LazyBundlesRuntimeData,
@@ -46,7 +48,7 @@ export const bootstrapLazy = (
   const endBootstrap = createTime('bootstrapLazy');
   const cmpTags: string[] = [];
   const exclude = options.exclude || [];
-  const customElements = win.customElements;
+  const _reg: CustomElementRegistry = options.registry ?? getRegistry();
   const head = win.document.head;
   const metaCharset = /*@__PURE__*/ head.querySelector('meta[charset]');
   const dataStyles = /*@__PURE__*/ win.document.createElement('style');
@@ -252,12 +254,15 @@ export const bootstrapLazy = (
 
       cmpMeta.$lazyBundleId$ = lazyBundle[0];
 
-      if (!exclude.includes(tagName) && !customElements.get(tagName)) {
+      if (!exclude.includes(tagName) && !_reg.get(tagName)) {
         cmpTags.push(tagName);
-        customElements.define(
-          tagName,
-          proxyComponent(HostElement as any, cmpMeta, PROXY_FLAGS.isElementConstructor) as any,
-        );
+        const proxied = proxyComponent(
+          HostElement as any,
+          cmpMeta,
+          PROXY_FLAGS.isElementConstructor,
+        ) as any;
+        proxied._registry = _reg;
+        _reg.define(tagName, proxied);
       }
     });
   });

--- a/packages/core/src/runtime/index.ts
+++ b/packages/core/src/runtime/index.ts
@@ -11,6 +11,7 @@ export { addHostEventListeners } from './host-listener';
 export { Mixin } from './mixin';
 export { getMode, setMode } from './mode';
 export { setNonce } from './nonce';
+export { setRegistry, getRegistry } from './registry';
 export { normalizeWatchers } from './normalize-watchers';
 export { parsePropertyValue } from './parse-property-value';
 export { setPlatformOptions } from './platform-options';

--- a/packages/core/src/runtime/registry.ts
+++ b/packages/core/src/runtime/registry.ts
@@ -1,0 +1,7 @@
+let _registry: CustomElementRegistry | undefined;
+
+export const setRegistry = (registry: CustomElementRegistry): void => {
+  _registry = registry;
+};
+
+export const getRegistry = (): CustomElementRegistry => _registry ?? customElements;

--- a/packages/core/src/runtime/vdom/vdom-render.ts
+++ b/packages/core/src/runtime/vdom/vdom-render.ts
@@ -10,10 +10,11 @@ import { BUILD } from 'virtual:app-data';
 import { consoleDevError, getHostRef, plt, win } from 'virtual:platform';
 import type * as d from '@stencil/core';
 
-import { CMP_FLAGS, HTML_NS, NODE_TYPES, SVG_NS } from '../../utils/constants';
+import { CMP_FLAGS, NODE_TYPES, SVG_NS } from '../../utils/constants';
 import { isDef } from '../../utils/helpers';
 import { patchParentNode } from '../dom-extras';
 import { getShadowRoot } from '../element';
+import { getRegistry } from '../registry';
 import { NODE_TYPE, PLATFORM_FLAGS, VNODE_FLAGS } from '../runtime-constants';
 import { effect } from '../signals';
 import {
@@ -137,23 +138,21 @@ const createElm = (oldParentVNode: d.VNode, newParentVNode: d.VNode, childIndex:
     }
 
     // create element
+    const tag =
+      !useNativeShadowDom && BUILD.slotRelocation && newVNode.$flags$ & VNODE_FLAGS.isSlotFallback
+        ? 'slot-fb'
+        : (newVNode.$tag$ as string);
+
+    const _reg = getRegistry();
+    const registryOpts =
+      _reg !== win.customElements && tag.includes('-')
+        ? ({ customElementRegistry: _reg } as ElementCreationOptions)
+        : undefined;
+
     elm = newVNode.$elm$ = (
-      BUILD.svg
-        ? win.document.createElementNS(
-            isSvgMode ? SVG_NS : HTML_NS,
-            !useNativeShadowDom &&
-              BUILD.slotRelocation &&
-              newVNode.$flags$ & VNODE_FLAGS.isSlotFallback
-              ? 'slot-fb'
-              : (newVNode.$tag$ as string),
-          )
-        : win.document.createElement(
-            !useNativeShadowDom &&
-              BUILD.slotRelocation &&
-              newVNode.$flags$ & VNODE_FLAGS.isSlotFallback
-              ? 'slot-fb'
-              : (newVNode.$tag$ as string),
-          )
+      BUILD.svg && isSvgMode
+        ? win.document.createElementNS(SVG_NS, tag)
+        : win.document.createElement(tag, registryOpts)
     ) as any;
 
     if (BUILD.svg && isSvgMode && newVNode.$tag$ === 'foreignObject') {

--- a/packages/core/src/utils/shadow-root.ts
+++ b/packages/core/src/utils/shadow-root.ts
@@ -20,6 +20,9 @@ export function createShadowRoot(this: HTMLElement, cmpMeta: d.ComponentRuntimeM
   const isClosed = BUILD.shadowModeClosed && !!(cmpMeta.$flags$ & CMP_FLAGS.shadowModeClosed);
   const opts: ShadowRootInit = { mode: isClosed ? 'closed' : 'open' };
 
+  const reg: CustomElementRegistry | undefined = (this.constructor as any)._registry;
+  if (reg) opts.customElementRegistry = reg;
+
   if (BUILD.shadowDelegatesFocus) {
     opts.delegatesFocus = !!(cmpMeta.$flags$ & CMP_FLAGS.shadowDelegatesFocus);
   }

--- a/packages/mock-doc/src/serialize-node.ts
+++ b/packages/mock-doc/src/serialize-node.ts
@@ -180,7 +180,9 @@ function* streamToHtml(
         if (
           tag === 'template' &&
           isShadowRoot &&
-          (attrName === 'shadowrootmode' || attrName === 'shadowrootdelegatesfocus')
+          (attrName === 'shadowrootmode' ||
+            attrName === 'shadowrootdelegatesfocus' ||
+            attrName === 'shadowrootcustomelementregistry')
         ) {
           continue;
         }
@@ -641,6 +643,7 @@ const BOOLEAN_ATTR = new Set([
   'reversed',
   'selected',
   'shadowrootclonable',
+  'shadowrootcustomelementregistry',
   'shadowrootdelegatesfocus',
   'shadowrootserializable',
 ]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,20 +7,20 @@ settings:
 catalogs:
   default:
     '@playwright/test':
-      specifier: ^1.52.0
-      version: 1.58.2
+      specifier: ^1.60.0
+      version: 1.60.0
     '@stencil/playwright':
       specifier: ~0.4.3
       version: 0.4.3
     '@stencil/vitest':
-      specifier: ^1.11.6
-      version: 1.11.6
+      specifier: ^1.12.1
+      version: 1.12.1
     '@vitest/browser':
-      specifier: ^4.1.1
-      version: 4.1.2
+      specifier: ^4.1.7
+      version: 4.1.7
     '@vitest/browser-playwright':
-      specifier: ^4.1.2
-      version: 4.1.2
+      specifier: ^4.1.7
+      version: 4.1.7
     playwright:
       specifier: ^1.58.0
       version: 1.58.2
@@ -31,11 +31,11 @@ catalogs:
       specifier: '>4.0.0 <7.0.0'
       version: 6.0.3
     vitest:
-      specifier: ^4.1.1
-      version: 4.1.2
+      specifier: ^4.1.7
+      version: 4.1.7
     vitest-environment-stencil:
-      specifier: ^1.11.6
-      version: 1.11.6
+      specifier: ^1.12.1
+      version: 1.12.1
 
 overrides:
   '@stencil/core': workspace:*
@@ -86,7 +86,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/core:
     dependencies:
@@ -162,7 +162,7 @@ importers:
         version: 4.0.0(prettier@3.8.1)
       '@stencil/vitest':
         specifier: 'catalog:'
-        version: 1.11.6(@stencil/mock-doc@packages+mock-doc)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)
+        version: 1.12.1(@stencil/mock-doc@packages+mock-doc)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
       prettier:
         specifier: ^3.5.0
         version: 3.8.1
@@ -171,10 +171,10 @@ importers:
         version: 0.22.0(@tsdown/css@0.22.0)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.34(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest-environment-stencil:
         specifier: 'catalog:'
-        version: 1.11.6(@stencil/mock-doc@packages+mock-doc)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)
+        version: 1.12.1(@stencil/mock-doc@packages+mock-doc)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
 
   packages/dev-server:
     dependencies:
@@ -205,10 +205,10 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       vitest-environment-stencil:
         specifier: 'catalog:'
-        version: 1.11.6(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)
+        version: 1.12.1(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
 
   packages/mock-doc:
     dependencies:
@@ -221,7 +221,7 @@ importers:
     devDependencies:
       '@stencil/vitest':
         specifier: 'catalog:'
-        version: 1.11.6(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)
+        version: 1.12.1(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
       tsdown:
         specifier: 'catalog:'
         version: 0.22.0(@tsdown/css@0.22.0)(oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.34(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
@@ -230,7 +230,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   test/build: {}
 
@@ -277,7 +277,7 @@ importers:
         version: 6.1.3
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   test/build/docs-json:
     dependencies:
@@ -334,7 +334,7 @@ importers:
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.58.2
+        version: 1.60.0
       serve:
         specifier: ^14.2.4
         version: 14.2.5
@@ -359,7 +359,7 @@ importers:
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.58.2
+        version: 1.60.0
       '@stencil/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -368,7 +368,7 @@ importers:
         version: link:../../../packages/mock-doc
       '@stencil/playwright':
         specifier: 'catalog:'
-        version: 0.4.3(@playwright/test@1.58.2)(@stencil/core@packages+core)
+        version: 0.4.3(@playwright/test@1.60.0)(@stencil/core@packages+core)
       '@stencil/react-output-target':
         specifier: ^0.0.9
         version: 0.0.9(@stencil/core@packages+core)
@@ -423,22 +423,22 @@ importers:
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.58.2
+        version: 1.60.0
       '@stencil/playwright':
         specifier: 'catalog:'
-        version: 0.4.3(@playwright/test@1.58.2)(@stencil/core@packages+core)
+        version: 0.4.3(@playwright/test@1.60.0)(@stencil/core@packages+core)
       '@stencil/vitest':
         specifier: 'catalog:'
-        version: 1.11.6(@playwright/test@1.58.2)(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)
+        version: 1.12.1(@playwright/test@1.60.0)(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   test/integration/prerender:
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.58.2
+        version: 1.60.0
       '@stencil/core':
         specifier: workspace:*
         version: link:../../../packages/core
@@ -459,7 +459,7 @@ importers:
         version: link:../../../packages/core
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   test/perf: {}
 
@@ -489,13 +489,13 @@ importers:
         version: 3.2.3(@stencil/core@packages+core)
       '@stencil/vitest':
         specifier: 'catalog:'
-        version: 1.11.6(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)
+        version: 1.12.1(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
       '@vitest/browser':
         specifier: 'catalog:'
-        version: 4.1.2(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.2)
+        version: 4.1.7(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.2(playwright@1.58.2)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.2)
+        version: 4.1.7(playwright@1.60.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
       bootstrap:
         specifier: ^5.3.3
         version: 5.3.8(@popperjs/core@2.11.8)
@@ -504,7 +504,7 @@ importers:
         version: 8.0.1
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   test/runtime/fixtures/external-base-classes:
     dependencies:
@@ -522,22 +522,22 @@ importers:
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.58.2
+        version: 1.60.0
       '@stencil/playwright':
         specifier: 'catalog:'
-        version: 0.4.3(@playwright/test@1.58.2)(@stencil/core@packages+core)
+        version: 0.4.3(@playwright/test@1.60.0)(@stencil/core@packages+core)
       '@stencil/vitest':
         specifier: 'catalog:'
-        version: 1.11.6(@playwright/test@1.58.2)(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)
+        version: 1.12.1(@playwright/test@1.60.0)(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
       '@vitest/browser':
         specifier: 'catalog:'
-        version: 4.1.2(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.2)
+        version: 4.1.7(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.2(playwright@1.58.2)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.2)
+        version: 4.1.7(playwright@1.60.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   test/special-config/external-runtime:
     dependencies:
@@ -547,28 +547,28 @@ importers:
     devDependencies:
       '@stencil/vitest':
         specifier: 'catalog:'
-        version: 1.11.6(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)
+        version: 1.12.1(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
       '@vitest/browser':
         specifier: 'catalog:'
-        version: 4.1.2(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.2)
+        version: 4.1.7(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.2(playwright@1.58.2)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.2)
+        version: 4.1.7(playwright@1.60.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   test/special-config/invisible-prehydration:
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.58.2
+        version: 1.60.0
       '@stencil/core':
         specifier: workspace:*
         version: link:../../../packages/core
       '@stencil/playwright':
         specifier: 'catalog:'
-        version: 0.4.3(@playwright/test@1.58.2)(@stencil/core@packages+core)
+        version: 0.4.3(@playwright/test@1.60.0)(@stencil/core@packages+core)
 
   test/special-config/signals:
     dependencies:
@@ -578,22 +578,22 @@ importers:
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.58.2
+        version: 1.60.0
       '@stencil/playwright':
         specifier: 'catalog:'
-        version: 0.4.3(@playwright/test@1.58.2)(@stencil/core@packages+core)
+        version: 0.4.3(@playwright/test@1.60.0)(@stencil/core@packages+core)
       '@stencil/vitest':
         specifier: 'catalog:'
-        version: 1.11.6(@playwright/test@1.58.2)(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)
+        version: 1.12.1(@playwright/test@1.60.0)(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
       '@vitest/browser':
         specifier: 'catalog:'
-        version: 4.1.2(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.2)
+        version: 4.1.7(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.2(playwright@1.58.2)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.2)
+        version: 4.1.7(playwright@1.60.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   test/special-config/slot-patching:
     dependencies:
@@ -603,16 +603,16 @@ importers:
     devDependencies:
       '@stencil/vitest':
         specifier: 'catalog:'
-        version: 1.11.6(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)
+        version: 1.12.1(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
       '@vitest/browser':
         specifier: 'catalog:'
-        version: 4.1.2(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.2)
+        version: 4.1.7(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
       '@vitest/browser-playwright':
         specifier: 'catalog:'
-        version: 4.1.2(playwright@1.58.2)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.2)
+        version: 4.1.7(playwright@1.60.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
       vitest:
         specifier: 'catalog:'
-        version: 4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+        version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
 
   test/special-config/standalone-devmode:
     dependencies:
@@ -624,13 +624,13 @@ importers:
     devDependencies:
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.58.2
+        version: 1.60.0
       '@stencil/core':
         specifier: workspace:*
         version: link:../../packages/core
       '@stencil/playwright':
         specifier: 'catalog:'
-        version: 0.4.3(@playwright/test@1.58.2)(@stencil/core@packages+core)
+        version: 0.4.3(@playwright/test@1.60.0)(@stencil/core@packages+core)
       file-saver:
         specifier: ^2.0.5
         version: 2.0.5
@@ -2108,8 +2108,8 @@ packages:
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
 
-  '@playwright/test@1.58.2':
-    resolution: {integrity: sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2544,8 +2544,8 @@ packages:
     peerDependencies:
       '@stencil/core': workspace:*
 
-  '@stencil/vitest@1.11.6':
-    resolution: {integrity: sha512-8aqZzN2O0bppsGJSqLetgzyATufRRSybKLctKuW93KtHED/WwJyS0U+8D9OqKEjxnopvSNO4QrvLWqntaqhvSw==}
+  '@stencil/vitest@1.12.1':
+    resolution: {integrity: sha512-5ke83kEpmyM0t+YUE1VSrAf608G5ZhliSWdOWehJ6sk0E9SnV8KNWoqBaEEDgUcordHF3z//uOrry5pmIBhl2Q==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
@@ -2660,22 +2660,22 @@ packages:
   '@videojs/xhr@2.6.0':
     resolution: {integrity: sha512-7J361GiN1tXpm+gd0xz2QWr3xNWBE+rytvo8J3KuggFaLg+U37gZQ2BuPLcnkfGffy2e+ozY70RHC8jt7zjA6Q==}
 
-  '@vitest/browser-playwright@4.1.2':
-    resolution: {integrity: sha512-N0Z2HzMLvMR6k/tWPTS6Q/DaRscrkax/f2f9DIbNQr+Cd1l4W4wTf/I6S983PAMr0tNqqoTL+xNkLh9M5vbkLg==}
+  '@vitest/browser-playwright@4.1.7':
+    resolution: {integrity: sha512-OlTlJej7YN6VwV7zJJoNeaCsctF+JXpzpZ4oBHUbrQFfIq+0KW2f07rprCLh9N/zRIZ0v4Mchn1QDDmWMUhPKw==}
     peerDependencies:
       playwright: '*'
-      vitest: 4.1.2
+      vitest: 4.1.7
 
-  '@vitest/browser@4.1.2':
-    resolution: {integrity: sha512-CwdIf90LNf1Zitgqy63ciMAzmyb4oIGs8WZ40VGYrWkssQKeEKr32EzO8MKUrDPPcPVHFI9oQ5ni2Hp24NaNRQ==}
+  '@vitest/browser@4.1.7':
+    resolution: {integrity: sha512-N2JFGfXoEGVAut+kHeru9dD4BUMq/q5xDvBARNl0tUsly3m5KglLOu8VO/6MkDfOlgxXTycojkt6gBKsuyR+IQ==}
     peerDependencies:
-      vitest: 4.1.2
+      vitest: 4.1.7
 
-  '@vitest/expect@4.1.2':
-    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
+  '@vitest/expect@4.1.7':
+    resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
 
-  '@vitest/mocker@4.1.2':
-    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
+  '@vitest/mocker@4.1.7':
+    resolution: {integrity: sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2685,20 +2685,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.2':
-    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
+  '@vitest/pretty-format@4.1.7':
+    resolution: {integrity: sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==}
 
-  '@vitest/runner@4.1.2':
-    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
+  '@vitest/runner@4.1.7':
+    resolution: {integrity: sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==}
 
-  '@vitest/snapshot@4.1.2':
-    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
+  '@vitest/snapshot@4.1.7':
+    resolution: {integrity: sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==}
 
-  '@vitest/spy@4.1.2':
-    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
+  '@vitest/spy@4.1.7':
+    resolution: {integrity: sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==}
 
-  '@vitest/utils@4.1.2':
-    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
+  '@vitest/utils@4.1.7':
+    resolution: {integrity: sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==}
 
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
@@ -2710,11 +2710,6 @@ packages:
   abstract-leveldown@0.12.4:
     resolution: {integrity: sha512-TOod9d5RDExo6STLMGa+04HGkl+TlMfbDnTyN93/ETJ9DpQ0DaYLqcMZlbXvdc4W3vVo1Qrl+WhSp8zvDsJ+jA==}
     deprecated: Superseded by abstract-level (https://github.com/Level/community#faq)
-
-  acorn@8.15.0:
-    resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
 
   acorn@8.16.0:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
@@ -3913,10 +3908,6 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
-  jiti@2.6.1:
-    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
-    hasBin: true
-
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
@@ -4506,8 +4497,18 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   playwright@1.58.2:
     resolution: {integrity: sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5139,17 +5140,9 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.0.4:
-    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
-    engines: {node: '>=18'}
-
   tinyexec@1.1.2:
     resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
     engines: {node: '>=18'}
-
-  tinyglobby@0.2.15:
-    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
-    engines: {node: '>=12.0.0'}
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
@@ -5402,23 +5395,25 @@ packages:
       yaml:
         optional: true
 
-  vitest-environment-stencil@1.11.6:
-    resolution: {integrity: sha512-HQzfsZ9WWqvlK3k/5PMUXYmiN2H29dLlM7oKg75/nMoZv0u5DeU5Xs6vTMxqePzXbCRvG/HW0SLUMQNRWnC4EQ==}
+  vitest-environment-stencil@1.12.1:
+    resolution: {integrity: sha512-38mjt32BcjhT08SdVkQlTS1VhQe6HTFdVk0n8PETATxVEyeLPahihKOMmjhHRwzc7xfWsP+nW04NqvPobtQNJg==}
     peerDependencies:
       '@stencil/core': workspace:*
 
-  vitest@4.1.2:
-    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+  vitest@4.1.7:
+    resolution: {integrity: sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.2
-      '@vitest/browser-preview': 4.1.2
-      '@vitest/browser-webdriverio': 4.1.2
-      '@vitest/ui': 4.1.2
+      '@vitest/browser-playwright': 4.1.7
+      '@vitest/browser-preview': 4.1.7
+      '@vitest/browser-webdriverio': 4.1.7
+      '@vitest/coverage-istanbul': 4.1.7
+      '@vitest/coverage-v8': 4.1.7
+      '@vitest/ui': 4.1.7
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -5434,6 +5429,10 @@ packages:
       '@vitest/browser-preview':
         optional: true
       '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
         optional: true
       '@vitest/ui':
         optional: true
@@ -6753,9 +6752,9 @@ snapshots:
       '@parcel/watcher-win32-ia32': 2.5.6
       '@parcel/watcher-win32-x64': 2.5.6
 
-  '@playwright/test@1.58.2':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.58.2
+      playwright: 1.60.0
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -6998,9 +6997,9 @@ snapshots:
       '@rollup/rollup-win32-arm64-msvc': 4.44.0
       '@rollup/rollup-win32-x64-msvc': 4.44.0
 
-  '@stencil/playwright@0.4.3(@playwright/test@1.58.2)(@stencil/core@packages+core)':
+  '@stencil/playwright@0.4.3(@playwright/test@1.60.0)(@stencil/core@packages+core)':
     dependencies:
-      '@playwright/test': 1.58.2
+      '@playwright/test': 1.60.0
       '@stencil/core': link:packages/core
       deepmerge: 4.3.1
       find-up: 8.0.0
@@ -7014,53 +7013,53 @@ snapshots:
       '@stencil/core': link:packages/core
       sass-embedded: 1.97.3
 
-  '@stencil/vitest@1.11.6(@playwright/test@1.58.2)(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)':
+  '@stencil/vitest@1.12.1(@playwright/test@1.60.0)(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)':
     dependencies:
       '@stencil/core': link:packages/core
-      jiti: 2.6.1
+      jiti: 2.7.0
       local-pkg: 1.1.2
-      vitest: 4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
-      vitest-environment-stencil: 1.11.6(@playwright/test@1.58.2)(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest-environment-stencil: 1.12.1(@playwright/test@1.60.0)(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
     optionalDependencies:
-      '@playwright/test': 1.58.2
-      '@vitest/browser-playwright': 4.1.2(playwright@1.58.2)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.2)
+      '@playwright/test': 1.60.0
+      '@vitest/browser-playwright': 4.1.7(playwright@1.60.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
       jsdom: 28.0.0
-      playwright: 1.58.2
+      playwright: 1.60.0
 
-  '@stencil/vitest@1.11.6(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)':
+  '@stencil/vitest@1.12.1(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)':
     dependencies:
       '@stencil/core': link:packages/core
-      jiti: 2.6.1
+      jiti: 2.7.0
       local-pkg: 1.1.2
-      vitest: 4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
-      vitest-environment-stencil: 1.11.6(@stencil/core@packages+core)
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest-environment-stencil: 1.12.1(@stencil/core@packages+core)
     optionalDependencies:
-      '@vitest/browser-playwright': 4.1.2(playwright@1.58.2)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.2)
+      '@vitest/browser-playwright': 4.1.7(playwright@1.60.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
       jsdom: 28.0.0
-      playwright: 1.58.2
+      playwright: 1.60.0
 
-  '@stencil/vitest@1.11.6(@stencil/mock-doc@packages+mock-doc)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)':
+  '@stencil/vitest@1.12.1(@stencil/mock-doc@packages+mock-doc)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)':
     dependencies:
-      jiti: 2.6.1
+      jiti: 2.7.0
       local-pkg: 1.1.2
-      vitest: 4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
-      vitest-environment-stencil: 1.11.6(@stencil/mock-doc@packages+mock-doc)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest-environment-stencil: 1.12.1(@stencil/mock-doc@packages+mock-doc)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
     optionalDependencies:
       '@stencil/mock-doc': link:packages/mock-doc
-      '@vitest/browser-playwright': 4.1.2(playwright@1.58.2)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.2)
+      '@vitest/browser-playwright': 4.1.7(playwright@1.60.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
       jsdom: 28.0.0
-      playwright: 1.58.2
+      playwright: 1.60.0
 
-  '@stencil/vitest@1.11.6(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)':
+  '@stencil/vitest@1.12.1(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)':
     dependencies:
-      jiti: 2.6.1
+      jiti: 2.7.0
       local-pkg: 1.1.2
-      vitest: 4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
-      vitest-environment-stencil: 1.11.6(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest-environment-stencil: 1.12.1(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
     optionalDependencies:
-      '@vitest/browser-playwright': 4.1.2(playwright@1.58.2)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.2)
+      '@vitest/browser-playwright': 4.1.7(playwright@1.60.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
       jsdom: 28.0.0
-      playwright: 1.58.2
+      playwright: 1.60.0
 
   '@tsdown/css@0.22.0(jiti@2.7.0)(postcss@8.5.15)(sass-embedded@1.97.3)(sass@1.97.3)(tsdown@0.22.0)(tsx@4.21.0)(yaml@2.9.0)':
     dependencies:
@@ -7147,29 +7146,29 @@ snapshots:
       global: 4.4.0
       is-function: 1.0.2
 
-  '@vitest/browser-playwright@4.1.2(playwright@1.58.2)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.2)':
+  '@vitest/browser-playwright@4.1.7(playwright@1.60.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)':
     dependencies:
-      '@vitest/browser': 4.1.2(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.2)
-      '@vitest/mocker': 4.1.2(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
-      playwright: 1.58.2
+      '@vitest/browser': 4.1.7(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
+      '@vitest/mocker': 4.1.7(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      playwright: 1.60.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.1.2(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.2)':
+  '@vitest/browser@4.1.7(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)':
     dependencies:
       '@blazediff/core': 1.9.1
-      '@vitest/mocker': 4.1.2(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@vitest/utils': 4.1.2
+      '@vitest/mocker': 4.1.7(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/utils': 4.1.7
       magic-string: 0.30.21
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      vitest: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -7177,44 +7176,44 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/expect@4.1.2':
+  '@vitest/expect@4.1.7':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.2(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.7(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.2
+      '@vitest/spy': 4.1.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
 
-  '@vitest/pretty-format@4.1.2':
+  '@vitest/pretty-format@4.1.7':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.2':
+  '@vitest/runner@4.1.7':
     dependencies:
-      '@vitest/utils': 4.1.2
+      '@vitest/utils': 4.1.7
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.2':
+  '@vitest/snapshot@4.1.7':
     dependencies:
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/utils': 4.1.7
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.2': {}
+  '@vitest/spy@4.1.7': {}
 
-  '@vitest/utils@4.1.2':
+  '@vitest/utils@4.1.7':
     dependencies:
-      '@vitest/pretty-format': 4.1.2
+      '@vitest/pretty-format': 4.1.7
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -7225,8 +7224,6 @@ snapshots:
   abstract-leveldown@0.12.4:
     dependencies:
       xtend: 3.0.0
-
-  acorn@8.15.0: {}
 
   acorn@8.16.0: {}
 
@@ -8557,8 +8554,6 @@ snapshots:
 
   isobject@3.0.1: {}
 
-  jiti@2.6.1: {}
-
   jiti@2.7.0: {}
 
   js-tokens@4.0.0: {}
@@ -8949,7 +8944,7 @@ snapshots:
 
   mlly@1.8.0:
     dependencies:
-      acorn: 8.15.0
+      acorn: 8.16.0
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
@@ -9273,9 +9268,17 @@ snapshots:
 
   playwright-core@1.58.2: {}
 
+  playwright-core@1.60.0: {}
+
   playwright@1.58.2:
     dependencies:
       playwright-core: 1.58.2
+    optionalDependencies:
+      fsevents: 2.3.2
+
+  playwright@1.60.0:
+    dependencies:
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -9927,14 +9930,7 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.0.4: {}
-
   tinyexec@1.1.2: {}
-
-  tinyglobby@0.2.15:
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
 
   tinyglobby@0.2.16:
     dependencies:
@@ -10156,10 +10152,10 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.9.0
 
-  vitest-environment-stencil@1.11.6(@playwright/test@1.58.2)(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2):
+  vitest-environment-stencil@1.12.1(@playwright/test@1.60.0)(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7):
     dependencies:
       '@stencil/core': link:packages/core
-      '@stencil/vitest': 1.11.6(@playwright/test@1.58.2)(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)
+      '@stencil/vitest': 1.12.1(@playwright/test@1.60.0)(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
     transitivePeerDependencies:
       - '@playwright/test'
       - '@stencil/mock-doc'
@@ -10172,15 +10168,15 @@ snapshots:
       - playwright
       - vitest
 
-  vitest-environment-stencil@1.11.6(@stencil/core@packages+core):
+  vitest-environment-stencil@1.12.1(@stencil/core@packages+core):
     dependencies:
       '@stencil/core': link:packages/core
-      '@stencil/vitest': 1.11.6(@playwright/test@1.58.2)(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)
+      '@stencil/vitest': 1.12.1(@playwright/test@1.60.0)(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
 
-  vitest-environment-stencil@1.11.6(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2):
+  vitest-environment-stencil@1.12.1(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7):
     dependencies:
       '@stencil/core': link:packages/core
-      '@stencil/vitest': 1.11.6(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)
+      '@stencil/vitest': 1.12.1(@stencil/core@packages+core)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
     transitivePeerDependencies:
       - '@playwright/test'
       - '@stencil/mock-doc'
@@ -10193,9 +10189,9 @@ snapshots:
       - playwright
       - vitest
 
-  vitest-environment-stencil@1.11.6(@stencil/mock-doc@packages+mock-doc)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2):
+  vitest-environment-stencil@1.12.1(@stencil/mock-doc@packages+mock-doc)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7):
     dependencies:
-      '@stencil/vitest': 1.11.6(@stencil/mock-doc@packages+mock-doc)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)
+      '@stencil/vitest': 1.12.1(@stencil/mock-doc@packages+mock-doc)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
     transitivePeerDependencies:
       - '@playwright/test'
       - '@stencil/mock-doc'
@@ -10208,9 +10204,9 @@ snapshots:
       - playwright
       - vitest
 
-  vitest-environment-stencil@1.11.6(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2):
+  vitest-environment-stencil@1.12.1(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7):
     dependencies:
-      '@stencil/vitest': 1.11.6(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(playwright@1.58.2)(vitest@4.1.2)
+      '@stencil/vitest': 1.12.1(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
     transitivePeerDependencies:
       - '@playwright/test'
       - '@stencil/mock-doc'
@@ -10223,15 +10219,15 @@ snapshots:
       - playwright
       - vitest
 
-  vitest@4.1.2(@types/node@25.9.1)(@vitest/browser-playwright@4.1.2)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
+  vitest@4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.2
-      '@vitest/runner': 4.1.2
-      '@vitest/snapshot': 4.1.2
-      '@vitest/spy': 4.1.2
-      '@vitest/utils': 4.1.2
+      '@vitest/expect': 4.1.7
+      '@vitest/mocker': 4.1.7(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.7
+      '@vitest/runner': 4.1.7
+      '@vitest/snapshot': 4.1.7
+      '@vitest/spy': 4.1.7
+      '@vitest/utils': 4.1.7
       es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -10240,14 +10236,14 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.15
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
       vite: 6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.9.1
-      '@vitest/browser-playwright': 4.1.2(playwright@1.58.2)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.2)
+      '@vitest/browser-playwright': 4.1.7(playwright@1.60.0)(vite@6.4.1(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))(vitest@4.1.7)
       jsdom: 28.0.0
     transitivePeerDependencies:
       - msw

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,13 +3,13 @@ packages:
   - 'test/**/*'
 
 catalog:
-  '@playwright/test': ^1.52.0
+  '@playwright/test': ^1.60.0
   '@stencil/playwright': '~0.4.3'
-  '@stencil/vitest': '^1.11.6'
-  '@vitest/browser': ^4.1.1
-  '@vitest/browser-playwright': ^4.1.2
+  '@stencil/vitest': '^1.12.1'
+  '@vitest/browser': ^4.1.7
+  '@vitest/browser-playwright': ^4.1.7
   playwright: ^1.58.0
   tsdown: '>=0.21.0 <1.0.0'
   typescript: '>4.0.0 <7.0.0'
-  vitest: ^4.1.1
-  'vitest-environment-stencil': '^1.11.6'
+  vitest: ^4.1.7
+  'vitest-environment-stencil': '^1.12.1'

--- a/test/runtime/src/scer/scer.spec.tsx
+++ b/test/runtime/src/scer/scer.spec.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach } from '@stencil/vitest';
+import { render } from '@stencil/vitest';
+
+import { scerRegistry } from './test-registry';
+
+describe('SCER', () => {
+  it('defines components in scoped registry, not global customElements', async () => {
+    // for the standalone loader, nothing is initialized until the element is found in the DOM
+    await render(`<shadow-dom-basic />`, { registry: scerRegistry });
+    expect(scerRegistry.get('shadow-dom-basic')).toBeDefined();
+    expect(customElements.get('shadow-dom-basic')).toBeUndefined();
+  });
+
+  it('defines light-DOM components in scoped registry, not global', async () => {
+    // for the standalone loader, nothing is initialized until the element is found in the DOM
+    await render(`<element-cmp />`, { registry: scerRegistry });
+    expect(scerRegistry.get('element-cmp')).toBeDefined();
+    expect(customElements.get('element-cmp')).toBeUndefined();
+  });
+
+  it('renders a shadow component via scoped registry', async () => {
+    const { root } = await render(`<shadow-dom-basic />`, { registry: scerRegistry });
+    expect(root.tagName.toLowerCase()).toBe('shadow-dom-basic');
+    expect(root.classList.contains('hydrated')).toBe(true);
+    expect(root.shadowRoot).not.toBeNull();
+  });
+
+  it('shadow root is associated with the scoped registry', async () => {
+    const { root } = await render(`<shadow-dom-basic />`, { registry: scerRegistry });
+    expect((root.shadowRoot as any).customElementRegistry).toBe(scerRegistry);
+  });
+
+  it('renders a scoped-encapsulation component via scoped registry', async () => {
+    const { root } = await render(`<scoped-basic />`, { registry: scerRegistry });
+    expect(root.tagName.toLowerCase()).toBe('scoped-basic');
+    expect(root.classList.contains('hydrated')).toBe(true);
+  });
+
+  it('elements appended to the initialized subtree upgrade from scoped registry', async () => {
+    const el = document.createElement('element-cmp', {
+      customElementRegistry: scerRegistry,
+    }) as any & {
+      componentOnReady?: () => Promise<void>;
+    };
+    el.setAttribute('data-scer-test', '');
+    document.body.appendChild(el);
+    await scerRegistry.whenDefined('element-cmp');
+    await el.componentOnReady?.();
+    expect(el.classList.contains('hydrated')).toBe(true);
+  });
+});

--- a/test/runtime/src/scer/test-registry.ts
+++ b/test/runtime/src/scer/test-registry.ts
@@ -1,0 +1,1 @@
+export const scerRegistry = new CustomElementRegistry();

--- a/test/runtime/vitest-setup-scer-lazy.ts
+++ b/test/runtime/vitest-setup-scer-lazy.ts
@@ -1,0 +1,9 @@
+import './hydrated.css';
+import { setRegistry, setNonce, defineCustomElements } from './dist/lazy/loader';
+import { scerRegistry } from './src/scer/test-registry';
+
+setNonce('test-csp-nonce');
+setRegistry(scerRegistry);
+await defineCustomElements();
+
+export {};

--- a/test/runtime/vitest-setup-scer-standalone.ts
+++ b/test/runtime/vitest-setup-scer-standalone.ts
@@ -1,0 +1,12 @@
+/// <reference types="@stencil/core" />
+import './hydrated.css';
+import { setNonce, setRegistry } from './dist/custom-elements/';
+import { scerRegistry } from './src/scer/test-registry';
+
+setNonce('test-csp-nonce');
+setRegistry(scerRegistry);
+
+// Load bundled custom elements via autoloader
+await import('./dist/custom-elements/loader.js');
+
+export {};

--- a/test/runtime/vitest.config.ts
+++ b/test/runtime/vitest.config.ts
@@ -41,7 +41,7 @@ export default defineVitestConfig({
           },
         },
       },
-      // Scoped Custom Element Registry tests — lazy loader with pre-set scoped registry
+      // Scoped Custom Element Registry tests - lazy loader
       {
         test: {
           name: 'scer-lazy',
@@ -55,7 +55,7 @@ export default defineVitestConfig({
           },
         },
       },
-      // Scoped Custom Element Registry tests — standalone defineCustomElement per-test
+      // Scoped Custom Element Registry tests - standalone
       {
         test: {
           name: 'scer-standalone',

--- a/test/runtime/vitest.config.ts
+++ b/test/runtime/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineVitestConfig({
         test: {
           name: 'lazy',
           include: ['src/**/*.spec.{ts,tsx}'],
+          exclude: ['src/scer/**'],
           setupFiles: ['./vitest-setup-dist.ts'],
           env: {
             TEST_PROJECT: 'dist',
@@ -27,10 +28,39 @@ export default defineVitestConfig({
         test: {
           name: 'standalone',
           include: ['src/**/*.spec.{ts,tsx}'],
+          exclude: ['src/scer/**'],
           setupFiles: ['./vitest-setup-custom-elements.ts'],
           env: {
             TEST_PROJECT: 'custom-elements',
           },
+          browser: {
+            enabled: true,
+            provider: playwright(),
+            headless: true,
+            instances: [{ browser: 'chromium' }],
+          },
+        },
+      },
+      // Scoped Custom Element Registry tests — lazy loader with pre-set scoped registry
+      {
+        test: {
+          name: 'scer-lazy',
+          include: ['src/scer/**/*.spec.{ts,tsx}'],
+          setupFiles: ['./vitest-setup-scer-lazy.ts'],
+          browser: {
+            enabled: true,
+            provider: playwright(),
+            headless: true,
+            instances: [{ browser: 'chromium' }],
+          },
+        },
+      },
+      // Scoped Custom Element Registry tests — standalone defineCustomElement per-test
+      {
+        test: {
+          name: 'scer-standalone',
+          include: ['src/scer/**/*.spec.{ts,tsx}'],
+          setupFiles: ['./vitest-setup-scer-standalone.ts'],
           browser: {
             enabled: true,
             provider: playwright(),


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## Scoped Custom Element Registries (SCER)

Components can now be defined in a scoped `CustomElementRegistry` instead of `window.customElements` - the primary mechanism for avoiding tag name conflicts when multiple component libraries (or versions) coexist on the same page.

Requires native SCER support - [check browser support](https://caniuse.com/wf-scoped-custom-element-registries)

### Usage

**Lazy loader**

```js
import { defineCustomElements, setRegistry } from 'my-lib/loader';

const registry = new CustomElementRegistry();
setRegistry(registry);
await defineCustomElements();
```

**Standalone**

```js
import { defineCustomElement } from 'my-lib/standalone';

const registry = new CustomElementRegistry();
defineCustomElement({ registry });
```

**Two libraries, no conflicts**

```js
import { setRegistry as setV1, defineCustomElements as defineV1 } from 'lib-v1/loader';
import { setRegistry as setV2, defineCustomElements as defineV2 } from 'lib-v2/loader';

setV1(new CustomElementRegistry());
setV2(new CustomElementRegistry());
await Promise.all([defineV1(), defineV2()]);

// Both define <my-button> - no "already defined" error
```

- Shadow roots are associated with the scoped registry so nested components inside shadow DOM resolve from the correct registry
- All elements created by Stencil's vdom renderer use the scoped registry; nested custom elements in both shadow and non-shadow components upgrade correctly

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
