### PR TITLE
fix(compiler): preserve bundler directive comments in es5 output

### DIFF
--- a/src/compiler/optimize/optimize-module.ts
+++ b/src/compiler/optimize/optimize-module.ts
@@ -6,6 +6,17 @@ import type { CompilerCtx, OptimizeJsResult, SourceMap, SourceTarget, ValidatedC
 import { minfyJsId } from '../../version';
 import { minifyJs } from './minify-js';
 
+/**
+ * Matches the comments that must survive minification. This extends Terser's default
+ * `comments: 'some'` behavior (`@license`, `@preserve`, etc.) with bundler directive
+ * comments — `@vite-ignore` and webpack magic comments (e.g. `webpackInclude:`,
+ * `webpackMode:`) — which downstream bundlers read from inside dynamic `import()`
+ * calls in the emitted output (e.g. `esm-es5`). Without this, Vite warns that the
+ * runtime's dynamic import cannot be analyzed and webpack ignores the lazy-loading
+ * hints entirely.
+ */
+const PRESERVED_COMMENTS = /^\**!|@preserve|@license|@cc_on|@vite-ignore|webpack[A-Z][a-zA-Z]+:/i;
+
 interface OptimizeModuleOptions {
   input: string;
   sourceMap?: SourceMap;
@@ -139,6 +150,7 @@ export const getTerserOptions = (
   if (sourceTarget === 'es5') {
     opts.ecma = opts.format.ecma = 5;
     opts.compress = false;
+    opts.format.comments = PRESERVED_COMMENTS;
     opts.mangle = {
       properties: getTerserManglePropertiesConfig(),
     };

--- a/src/compiler/optimize/test/optimize-module.spec.ts
+++ b/src/compiler/optimize/test/optimize-module.spec.ts
@@ -1,0 +1,62 @@
+import { mockValidatedConfig } from '@stencil/core/testing';
+
+import { getTerserOptions, prepareModule } from '../optimize-module';
+
+describe('optimize-module', () => {
+  describe('prepareModule', () => {
+    // mirrors the dynamic import in `src/client/client-load-module.ts`, which relies on
+    // bundler directive comments being present in the emitted `esm-es5` output
+    const loadModuleSource = `export const loadModule = (bundleId, hmrVersionId) => {
+  return import(
+    /* @vite-ignore */
+    /* webpackInclude: /\\.entry\\.js$/ */
+    /* webpackExclude: /\\.system\\.entry\\.js$/ */
+    /* webpackMode: "lazy" */
+    \`./\${bundleId}.entry.js\${hmrVersionId ? '?s-hmr=' + hmrVersionId : ''}\`
+  ).then((importedModule) => importedModule);
+};`;
+
+    it('preserves bundler directive comments inside dynamic imports when transpiling to es5', async () => {
+      const config = mockValidatedConfig({ logLevel: 'info', sourceMap: false });
+      const minifyOpts = getTerserOptions(config, 'es5', false);
+
+      const results = await prepareModule(loadModuleSource, minifyOpts, true, true);
+
+      expect(results.diagnostics).toHaveLength(0);
+      const importCall = results.output.slice(results.output.indexOf('import('));
+      expect(importCall).toContain('/* @vite-ignore */');
+      expect(importCall).toContain('webpackInclude:');
+      expect(importCall).toContain('webpackExclude:');
+      expect(importCall).toContain('webpackMode:');
+      // the directive comments must appear before the import specifier argument for
+      // bundlers to associate them with the dynamic import
+      expect(importCall.indexOf('/* @vite-ignore */')).toBeLessThan(importCall.indexOf('.entry.js'));
+    });
+
+    it('still removes regular comments when transpiling to es5', async () => {
+      const config = mockValidatedConfig({ logLevel: 'info', sourceMap: false });
+      const minifyOpts = getTerserOptions(config, 'es5', false);
+      const input = `// a line comment
+/* a block comment */
+export const add = (a, b) => a + b;`;
+
+      const results = await prepareModule(input, minifyOpts, true, true);
+
+      expect(results.diagnostics).toHaveLength(0);
+      expect(results.output).not.toContain('a line comment');
+      expect(results.output).not.toContain('a block comment');
+    });
+
+    it('preserves license comments when transpiling to es5', async () => {
+      const config = mockValidatedConfig({ logLevel: 'info', sourceMap: false });
+      const minifyOpts = getTerserOptions(config, 'es5', false);
+      const input = `/*! some license */
+export const add = (a, b) => a + b;`;
+
+      const results = await prepareModule(input, minifyOpts, true, true);
+
+      expect(results.diagnostics).toHaveLength(0);
+      expect(results.output).toContain('/*! some license */');
+    });
+  });
+});


### PR DESCRIPTION
## What is the current behavior?

GitHub Issue Number: #4122

The Stencil runtime's lazy loader (`src/client/client-load-module.ts`) annotates its dynamic `import()` with bundler directive comments — `/* @vite-ignore */`, `/* webpackInclude: ... */`, `/* webpackExclude: ... */`, and `/* webpackMode: "lazy" */` — so that downstream bundlers handle the non-statically-analyzable import correctly.

With `buildEs5` enabled, those comments are lost in the `dist/esm-es5` output. They survive the TypeScript ES5 transpilation, but are then stripped by terser: `getTerserOptions` doesn't configure `format.comments`, so terser's default applies, which only keeps license-style comments (`@license`, `@preserve`, `/*! ... */`).

As a result:

- **Vite** emits a warning for every consumer of an es5-enabled library: `The above dynamic import cannot be analyzed by Vite.` (this is the warning reported in #4122)
- **webpack** silently loses its `webpackInclude`/`webpackExclude`/`webpackMode` lazy-loading hints in the es5 output.

## What is the new behavior?

The ES5 minification options now pass terser a `format.comments` pattern that preserves bundler directive comments (`@vite-ignore` and `webpack*:` magic comments) in addition to terser's default license-comment behavior. The directives now ship in the `esm-es5` output, Vite no longer warns, and webpack's hints are honored.

This is a compiler-only change: it does not add any code to the runtime, and modern (non-es5) output is unaffected. Regular comments are still stripped from es5 output as before.

## Documentation

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

- Added unit tests in `src/compiler/optimize/test/optimize-module.spec.ts` covering the ES5 path: bundler directive comments are preserved inside the dynamic `import()`, ordinary line/block comments are still removed, and license comments are still preserved.
- Manually verified end-to-end: built a component library with `buildEs5` enabled against this branch and confirmed the directive comments are present in `dist/esm-es5`. Ran the output through Vite's dev-server transform (`vite:import-analysis`): the current published output reproduces the exact warning from #4122, and the output built with this fix produces no warning.

## Other information

`esm-es5` output before this change:

```js
return import("./".concat(o,".entry.js").concat("")).then(...)