### PR TITLE
chore: v5 sensible  `hydrateClientSide` default & collection meta handling for `externalRuntime: true`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,4 +28,4 @@ Generally, non-trivial changes should pass -
 
 To run a specific unit test: `pnpm -F PACKAGE_NAME test TEST_NAME`
 
-When adding debug / console.log messaging, do not remove it until it has been confirmed that the issue has been resolved by the user. 
+When stuck on any problem, try adding debug logging. Ask the user to paste the results if need be. Having added debug / console.log messaging, do not remove them until it has been confirmed that the issue has been resolved by the user. 

--- a/packages/core/src/app-data/index.ts
+++ b/packages/core/src/app-data/index.ts
@@ -77,7 +77,7 @@ export const BUILD: BuildConditionals = {
   isDev: false,
   isTesting: false,
   hydrateServerSide: false,
-  hydrateClientSide: false,
+  hydrateClientSide: true,
   lifecycleDOMEvents: false,
   lazyLoad: false,
   profile: false,

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-collection.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-collection.spec.ts
@@ -49,6 +49,44 @@ describe('Stencil Collection output target', () => {
     vi.restoreAllMocks();
   });
 
+  describe('app-data.js hydrateClientSide flag', () => {
+    const collectionTarget: d.OutputTargetCollection = {
+      type: 'collection',
+      dir: '/dist/collection',
+    };
+    const appDataPath = '/dist/collection/app-data.js';
+
+    it('sets hydrateClientSide: true when an SSR output target is present', async () => {
+      const config = mockValidatedConfig({
+        srcDir: '/src',
+        bundles: [],
+        outputTargets: [collectionTarget, { type: 'ssr', dir: '/dist/ssr' } as d.OutputTargetSsr],
+      });
+      const compilerCtx = mockCompilerCtx(config);
+      const buildCtx = mockBuildCtx(config, compilerCtx);
+
+      await outputCollection(config, compilerCtx, buildCtx, changedModules);
+
+      const content = await compilerCtx.fs.readFile(appDataPath);
+      expect(content).toContain('"hydrateClientSide": true');
+    });
+
+    it('sets hydrateClientSide: false when no SSR output target is present', async () => {
+      const config = mockValidatedConfig({
+        srcDir: '/src',
+        bundles: [],
+        outputTargets: [collectionTarget],
+      });
+      const compilerCtx = mockCompilerCtx(config);
+      const buildCtx = mockBuildCtx(config, compilerCtx);
+
+      await outputCollection(config, compilerCtx, buildCtx, changedModules);
+
+      const content = await compilerCtx.fs.readFile(appDataPath);
+      expect(content).toContain('"hydrateClientSide": false');
+    });
+  });
+
   describe('transform aliased import paths', () => {
     // These tests ensure that the transformer for import paths is called regardless
     // of the config value (the function will decide whether or not to actually do anything) to avoid

--- a/packages/core/src/compiler/output-targets/collection/index.ts
+++ b/packages/core/src/compiler/output-targets/collection/index.ts
@@ -8,6 +8,7 @@ import {
   flatOne,
   generatePreamble,
   isOutputTargetCollection,
+  isOutputTargetSsr,
   join,
   normalizePath,
   relative,
@@ -147,6 +148,8 @@ const serializeCollectionManifest = (
     .flatMap((mod) => mod.cmps);
 
   const buildFlags = getBuildFeatures(localCmps) as d.BuildConditionals;
+
+  buildFlags.hydrateClientSide = config.outputTargets.some(isOutputTargetSsr);
 
   // Apply config-driven runtime flags (not build-mode flags like isDev/isTesting)
   const ldp = config.compat?.lightDomPatches ?? true;


### PR DESCRIPTION
…a handling for `externalRuntime: true`

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
