### PR TITLE
fix(compiler): handle constructor overloads

### DIFF
--- a/src/compiler/transformers/test/transform-utils.spec.ts
+++ b/src/compiler/transformers/test/transform-utils.spec.ts
@@ -306,6 +306,41 @@ describe('transform-utils', () => {
       );
     });
 
+    it('updates the implementation constructor when overload signatures are present', () => {
+      const sourceFile = ts.createSourceFile(
+        'dummy.ts',
+        `class MyClass extends BaseClass {
+          constructor(value: string);
+          constructor(value?: string) {
+            super();
+            this.value = value;
+          }
+        }`,
+        ts.ScriptTarget.ESNext,
+        true,
+        ts.ScriptKind.TS,
+      );
+      const classNode = sourceFile.statements.find(ts.isClassDeclaration);
+      if (!classNode) {
+        throw new Error('Expected a class declaration');
+      }
+      const ctorStatements = [
+        ts.factory.createExpressionStatement(
+          ts.factory.createCallExpression(ts.factory.createIdentifier('someMethod'), undefined, []),
+        ),
+      ];
+
+      const updatedMembers = updateConstructor(classNode, Array.from(classNode.members), ctorStatements);
+      const constructors = updatedMembers.filter(ts.isConstructorDeclaration);
+
+      expect(constructors).toHaveLength(2);
+      expect(constructors[0].body).toBeUndefined();
+      expect(constructors[1].body?.statements).toHaveLength(3);
+      expect(printClassMembers(classNode, updatedMembers)).toBe(
+        `class MyClass extends BaseClass { constructor(value: string); constructor(value?: string) {  super();  someMethod();  this.value = value; }}`,
+      );
+    });
+
     it('adds false argument to super call when no parameters are provided', () => {
       const classNode = ts.factory.createClassDeclaration(
         [],

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -1228,7 +1228,7 @@ export const updateConstructor = (
   parameters?: ts.ParameterDeclaration[],
   includeFalseArg?: boolean,
 ): ts.ClassElement[] => {
-  const constructorIndex = classMembers.findIndex((m) => m.kind === ts.SyntaxKind.Constructor);
+  const constructorIndex = classMembers.findIndex((m) => ts.isConstructorDeclaration(m) && m.body != null);
   const constructorMethod = classMembers[constructorIndex];
 
   if (constructorIndex < 0 && !statements?.length && !needsSuper(classNode)) return classMembers;


### PR DESCRIPTION
## What is the current behavior?

GitHub Issue Number: fixes #6712

`updateConstructor` finds the first constructor declaration in a class. For classes with constructor overloads, that first declaration is an overload signature without a body, so updating derived classes can crash while trying to merge constructor statements.

## What is the new behavior?

`updateConstructor` now updates the constructor implementation (the constructor declaration with a body) instead of overload signatures. A regression test verifies overload signatures are preserved while generated statements are merged into the implementation constructor.

## Documentation

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

- `PUPPETEER_SKIP_DOWNLOAD=true npm ci`
- `PUPPETEER_SKIP_DOWNLOAD=true npm run install.jest`
- `npm run build`
- `npm run test.jest -- src/compiler/transformers/test/transform-utils.spec.ts --runInBand`
- `npx prettier --write src/compiler/transformers/transform-utils.ts src/compiler/transformers/test/transform-utils.spec.ts`
- `git diff --check HEAD~1..HEAD`

## Other information

The fix intentionally selects a constructor with a body so TypeScript overload signatures remain signature-only declarations.
