### PR TITLE
feat(css): v5 `stencil-*` `@import` layer / supports modifiers

### DIFF
--- a/packages/core/src/compiler/style/_test_/component-global-styles.spec.ts
+++ b/packages/core/src/compiler/style/_test_/component-global-styles.spec.ts
@@ -158,6 +158,35 @@ describe('component-global-styles', () => {
       expect(result).toContain(':root {}');
       expect(result).toContain('body {}');
     });
+
+    it('wraps in @layer when a layer() modifier is present', async () => {
+      buildCtx.components = [
+        mockCmp({ globalStyles: [{ styleStr: 'my-cmp { display: block; }', absolutePath: null }] }),
+      ];
+      const css = `@import "stencil-globals" layer(init);`;
+      const result = await resolveStencilGlobalsImport(
+        css,
+        config,
+        compilerCtx,
+        buildCtx,
+        '/src/global.css',
+      );
+      expect(result).not.toContain('@import');
+      expect(result).toBe('@layer init {\nmy-cmp { display: block; }\n}');
+    });
+
+    it('wraps in @supports and @media when those modifiers are present', async () => {
+      buildCtx.components = [mockCmp({ globalStyles: [{ styleStr: 'x {}', absolutePath: null }] })];
+      const css = `@import "stencil-globals" supports(display: grid) (min-width: 400px);`;
+      const result = await resolveStencilGlobalsImport(
+        css,
+        config,
+        compilerCtx,
+        buildCtx,
+        '/src/global.css',
+      );
+      expect(result).toBe('@supports (display: grid) {\n@media (min-width: 400px) {\nx {}\n}\n}');
+    });
   });
 
   describe('hasStencilHydrateImport', () => {
@@ -273,6 +302,23 @@ describe('component-global-styles', () => {
       const result = resolveStencilHydrateImport(css, config, buildCtx);
       expect(result).not.toContain('@import "stencil-hydrate"');
       expect(result).toContain('body {}');
+    });
+
+    it('wraps in @layer when a layer() modifier is present', () => {
+      config.hydratedFlag = {
+        selector: 'class',
+        name: 'hydrated',
+        property: 'visibility',
+        initialValue: 'hidden',
+        hydratedValue: 'inherit',
+      };
+      buildCtx.components = [mockCmp({ tagName: 'my-cmp' })];
+      const css = `@import "stencil-hydrate" layer(init);`;
+      const result = resolveStencilHydrateImport(css, config, buildCtx);
+      expect(result).not.toContain('@import');
+      expect(result).toBe(
+        '@layer init {\nmy-cmp{visibility:hidden}.hydrated{visibility:inherit}\n}',
+      );
     });
   });
 });

--- a/packages/core/src/compiler/style/component-global-styles.ts
+++ b/packages/core/src/compiler/style/component-global-styles.ts
@@ -3,9 +3,11 @@ import type * as d from '@stencil/core';
 import { normalizePath } from '../../utils';
 import { runPluginTransforms } from '../plugin/plugin';
 import { optimizeCss } from './optimize-css';
+import { wrapCssWithImportModifiers } from './style-utils';
 
