### PR TITLE
fix(compiler): escape backslashes before other escape sequences in styles

### DIFF
--- a/src/compiler/style/css-to-esm.ts
+++ b/src/compiler/style/css-to-esm.ts
@@ -165,18 +165,25 @@ const generateTransformCssToEsm = (
 ): d.TransformCssToEsmOutput => {
   const s = new MagicString('');
 
-  // Replace literal newlines/tabs/returns with spaces to avoid them becoming escape sequences
-  // Then handle other special characters and escape backslashes last
+  // Escape backslashes first so the escape sequences added below are not
+  // re-escaped afterwards. Escaping backslashes last would turn the
+  // escaped backtick produced below back into an unescaped backtick,
+  // which terminates the generated template literal early.
+  // Then replace literal newlines/tabs/returns with spaces, keep control
+  // characters visible as escape sequences in the runtime CSS string,
+  // and escape the remaining characters that have a special meaning
+  // inside a template literal (backticks and dollar-brace).
   results.styleText = results.styleText
+    .replace(/\\/g, '\\\\')
     .replace(/\n/g, ' ')
     .replace(/\r/g, ' ')
     .replace(/\t/g, ' ')
+    .replace(/\u000c/g, '\\\\f')
+    .replace(/\u0008/g, '\\\\b')
+    .replace(/\u000b/g, '\\\\v')
+    .replace(/\0/g, '\\\\0')
     .replace(/`/g, '\\`')
-    .replace(/\u000c/g, '\\f')
-    .replace(/\u0008/g, '\\b')
-    .replace(/\u000b/g, '\\v')
-    .replace(/\0/g, '\\0')
-    .replace(/\\/g, '\\\\');
+    .replace(/\$\{/g, '\\${');
 
   if (input.addTagTransformers) {
     results.styleText = addTagTransformToCssString(results.styleText, input.tags);

--- a/src/compiler/style/test/css-to-esm.spec.ts
+++ b/src/compiler/style/test/css-to-esm.spec.ts
@@ -434,8 +434,9 @@ var(--theme-secondary-color) var(--theme-secondary-opacity));
   });
 
   it('escapes backticks in CSS content', () => {
+    const input = '.my-class::before { content: "`"; }';
     const result = transformCssToEsmSync({
-      input: '.my-class::before { content: "`"; }',
+      input,
       file: '/test.css',
       mode: 'md',
       module: 'esm',
@@ -449,5 +450,62 @@ var(--theme-secondary-color) var(--theme-secondary-opacity));
 
     // Should escape backticks to avoid breaking template literal
     expect(result.output).toContain('\\`');
+    // The backslash escaping the backtick must not itself be escaped,
+    // otherwise the backtick terminates the template literal early
+    expect(result.output).not.toContain('\\\\`');
+    // The generated module must be valid JavaScript and evaluate back to the
+    // original CSS
+    expect(evaluateEsmOutput(result.output)).toBe(input);
+  });
+
+  it('escapes template literal interpolation in CSS content', () => {
+    const input = '.my-class::before { content: "${notAVariable}"; }';
+    const result = transformCssToEsmSync({
+      input,
+      file: '/test.css',
+      mode: 'md',
+      module: 'esm',
+      tags: [],
+      addTagTransformers: false,
+      encapsulation: undefined,
+      docs: false,
+      sourceMap: false,
+      styleImportData: undefined,
+    });
+
+    // ${ must be escaped so it is not evaluated as an interpolation
+    expect(evaluateEsmOutput(result.output)).toBe(input);
+  });
+
+  it('preserves CSS escape sequences like icon font content', () => {
+    // as read from a CSS file, `content: "\f101"` contains a literal backslash
+    const input = '.icon::before { content: "\\f101"; }';
+    const result = transformCssToEsmSync({
+      input,
+      file: '/test.css',
+      mode: 'md',
+      module: 'esm',
+      tags: [],
+      addTagTransformers: false,
+      encapsulation: undefined,
+      docs: false,
+      sourceMap: false,
+      styleImportData: undefined,
+    });
+
+    // The runtime CSS string must round-trip the single backslash
+    expect(evaluateEsmOutput(result.output)).toBe(input);
   });
 });
