### PR TITLE
fix(mock-doc): add File global for tests

### DIFF
--- a/src/mock-doc/file.ts
+++ b/src/mock-doc/file.ts
@@ -1,0 +1,52 @@
+const NativeBlob = typeof Blob === 'function' ? Blob : null;
+
+class MockBlob {
+  readonly size: number;
+  readonly type: string;
+
+  constructor(blobParts: BlobPart[] = [], options: BlobPropertyBag = {}) {
+    this.size = blobParts.reduce((total, part) => {
+      if (typeof part === 'string') {
+        return total + part.length;
+      }
+      if (part instanceof ArrayBuffer) {
+        return total + part.byteLength;
+      }
+      if (ArrayBuffer.isView(part)) {
+        return total + part.byteLength;
+      }
+      return total + ((part as Blob).size ?? 0);
+    }, 0);
+    this.type = options.type?.toLowerCase() ?? '';
+  }
+
+  async arrayBuffer() {
+    return new ArrayBuffer(0);
+  }
+
+  slice() {
+    return new MockBlob([], { type: this.type });
+  }
+
+  async text() {
+    return '';
+  }
+}
+
+const BlobBase = NativeBlob ?? MockBlob;
+
+export class MockFile extends BlobBase {
+  readonly lastModified: number;
+  readonly name: string;
+  readonly webkitRelativePath = '';
+
+  constructor(fileBits: BlobPart[] = [], fileName = '', options: FilePropertyBag = {}) {
+    super(fileBits, options);
+    this.name = String(fileName);
+    this.lastModified = options.lastModified ?? Date.now();
+  }
+
+  get [Symbol.toStringTag]() {
+    return 'File';
+  }
+}

--- a/src/mock-doc/global.ts
+++ b/src/mock-doc/global.ts
@@ -17,6 +17,7 @@ import {
   MockUListElement,
 } from './element';
 import { MockCustomEvent, MockEvent, MockFocusEvent, MockKeyboardEvent, MockMouseEvent } from './event';
+import { MockFile } from './file';
 import { MockHeaders } from './headers';
 import { MockDOMParser } from './parser';
 import { MockRequest, MockResponse } from './request-response';
@@ -163,6 +164,7 @@ const GLOBAL_CONSTRUCTORS: [string, any][] = [
   ['DocumentFragment', MockDocumentFragment],
   ['DOMParser', MockDOMParser],
   ['Event', MockEvent],
+  ['File', MockFile],
   ['FocusEvent', MockFocusEvent],
   ['Headers', MockHeaders],
   ['KeyboardEvent', MockKeyboardEvent],

--- a/src/mock-doc/index.ts
+++ b/src/mock-doc/index.ts
@@ -3,6 +3,7 @@ export { MockComment } from './comment-node';
 export { NODE_TYPES } from './constants';
 export { createDocument, createFragment, MockDocument, resetDocument } from './document';
 export { MockCustomEvent, MockKeyboardEvent, MockMouseEvent } from './event';
+export { MockFile } from './file';
 export { patchWindow, setupGlobal, teardownGlobal } from './global';
 export { MockHeaders } from './headers';
 export { MockElement, MockHTMLElement, MockNode, MockTextNode } from './node';

--- a/src/mock-doc/test/global.spec.ts
+++ b/src/mock-doc/test/global.spec.ts
@@ -28,6 +28,21 @@ describe('global', () => {
     expect(Response).toBeDefined();
   });
 
+  it('File', () => {
+    expect(File).toBeDefined();
+    expect(window.File).toBeDefined();
+
+    const file = new File(['whatever'], 'myFile.png', {
+      lastModified: 123,
+      type: 'image/png',
+    });
+
+    expect(file.name).toBe('myFile.png');
+    expect(file.type).toBe('image/png');
+    expect(file.lastModified).toBe(123);
+    expect(file.size).toBe(8);
+  });
+
   it('Parse', () => {
     expect(DOMParser).toBeDefined();
   });

--- a/src/testing/test/functional.spec.tsx
+++ b/src/testing/test/functional.spec.tsx
@@ -13,6 +13,22 @@ describe('testing function and class components', () => {
     expect(page.root).toEqualHtml(`<div>Hello World</div>`);
   });
 
+  it('can construct a File after rendering a spec page', async () => {
+    const MyFunctionalComponent = () => <div>Hello World</div>;
+    await newSpecPage({
+      components: [MyFunctionalComponent],
+      template: () => <MyFunctionalComponent></MyFunctionalComponent>,
+    });
+
+    const file = new File(['whatever'], 'myFile.png', {
+      type: 'image/png',
+    });
+
+    expect(file.name).toBe('myFile.png');
+    expect(file.type).toBe('image/png');
+    expect(file.size).toBe(8);
+  });
+
   it('can render a single functional component with props', async () => {
     const MyFunctionalComponent = (props: { foo: 'bar' }) => <div>{props.foo}</div>;
     const page: SpecPage = await newSpecPage({


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->

## What is the current behavior?

Stencil's mock DOM test environment exposes browser-like globals such as `Event`, `Request`, and `Response`, but it does not expose `File`.

As a result, unit tests that construct a browser `File` object can fail with `ReferenceError: File is not defined`.

GitHub Issue Number: #3539

## What is the new behavior?

Adds a mock `File` constructor to Stencil's mock DOM globals.

This allows Stencil unit tests to call `new File(...)` in the test environment, including after rendering with `newSpecPage()`.

The PR also adds regression coverage for:
- `File` being available on the test global and `window`
- constructing a `File` with `name`, `type`, `lastModified`, and `size`
- constructing a `File` after rendering a spec page

## Documentation

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

- `npm run prettier.base -- --check src/mock-doc/file.ts src/mock-doc/global.ts src/mock-doc/index.ts src/mock-doc/test/global.spec.ts src/testing/test/functional.spec.tsx`
- `npx eslint src/mock-doc/file.ts src/mock-doc/global.ts src/mock-doc/index.ts src/mock-doc/test/global.spec.ts src/testing/test/functional.spec.tsx`
- `npm run tsc.prod`

## Other information

Fixes #3539.