-const STENCIL_GLOBALS_RE = /@import\s+(?:url\()?\s*['"]stencil-globals['"]\s*\)?\s*;?/g;
-const STENCIL_HYDRATE_RE = /@import\s+(?:url\()?\s*['"]stencil-hydrate['"]\s*\)?\s*;?/g;
+// the trailing capture group picks up any modifiers (e.g. `layer(name)`) following the specifier
+const STENCIL_GLOBALS_RE = /@import\s+(?:url\()?\s*['"]stencil-globals['"]\s*\)?([^;]*);?/g;
+const STENCIL_HYDRATE_RE = /@import\s+(?:url\()?\s*['"]stencil-hydrate['"]\s*\)?([^;]*);?/g;
 
 export const hasStencilGlobalsImport = (css: string): boolean => css.includes('stencil-globals');
 export const hasStencilHydrateImport = (css: string): boolean => css.includes('stencil-hydrate');
@@ -38,6 +40,7 @@ export const generateHydrateCss = (config: d.ValidatedConfig, buildCtx: d.BuildC
 
 /**
  * Replace `@import "stencil-hydrate"` in CSS with the generated FOUC-prevention styles.
+ * Supports trailing `layer()`/`supports()`/media modifiers, e.g. `@import "stencil-hydrate" layer(init);`.
  * @param css the CSS string to process
  * @param config the Stencil configuration
  * @param buildCtx the current build context, used to get the list of components in the build
@@ -47,7 +50,12 @@ export const resolveStencilHydrateImport = (
   css: string,
   config: d.ValidatedConfig,
   buildCtx: d.BuildCtx,
-): string => css.replace(STENCIL_HYDRATE_RE, generateHydrateCss(config, buildCtx));
+): string => {
+  const hydrateCss = generateHydrateCss(config, buildCtx);
+  return css.replace(STENCIL_HYDRATE_RE, (_match, modifiers: string) =>
+    wrapCssWithImportModifiers(hydrateCss, modifiers),
+  );
+};
 
 /**
  * Collect and build all component-level globalStyle/globalStyleUrl CSS from the current build.
@@ -107,6 +115,7 @@ export const collectAndBuildComponentGlobalStyles = async (
  * Replace `@import "stencil-globals"` in CSS with the collected component global styles.
  * Also registers component global style files as cssModuleImports of the global stylesheet
  * so the build cache is properly invalidated when those files change.
+ * Supports trailing `layer()`/`supports()`/media modifiers, e.g. `@import "stencil-globals" layer(init);`.
  *
  * @param css the CSS string to process
  * @param config the Stencil configuration
@@ -139,5 +148,7 @@ export const resolveStencilGlobalsImport = async (
     compilerCtx.cssModuleImports.set(globalStyleInputPath, existing);
   }
 
-  return css.replace(STENCIL_GLOBALS_RE, collectedCss);
+  return css.replace(STENCIL_GLOBALS_RE, (_match, modifiers: string) =>
+    wrapCssWithImportModifiers(collectedCss, modifiers),
+  );
 };

--- a/packages/core/src/compiler/style/css-imports.ts
+++ b/packages/core/src/compiler/style/css-imports.ts
@@ -5,7 +5,7 @@ import { buildError, join, normalizePath } from '../../utils';
 import { parseStyleDocs } from '../docs/style-docs';
 import { resolveModuleIdAsync } from '../sys/resolve/resolve-module-async';
 import { getModuleId } from '../sys/resolve/resolve-utils';
-import { stripCssComments } from './style-utils';
+import { stripCssComments, wrapCssWithImportModifiers } from './style-utils';
 
 /**
  * Parse CSS imports into an object which contains a manifest of imports and a
@@ -309,67 +309,9 @@ export const replaceImportDeclarations = (
   for (const cssImport of cssImports) {
     if (isCssEntry) {
       if (typeof cssImport.styleText === 'string') {
-        // For CSS entries, inline the imported CSS content
-        // If there are modifiers (layer, supports, media queries), wrap the content appropriately
-        let replacement = cssImport.styleText;
-
-        if (cssImport.modifiers) {
-          let modifiers = cssImport.modifiers;
-          let layerName = '';
-          let supportsCondition = '';
-          let mediaQuery = '';
-
-          // Extract layer() - innermost wrapper
-          const layerMatch = modifiers.match(/layer\(([^)]+)\)/);
-          if (layerMatch) {
-            layerName = layerMatch[1].trim();
-            modifiers = modifiers.replace(/layer\([^)]+\)/, '').trim();
-          }
-
-          // Extract supports() - handles nested parentheses with a more robust approach
-          // This regex matches supports() and captures content with balanced parentheses
-          let depth = 0;
-          let startIdx = -1;
-          let endIdx = -1;
-          const supportsIdx = modifiers.indexOf('supports(');
-
-          if (supportsIdx !== -1) {
-            startIdx = supportsIdx + 9; // length of 'supports('
-            for (let i = startIdx; i < modifiers.length; i++) {
-              if (modifiers[i] === '(') depth++;
-              if (modifiers[i] === ')') {
-                if (depth === 0) {
-                  endIdx = i;
-                  break;
-                }
-                depth--;
-              }
-            }
-
-            if (endIdx !== -1) {
-              supportsCondition = modifiers.substring(startIdx, endIdx).trim();
-              modifiers = modifiers.substring(0, supportsIdx) + modifiers.substring(endIdx + 1);
-              modifiers = modifiers.trim();
-            }
-          }
-
-          // Anything remaining should be media queries
-          mediaQuery = modifiers.trim();
-
-          // Apply wrappers in correct order: layer (innermost) -> media -> supports (outermost)
-          if (layerName) {
-            replacement = `@layer ${layerName} {\n${replacement}\n}`;
-          }
-
-          if (mediaQuery) {
-            replacement = `@media ${mediaQuery} {\n${replacement}\n}`;
-          }
-
-          if (supportsCondition) {
-            replacement = `@supports (${supportsCondition}) {\n${replacement}\n}`;
-          }
-        }
-
+        // For CSS entries, inline the imported CSS content, wrapped in any
+        // layer/supports/media modifiers that followed the import specifier
+        const replacement = wrapCssWithImportModifiers(cssImport.styleText, cssImport.modifiers);
         styleText = styleText.replace(cssImport.srcImport, replacement);
       }
     } else if (typeof cssImport.updatedImport === 'string') {

--- a/packages/core/src/compiler/style/style-utils.ts
+++ b/packages/core/src/compiler/style/style-utils.ts
@@ -1,4 +1,78 @@
 /**
+ * Wrap CSS content according to the modifiers trailing an `@import` specifier
+ * (`layer(name)`, `supports(condition)`, and/or a media query), mirroring what
+ * `@import url(...) layer(name) supports(condition) (media);` would do natively.
+ *
+ * @param cssText the CSS content to wrap
+ * @param modifiers the raw modifier string following the import specifier, if any
+ * @returns cssText wrapped in @layer/@media/@supports blocks as needed
+ */
+export const wrapCssWithImportModifiers = (
+  cssText: string,
+  modifiers: string | undefined,
+): string => {
+  if (!modifiers?.trim()) {
+    return cssText;
+  }
+
+  let remaining = modifiers.trim();
+  let replacement = cssText;
+  let layerName = '';
+  let supportsCondition = '';
+
+  // Extract layer() - innermost wrapper
+  const layerMatch = remaining.match(/layer\(([^)]+)\)/);
+  if (layerMatch) {
+    layerName = layerMatch[1].trim();
+    remaining = remaining.replace(/layer\([^)]+\)/, '').trim();
+  }
+
+  // Extract supports() - handles nested parentheses with a balanced-paren scan
+  let depth = 0;
+  let startIdx = -1;
+  let endIdx = -1;
+  const supportsIdx = remaining.indexOf('supports(');
+
+  if (supportsIdx !== -1) {
+    startIdx = supportsIdx + 9; // length of 'supports('
+    for (let i = startIdx; i < remaining.length; i++) {
+      if (remaining[i] === '(') depth++;
+      if (remaining[i] === ')') {
+        if (depth === 0) {
+          endIdx = i;
+          break;
+        }
+        depth--;
+      }
+    }
+
+    if (endIdx !== -1) {
+      supportsCondition = remaining.substring(startIdx, endIdx).trim();
+      remaining = remaining.substring(0, supportsIdx) + remaining.substring(endIdx + 1);
+      remaining = remaining.trim();
+    }
+  }
+
+  // Anything remaining should be a media query
+  const mediaQuery = remaining.trim();
+
+  // Apply wrappers in correct order: layer (innermost) -> media -> supports (outermost)
+  if (layerName) {
+    replacement = `@layer ${layerName} {\n${replacement}\n}`;
+  }
+
+  if (mediaQuery) {
+    replacement = `@media ${mediaQuery} {\n${replacement}\n}`;
+  }
+
+  if (supportsCondition) {
+    replacement = `@supports (${supportsCondition}) {\n${replacement}\n}`;
+  }
+
+  return replacement;
+};
+
+/**
  * Strip out comments from some CSS
  *
  * @param input the string we'd like to de-comment

--- a/test/build/global-style/src/global.css
+++ b/test/build/global-style/src/global.css
@@ -1,5 +1,6 @@
 /* FOUC prevention - replaced at build time with component visibility rules */
-@import 'stencil-hydrate';
+/* layer() modifier wraps the resolved import so it can be reordered/overridden via @layer */
+@import 'stencil-hydrate' layer(init);
 
 /* Base page styles */
 :root {
@@ -7,7 +8,7 @@
 }
 
 /* Component global styles are injected here */
-@import 'stencil-globals';
+@import 'stencil-globals' supports(display: grid);
 
 body {
   margin: 0;

--- a/test/build/global-style/validate.js
+++ b/test/build/global-style/validate.js
@@ -50,6 +50,18 @@ assert(
   'Missing hydrated selector rule from stencil-hydrate',
 );
 
+// @import "stencil-hydrate" layer(init) wraps the generated FOUC CSS in a named layer
+assert(
+  /@layer init\s*{/.test(css),
+  'stencil-hydrate output should be wrapped in "@layer init" per the layer() modifier',
+);
+
+// @import "stencil-globals" supports(display: grid) wraps the collected styles in @supports
+assert(
+  /@supports\s*\(display:\s*grid\)\s*{/.test(css),
+  'stencil-globals output should be wrapped in "@supports (display: grid)" per the supports() modifier',
+);
+
 // stencil-hydrate.css must NOT be generated when @import "stencil-hydrate" is present
 // in a global-style input - the standalone output target should detect this and skip it.
 const hydrateCssPath = path.resolve(__dirname, 'dist', 'assets', 'stencil-hydrate.css');


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: https://github.com/stenciljs/core/issues/6649


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The new `@import "stencil-hydrate"` and `@import "stencil-globals"` placeholders now support the layer modifier
e.g

`@import 'stencil-hydrate' layer(init);`

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