+
+/**
+ * Evaluate the ESM output produced by `transformCssToEsmSync` and return the
+ * runtime CSS string, to assert that the generated module is valid JavaScript.
+ *
+ * @param output the generated ESM module source
+ * @returns the CSS text the module produces at runtime
+ */
+function evaluateEsmOutput(output: string): string {
+  const styleFn = new Function(output.replace('export default', 'return'))();
+  return styleFn();
+}

--- a/src/compiler/style/test/css-to-esm.spec.ts
+++ b/src/compiler/style/test/css-to-esm.spec.ts
@@ -496,6 +496,29 @@ var(--theme-secondary-color) var(--theme-secondary-opacity));
     // The runtime CSS string must round-trip the single backslash
     expect(evaluateEsmOutput(result.output)).toBe(input);
   });
+
+  it('escapes raw control characters as visible escape sequences', () => {
+    // genuine control character bytes (form feed, backspace, vertical tab, null),
+    // not their escaped text forms
+    const input = '.x::before { content: "\u000c101 \u0008 \u000b \u0000"; }';
+    const result = transformCssToEsmSync({
+      input,
+      file: '/test.css',
+      mode: 'md',
+      module: 'esm',
+      tags: [],
+      addTagTransformers: false,
+      encapsulation: undefined,
+      docs: false,
+      sourceMap: false,
+      styleImportData: undefined,
+    });
+
+    // The generated module must be valid JavaScript and the runtime CSS string
+    // must contain the control characters as visible escape sequences
+    // (e.g. U+000C followed by "101" becomes the CSS escape `\f101`)
+    expect(evaluateEsmOutput(result.output)).toBe('.x::before { content: "\\f101 \\b \\v \\0"; }');
+  });
 });
 
 /**


### PR DESCRIPTION
Escaping backslashes last re-escaped the backslash added for backticks, leaving an unescaped backtick that terminated the generated template literal and failed the build. Escape backslashes first, and also escape dollar-brace so CSS content cannot be evaluated as a template literal interpolation.

Fixes #6710

## What is the current behavior?

GitHub Issue Number: #6710

A component stylesheet containing a backtick, e.g.

```css
p::before {
  content: "`";
}
```

fails the whole build with:

```
Rollup: Parse Error
src/components/my-component/my-component.css?tag=my-component&encapsulation=shadow (1:183): Unterminated string constant
```

When embedding CSS into the generated JS template literal, `css-to-esm.ts` escaped backslashes *last*, which re-escaped the backslash it had just added for backticks (`` \` `` became ``\\` ``), leaving an unescaped backtick that terminates the template literal early. This is a regression — it worked in 4.29.3, before the escape chain was introduced.

`${` in CSS content had the same class of problem: it was not escaped at all, so it was evaluated as a template literal interpolation at runtime.

## What is the new behavior?

Backslashes are escaped first, so the escape sequences added afterwards are not re-escaped, and `${` is now escaped as well. CSS containing backticks or `${` compiles and round-trips correctly.

Behavior for everything else is unchanged, including the intentional handling of control characters (`\f`, `\b`, `\v`, `\0`) and icon-font content like `content: "\f101"` — the generated source for those inputs is identical to before this change.

## Documentation

N/A — internal compiler fix, no API or documentation changes.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

- Strengthened the existing `escapes backticks in CSS content` unit test: it previously only did a substring check that the broken output also satisfied; it now evaluates the generated module to prove it is valid JavaScript and round-trips the input CSS.
- Added unit tests for `${}` in CSS content and for icon-font escape sequences (`\f101`) round-tripping.
- `src/compiler/style/test/css-to-esm.spec.ts`: 31/31 pass locally; full jest suite run locally as well.
- End-to-end: built a minimal component project using the reproduction CSS from #6710 against this branch — the build succeeds and the emitted bundle contains the correctly escaped style:

```js
const myComponentCss = () => `:host{display:block}p::before{content:"\`"}`;
```

Before this change, the same input reproduced the Rollup parse error from the issue.

## Other information

N/A