### PR TITLE
fix(runtime): map camelCase SVG props to kebab-case attributes

### DIFF
--- a/src/runtime/test/svg-element.spec.tsx
+++ b/src/runtime/test/svg-element.spec.tsx
@@ -74,6 +74,64 @@ describe('SVG element', () => {
     `);
   });
 
+  it('should map camelCase props to kebab-case svg attributes', async () => {
+    @Component({ tag: 'cmp-a' })
+    class CmpA {
+      render() {
+        const circleProps = { cx: 15, cy: 5, r: 3, stroke: 'green', strokeWidth: 3 };
+        return (
+          <svg viewBox="0 0 30 10">
+            <circle {...circleProps} />
+            <rect width={4} height={4} fillOpacity={0.5} />
+          </svg>
+        );
+      }
+    }
+    const { root } = await newSpecPage({
+      components: [CmpA],
+      html: `<cmp-a></cmp-a>`,
+    });
+    expect(root).toEqualHtml(`
+      <cmp-a>
+        <svg viewBox=\"0 0 30 10\">
+          <circle cx=\"15\" cy=\"5\" r=\"3\" stroke=\"green\" stroke-width=\"3\"></circle>
+          <rect width=\"4\" height=\"4\" fill-opacity=\"0.5\"></rect>
+        </svg>
+      </cmp-a>
+    `);
+  });
+
+  it('should update and remove kebab-case mapped svg attributes', async () => {
+    @Component({ tag: 'cmp-a' })
+    class CmpA {
+      @Prop() strokeWidth?: number = 3;
+
+      render() {
+        return (
+          <svg viewBox="0 0 30 10">
+            <circle cx="15" cy="5" r="3" strokeWidth={this.strokeWidth} />
+          </svg>
+        );
+      }
+    }
+    const { root, waitForChanges } = await newSpecPage({
+      components: [CmpA],
+      html: `<cmp-a></cmp-a>`,
+    });
+    let circle = root.querySelector('circle');
+    expect(circle.getAttribute('stroke-width')).toBe('3');
+
+    root.strokeWidth = 5;
+    await waitForChanges();
+    circle = root.querySelector('circle');
+    expect(circle.getAttribute('stroke-width')).toBe('5');
+
+    root.strokeWidth = undefined;
+    await waitForChanges();
+    circle = root.querySelector('circle');
+    expect(circle.hasAttribute('stroke-width')).toBe(false);
+  });
+
   describe('path', () => {
     @Component({ tag: 'cmp-a' })
     class CmpA {

--- a/src/runtime/vdom/set-accessor.ts
+++ b/src/runtime/vdom/set-accessor.ts
@@ -224,6 +224,9 @@ export const setAccessor = (
         xlink = true;
       }
     }
+    if (BUILD.svg && isSvg && !xlink) {
+      memberName = mapSvgCamelCaseAttribute(memberName);
+    }
     if (newValue == null || newValue === false) {
       if (newValue !== false || elm.getAttribute(memberName) === '') {
         if (BUILD.vdomXlink && xlink) {
@@ -266,5 +269,45 @@ export const parseClassList = /*@__PURE__*/ (value: string | SVGAnimatedString |
 
   return value.split(parseClassListRegex);
 };
+/**
+ * SVG attributes that are genuinely camelCase per the SVG specification and
+ * must not be converted to kebab-case (e.g. `viewBox`, `preserveAspectRatio`).
+ */
+const SVG_CAMEL_CASE_ATTRS = /*@__PURE__*/ new Set(
+  (
+    'allowReorder attributeName attributeType autoReverse baseFrequency baseProfile calcMode clipPathUnits ' +
+    'contentScriptType contentStyleType diffuseConstant edgeMode externalResourcesRequired filterRes filterUnits ' +
+    'glyphRef gradientTransform gradientUnits kernelMatrix kernelUnitLength keyPoints keySplines keyTimes ' +
+    'lengthAdjust limitingConeAngle markerHeight markerUnits markerWidth maskContentUnits maskUnits numOctaves ' +
+    'pathLength patternContentUnits patternTransform patternUnits pointsAtX pointsAtY pointsAtZ preserveAlpha ' +
+    'preserveAspectRatio primitiveUnits refX refY repeatCount repeatDur requiredExtensions requiredFeatures ' +
+    'specularConstant specularExponent spreadMethod startOffset stdDeviation stitchTiles surfaceScale ' +
+    'systemLanguage tableValues targetX targetY textLength viewBox viewTarget xChannelSelector yChannelSelector ' +
+    'zoomAndPan'
+  ).split(' '),
+);
+
+/**
+ * Maps a camelCase SVG JSX prop name to the corresponding SVG attribute name.
+ * SVG attribute matching is case-sensitive, so `strokeWidth` must be set as
+ * `stroke-width` to take effect. Attributes that are genuinely camelCase in
+ * the SVG specification (e.g. `viewBox`) and `xml`/`xmlns` prefixed names are
+ * left unmodified.
+ *
+ * @param memberName the JSX prop name
+ * @returns the SVG attribute name to set
+ */
+const mapSvgCamelCaseAttribute = (memberName: string): string => {
+  if (!/[A-Z]/.test(memberName) || SVG_CAMEL_CASE_ATTRS.has(memberName) || /^xml/.test(memberName)) {
+    return memberName;
+  }
+  if (memberName === 'tabIndex' || memberName === 'crossOrigin') {
+    // these map to all-lowercase attribute names rather than kebab-case
+    return memberName.toLowerCase();
+  }
+
+  return memberName.replace(/([A-Z])/g, (match) => '-' + match.toLowerCase());
+};
+
 const CAPTURE_EVENT_SUFFIX = 'Capture';
 const CAPTURE_EVENT_REGEX = new RegExp(CAPTURE_EVENT_SUFFIX + '$');

--- a/src/runtime/vdom/test/set-accessor.spec.ts
+++ b/src/runtime/vdom/test/set-accessor.spec.ts
@@ -319,6 +319,46 @@ describe('setAccessor for custom elements', () => {
     expect(elm.hasAttribute('transform')).toBe(false);
   });
 
+  it('should map camelCase svg prop to kebab-case attribute', () => {
+    setAccessor(elm, 'strokeWidth', undefined, 3, true, 0);
+    expect(elm.hasAttribute('strokeWidth')).toBe(false);
+    expect(elm.getAttribute('stroke-width')).toBe('3');
+  });
+
+  it('should update camelCase svg prop as kebab-case attribute', () => {
+    elm.setAttribute('stroke-width', '3');
+
+    setAccessor(elm, 'strokeWidth', 3, 5, true, 0);
+    expect(elm.getAttribute('stroke-width')).toBe('5');
+  });
+
+  it('should remove kebab-case attribute when camelCase svg prop is removed', () => {
+    elm.setAttribute('stroke-width', '3');
+
+    setAccessor(elm, 'strokeWidth', 3, undefined, true, 0);
+    expect(elm.hasAttribute('stroke-width')).toBe(false);
+  });
+
+  it('should not map camelCase svg attributes that are camelCase in the SVG spec', () => {
+    setAccessor(elm, 'viewBox', undefined, '0 0 30 10', true, 0);
+    expect(elm.getAttribute('viewBox')).toBe('0 0 30 10');
+    expect(elm.hasAttribute('view-box')).toBe(false);
+
+    setAccessor(elm, 'preserveAspectRatio', undefined, 'xMidYMid meet', true, 0);
+    expect(elm.getAttribute('preserveAspectRatio')).toBe('xMidYMid meet');
+  });
+
+  it('should map tabIndex on svg to the lowercase attribute', () => {
+    setAccessor(elm, 'tabIndex', undefined, 0, true, 0);
+    expect(elm.getAttribute('tabindex')).toBe('0');
+    expect(elm.hasAttribute('tab-index')).toBe(false);
+  });
+
+  it('should not map camelCase props when not in an svg context', () => {
+    setAccessor(elm, 'strokeWidth', undefined, 3, false, 0);
+    expect(elm.hasAttribute('stroke-width')).toBe(false);
+  });
+
   it('should set true boolean to attribute', () => {
     const oldValue: any = 'someval';
     const newValue: any = true;


### PR DESCRIPTION
SVG attribute matching is case-sensitive, so camelCase props spread onto SVG elements (e.g. strokeWidth) were set as-is and silently ignored by the renderer. Map them to their kebab-case attribute names like React does, leaving SVG's genuinely camelCase attributes (viewBox, preserveAspectRatio, etc.), xml/xmlns prefixed names, and xlink handling unchanged. The mapping is gated behind the svg build conditional.

Fixes #5674

## What is the current behavior?

GitHub Issue Number: #5674

camelCase SVG props are set verbatim as attributes. Since SVG attribute matching is case-sensitive, an attribute named `strokeWidth` does not match `stroke-width` and the styling is silently ignored — no warning or error. This mainly bites when spreading an object of props onto an SVG element (React-style prop objects, shared prop factories, etc.):

```tsx
const circleProps = { cx: 15, cy: 5, r: 3, stroke: 'green', strokeWidth: 3 };

<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30 10">
  <circle {...circleProps} />
</svg>
```

renders `<circle ... strokeWidth="3">`, which has no visual effect.

## What is the new behavior?

In an SVG context, camelCase prop names are mapped to their kebab-case SVG attribute names (`strokeWidth` → `stroke-width`, `fillOpacity` → `fill-opacity`, …) for setting, updating, and removal — matching React's behavior for SVG props.

Deliberately excluded from the mapping:

- SVG attributes that are genuinely camelCase per the SVG specification (`viewBox`, `preserveAspectRatio`, `gradientTransform`, `baseFrequency`, etc.) — passed through unchanged via an explicit exception list
- `tabIndex` and `crossOrigin`, which map to all-lowercase attribute names rather than kebab-case
- `xml`/`xmlns` prefixed names — left unmodified
- existing `xlink` handling — the mapping runs after it, so `xlinkHref` continues to work as before

The mapping only applies in SVG contexts (`isSvg`), is gated behind the `svg` build conditional so it is tree-shaken from applications that don't render SVG, and non-SVG elements are unaffected.

The kebab-case prop names Stencil's JSX typings declare today (`stroke-width={3}`) continue to work exactly as before — this is purely additive.

## Documentation

N/A — behavior now matches what the JSX allows; happy to add a docs note to the SVG guide in stenciljs/site if desired.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Previously, camelCase names in SVG contexts produced attributes that SVG ignores, so no working code depended on the old behavior.

## Testing

- Six new unit tests in `set-accessor.spec.ts`: setting, updating, and removing a camelCase prop as its kebab-case attribute; camelCase-in-spec attributes (`viewBox`, `preserveAspectRatio`) preserved; `tabIndex` → `tabindex`; and no mapping outside SVG contexts. Full `set-accessor` spec: 132/132 passing.
- Full runtime jest suite run locally: 655/655 across 63 suites — no regressions, including the existing SVG patching and xlink tests.
- Manual end-to-end: built a component using the exact reproduction from #5674 against this branch and inspected the DOM in a browser — the circle renders `<circle cx="15" cy="5" r="3" stroke="green" stroke-width="3">`, computed style reports `stroke-width: 3px`, and no `strokeWidth` attribute is present.

## Other information

The exception list mirrors the camelCase attribute names from the SVG specification (the same set React preserves). It lives behind the `BUILD.svg` conditional and a `@__PURE__` annotation, so it adds no bytes to builds without SVG rendering.