### PR TITLE
feat(runtime): v5 batched `componentShouldUpdate`

### DIFF
--- a/V5_PLANNING.md
+++ b/V5_PLANNING.md
@@ -118,6 +118,7 @@ Modernize Stencil after 10 years: shed tech debt, embrace modern tooling, simpli
 - **`esmLoaderPath` config option renamed to `loaderPath`** in `loader-bundle` output target.
 - **`hashFileNames` and `hashedFileNameLength` moved from top-level config to `loader-bundle` and `www` output targets.** Only these two targets serve bundles directly in the browser. Run `stencil migrate` to remove them from the top-level config, then add to your output targets if non-default values are needed.
 - **`suppressReservedPublicNameWarnings` / `suppressReservedEventNameWarnings` moved into `compat` and renamed** to `compat.suppressPublicNameWarnings` / `compat.suppressEventNameWarnings`. Run `stencil migrate` to update your config automatically.
+- **`componentShouldUpdate` signature changed from `(newVal, oldVal, propName)` to a single batched `(changes)` argument**, where `changes` is a `{ [propName]: { newVal, oldVal } }` map of every `@Prop`/`@State` that changed since the last render. It now fires once per render cycle instead of once per changed member (fixes [#6759](https://github.com/stenciljs/core/issues/6759) — v4.42's per-prop firing multiplied lifecycle cost by prop count on every update).
 
 ---
 

--- a/packages/core/src/compiler/transformers/_test_/parse-component.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/parse-component.spec.ts
@@ -71,6 +71,62 @@ describe('parse component', () => {
     expect(t.componentClassName).toBe('CmpA');
   });
 
+  it('warns about pre-v5 "componentShouldUpdate" signature', () => {
+    let error: Error | undefined;
+    try {
+      transpileModule(`
+        @Component({
+          tag: 'cmp-a'
+        })
+        export class CmpA {
+          componentShouldUpdate(newVal, oldVal, propName) {
+            return newVal !== oldVal;
+          }
+        }
+      `);
+    } catch (err: unknown) {
+      error = err as Error;
+    }
+
+    expect(error.message).toContain(
+      `The component "CmpA" defines "componentShouldUpdate" with 3 parameters.`,
+    );
+  });
+
+  it('does not warn about the v5 "componentShouldUpdate" signature', () => {
+    const t = transpileModule(`
+      @Component({
+        tag: 'cmp-a'
+      })
+      export class CmpA {
+        componentShouldUpdate(changes) {
+          return true;
+        }
+      }
+    `);
+
+    expect(t.componentClassName).toBe('CmpA');
+    expect(t.buildCtx.hasWarning).toBe(false);
+  });
+
+  it('ignores pre-v5 "componentShouldUpdate" signature in unrelated class', () => {
+    const t = transpileModule(`
+      @Component({
+        tag: 'cmp-a'
+      })
+      export class CmpA {}
+
+      export class Unrelated {
+        componentShouldUpdate(newVal, oldVal, propName) {
+          return newVal !== oldVal;
+        }
+      }
+    `);
+
+    expect(t.componentClassName).toBe('CmpA');
+    expect(t.buildCtx.hasWarning).toBe(false);
+  });
+
   it('should derive meta data from extended tree of classes', async () => {
     const t = transpileModule(`
     @Component({tag: 'cmp-a'})

--- a/packages/core/src/compiler/transformers/static-to-meta/component.ts
+++ b/packages/core/src/compiler/transformers/static-to-meta/component.ts
@@ -256,6 +256,25 @@ export const parseStaticComponentMeta = (
   return cmpNode;
 };
 
+/**
+ * Check whether a class declaration is a Stencil component, i.e. it's
+ * decorated with `@Component({ tag: ... })`.
+ * @param classNode the class declaration to check
+ * @returns whether `classNode` is a Stencil component class
+ */
+const isStencilComponentClass = (classNode: ts.ClassDeclaration): boolean => {
+  const decorator = ts.getDecorators(classNode)?.[0];
+  return (
+    decorator != null &&
+    ts.isCallExpression(decorator.expression) &&
+    decorator.expression.arguments.length === 1 &&
+    ts.isObjectLiteralExpression(decorator.expression.arguments[0]) &&
+    decorator.expression.arguments[0].properties.some(
+      (prop) => ts.isPropertyAssignment(prop) && prop.name.getText() === 'tag',
+    )
+  );
+};
+
 const validateComponentMembers = (node: ts.Node, buildCtx: d.BuildCtx) => {
   /**
    * validate if:
@@ -272,26 +291,33 @@ const validateComponentMembers = (node: ts.Node, buildCtx: d.BuildCtx) => {
      * the parent node is a class declaration
      */
     node.parent &&
-    ts.isClassDeclaration(node.parent)
+    ts.isClassDeclaration(node.parent) &&
+    isStencilComponentClass(node.parent)
   ) {
     const propName = node.name.escapedText;
-    const decorator = ts.getDecorators(node.parent)[0];
+    const componentName = node.parent.name.getText();
+    const err = buildWarn(buildCtx.diagnostics);
+    err.messageText = `The component "${componentName}" has a getter called "${propName}". This getter is reserved for use by Stencil components and should not be defined by the user.`;
+    augmentDiagnosticWithNode(err, node);
+  }
+
+  if (
     /**
-     * the class is actually a Stencil component, has a decorator with a property named "tag"
+     * the component defines a "componentShouldUpdate" method with more than one parameter,
+     * which was the pre-v5 per-prop signature "(newVal, oldVal, propName)"
      */
-    if (
-      ts.isCallExpression(decorator.expression) &&
-      decorator.expression.arguments.length === 1 &&
-      ts.isObjectLiteralExpression(decorator.expression.arguments[0]) &&
-      decorator.expression.arguments[0].properties.some(
-        (prop) => ts.isPropertyAssignment(prop) && prop.name.getText() === 'tag',
-      )
-    ) {
-      const componentName = node.parent.name.getText();
-      const err = buildWarn(buildCtx.diagnostics);
-      err.messageText = `The component "${componentName}" has a getter called "${propName}". This getter is reserved for use by Stencil components and should not be defined by the user.`;
-      augmentDiagnosticWithNode(err, node);
-    }
+    ts.isMethodDeclaration(node) &&
+    ts.isIdentifier(node.name) &&
+    node.name.escapedText === 'componentShouldUpdate' &&
+    node.parameters.length > 1 &&
+    node.parent &&
+    ts.isClassDeclaration(node.parent) &&
+    isStencilComponentClass(node.parent)
+  ) {
+    const componentName = node.parent.name.getText();
+    const err = buildWarn(buildCtx.diagnostics);
+    err.messageText = `The component "${componentName}" defines "componentShouldUpdate" with ${node.parameters.length} parameters. As of Stencil v5, "componentShouldUpdate" is called once per render with a single "changes" argument (a map of prop/state names to "{ newVal, oldVal }") instead of once per prop with "(newVal, oldVal, propName)". This method will still compile, but any extra parameters will be "undefined" at runtime.`;
+    augmentDiagnosticWithNode(err, node);
   }
 };
 

--- a/packages/core/src/declarations/stencil-private.ts
+++ b/packages/core/src/declarations/stencil-private.ts
@@ -22,7 +22,12 @@ import type {
   ValidatedConfig,
 } from './stencil-public-compiler';
 import type { JsonDocMethodParameter } from './stencil-public-docs';
-import type { ComponentInterface, ListenTargetOptions, VNode } from './stencil-public-runtime';
+import type {
+  ComponentInterface,
+  ComponentShouldUpdateChanges,
+  ListenTargetOptions,
+  VNode,
+} from './stencil-public-runtime';
 
 export type { InMemoryFileSystem } from '../compiler/sys/in-memory-fs';
 export type { RolldownSourceMap };
@@ -1801,6 +1806,11 @@ export interface HostRef {
   $cmpMeta$: ComponentRuntimeMeta;
   $hostElement$: HostElement;
   $instanceValues$?: Map<string, any>;
+  /**
+   * Prop/state changes accumulated since the last render, flushed to
+   * `componentShouldUpdate` once per render cycle.
+   */
+  $queuedPropChanges$?: ComponentShouldUpdateChanges;
   $signalValues$?: Map<string, import('@preact/signals-core').Signal<any>>;
   /** Dispose function that tears down all signal effects for this component. */
   $signalCleanup$?: () => void;

--- a/packages/core/src/declarations/stencil-public-runtime.ts
+++ b/packages/core/src/declarations/stencil-public-runtime.ts
@@ -730,6 +730,17 @@ export interface ComponentDidUpdate {
   componentDidUpdate(): void;
 }
 
+/**
+ * A map of `@Prop`/`@State` property names to their new and previous
+ * values, passed to `componentShouldUpdate` once per render cycle.
+ *
+ * Pass `this` as `T` to type `changes` against your component's own
+ * members, e.g. `componentShouldUpdate(changes: ComponentShouldUpdateChanges<this>)`.
+ */
+export type ComponentShouldUpdateChanges<T = any> = {
+  [K in Extract<keyof T, string>]?: { newVal: T[K]; oldVal: T[K] };
+};
+
 export interface ComponentInterface {
   connectedCallback?(): void;
   disconnectedCallback?(): void;
@@ -759,14 +770,18 @@ export interface ComponentInterface {
   componentDidLoad?(): void;
 
   /**
-   * A `@Prop` or `@State` property changed and a rerender is about to be requested.
+   * One or more `@Prop` or `@State` properties changed and a rerender is
+   * about to be requested. `changes` contains every property that changed
+   * since the last render, keyed by property name.
    *
-   * Called multiple times throughout the life of
-   * the component as its properties change.
+   * Called once per render cycle, batching all properties that changed
+   * synchronously since the last render.
+   *
+   * Return `false` to prevent the pending render.
    *
    * componentShouldUpdate is not called on the first render.
    */
-  componentShouldUpdate?(newVal: any, oldVal: any, propName: string): boolean | void;
+  componentShouldUpdate?(changes: ComponentShouldUpdateChanges<this>): boolean | void;
 
   /**
    * The component is about to update and re-render.

--- a/packages/core/src/index.d.mts
+++ b/packages/core/src/index.d.mts
@@ -11,6 +11,7 @@ export type {
   ComponentDidUpdate,
   ComponentInterface,
   ComponentOptions,
+  ComponentShouldUpdateChanges,
   ComponentWillLoad,
   ComponentWillUpdate,
   EventEmitter,

--- a/packages/core/src/runtime/_test_/lifecycle-sync.spec.tsx
+++ b/packages/core/src/runtime/_test_/lifecycle-sync.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, forceUpdate, h, Host, Method, Prop, Watch } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+import type { ComponentShouldUpdateChanges } from '@stencil/core';
 
 describe('lifecycle sync', () => {
   it('should fire connected/disconnected when removed', async () => {
@@ -154,9 +155,10 @@ describe('lifecycle sync', () => {
       renders = 0;
       @Prop() complex: any;
 
-      componentShouldUpdate(newValue: any, oldValue: any) {
+      componentShouldUpdate(changes: ComponentShouldUpdateChanges<this>) {
         try {
-          return JSON.stringify(newValue) !== JSON.stringify(oldValue);
+          const { newVal, oldVal } = changes.complex;
+          return JSON.stringify(newVal) !== JSON.stringify(oldVal);
         } catch {}
         return true;
       }

--- a/packages/core/src/runtime/_test_/prop.spec.tsx
+++ b/packages/core/src/runtime/_test_/prop.spec.tsx
@@ -1,6 +1,7 @@
 import { AttrDeserialize, Component, h, Prop } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+import type { ComponentShouldUpdateChanges } from '@stencil/core';
 
 function Clamp(lowerBound: number, upperBound: number): any {
   const clamp = (value: number) => Math.max(lowerBound, Math.min(value, upperBound));
@@ -130,8 +131,8 @@ describe('prop', () => {
     expect(root.clamped).toBe(5);
   });
 
-  it('should call componentShouldUpdate for each prop when multiple props change synchronously', async () => {
-    const shouldUpdateCalls: Array<{ value: any; old: any; prop: string }> = [];
+  it('should call componentShouldUpdate once with all changes when multiple props change synchronously', async () => {
+    const shouldUpdateCalls: ComponentShouldUpdateChanges[] = [];
 
     @Component({ tag: 'cmp-a' })
     class CmpA {
@@ -139,8 +140,8 @@ describe('prop', () => {
       @Prop({ mutable: true }) second = 'initial-second';
       @Prop({ mutable: true }) third = 'initial-third';
 
-      componentShouldUpdate(value: any, old: any, prop: string) {
-        shouldUpdateCalls.push({ value, old, prop });
+      componentShouldUpdate(changes: ComponentShouldUpdateChanges<this>) {
+        shouldUpdateCalls.push(changes);
       }
 
       render() {
@@ -166,22 +167,12 @@ describe('prop', () => {
     root.third = 'new-third';
     await waitForChanges();
 
-    // componentShouldUpdate should have been called for each prop
-    expect(shouldUpdateCalls).toHaveLength(3);
+    // componentShouldUpdate should have been called once, with all three changes batched
+    expect(shouldUpdateCalls).toHaveLength(1);
     expect(shouldUpdateCalls[0]).toEqual({
-      value: 'new-first',
-      old: 'initial-first',
-      prop: 'first',
-    });
-    expect(shouldUpdateCalls[1]).toEqual({
-      value: 'new-second',
-      old: 'initial-second',
-      prop: 'second',
-    });
-    expect(shouldUpdateCalls[2]).toEqual({
-      value: 'new-third',
-      old: 'initial-third',
-      prop: 'third',
+      first: { newVal: 'new-first', oldVal: 'initial-first' },
+      second: { newVal: 'new-second', oldVal: 'initial-second' },
+      third: { newVal: 'new-third', oldVal: 'initial-third' },
     });
 
     // All values should be rendered
@@ -197,9 +188,9 @@ describe('prop', () => {
     class CmpA {
       @Prop() num = 1;
 
-      componentShouldUpdate(newValue: number, _: number, propName: string) {
-        if (propName === 'num') {
-          return newValue % 2 === 0;
+      componentShouldUpdate(changes: ComponentShouldUpdateChanges<this>) {
+        if (changes.num) {
+          return changes.num.newVal % 2 === 0;
         }
         return true;
       }

--- a/packages/core/src/runtime/_test_/signals.spec.ts
+++ b/packages/core/src/runtime/_test_/signals.spec.ts
@@ -193,22 +193,15 @@ describe('initializeSignals', () => {
   });
 
   // componentShouldUpdate
+  //
+  // componentShouldUpdate itself is no longer invoked from the signal effect -
+  // changes are queued onto hostRef.$queuedPropChanges$ and flushed with a single
+  // batched call from dispatchHooks (see update-component.ts) right before the
+  // pending render, so scheduleUpdate always fires once a value changes.
 
-  describe('componentShouldUpdate veto', () => {
-    it('skips scheduleUpdate when componentShouldUpdate returns false', () => {
+  describe('componentShouldUpdate queuing', () => {
+    it('queues the change onto $queuedPropChanges$ and still calls scheduleUpdate', () => {
       const instance = { componentShouldUpdate: vi.fn().mockReturnValue(false) };
-      const hostRef = makeHostRef({ $lazyInstance$: instance as any });
-      const cmpMeta = makeCmpMeta({ count: MEMBER_FLAGS.State });
-      initializeSignals(elm, hostRef, cmpMeta);
-
-      hostRef.$flags$ |= HOST_FLAGS.hasRendered;
-      hostRef.$signalValues$!.get('count')!.value = 1;
-
-      expect(scheduleUpdate).not.toHaveBeenCalled();
-    });
-
-    it('calls componentShouldUpdate with (newVal, prevVal, memberName)', () => {
-      const instance = { componentShouldUpdate: vi.fn().mockReturnValue(true) };
       const hostRef = makeHostRef({
         $lazyInstance$: instance as any,
         $instanceValues$: new Map([['count', 0]]),
@@ -219,22 +212,28 @@ describe('initializeSignals', () => {
       hostRef.$flags$ |= HOST_FLAGS.hasRendered;
       hostRef.$signalValues$!.get('count')!.value = 5;
 
-      expect(instance.componentShouldUpdate).toHaveBeenCalledWith(5, 0, 'count');
-    });
-
-    it('still calls scheduleUpdate when componentShouldUpdate returns true', () => {
-      const instance = { componentShouldUpdate: vi.fn().mockReturnValue(true) };
-      const hostRef = makeHostRef({ $lazyInstance$: instance as any });
-      const cmpMeta = makeCmpMeta({ count: MEMBER_FLAGS.State });
-      initializeSignals(elm, hostRef, cmpMeta);
-
-      hostRef.$flags$ |= HOST_FLAGS.hasRendered;
-      hostRef.$signalValues$!.get('count')!.value = 1;
-
+      expect(instance.componentShouldUpdate).not.toHaveBeenCalled();
+      expect(hostRef.$queuedPropChanges$).toEqual({ count: { newVal: 5, oldVal: 0 } });
       expect(scheduleUpdate).toHaveBeenCalledOnce();
     });
 
-    it('still calls scheduleUpdate when componentShouldUpdate is absent', () => {
+    it('keeps the first oldVal and latest newVal when the same signal changes twice before flush', () => {
+      const instance = { componentShouldUpdate: vi.fn() };
+      const hostRef = makeHostRef({
+        $lazyInstance$: instance as any,
+        $instanceValues$: new Map([['count', 0]]),
+        $flags$: HOST_FLAGS.hasRendered,
+      });
+      const cmpMeta = makeCmpMeta({ count: MEMBER_FLAGS.State });
+      initializeSignals(elm, hostRef, cmpMeta);
+
+      hostRef.$signalValues$!.get('count')!.value = 5;
+      hostRef.$signalValues$!.get('count')!.value = 10;
+
+      expect(hostRef.$queuedPropChanges$).toEqual({ count: { newVal: 10, oldVal: 0 } });
+    });
+
+    it('does not touch $queuedPropChanges$ when componentShouldUpdate is absent', () => {
       const instance = {};
       const hostRef = makeHostRef({ $lazyInstance$: instance as any });
       const cmpMeta = makeCmpMeta({ count: MEMBER_FLAGS.State });
@@ -243,21 +242,33 @@ describe('initializeSignals', () => {
       hostRef.$flags$ |= HOST_FLAGS.hasRendered;
       hostRef.$signalValues$!.get('count')!.value = 1;
 
+      expect(hostRef.$queuedPropChanges$).toBeUndefined();
       expect(scheduleUpdate).toHaveBeenCalledOnce();
     });
 
-    it('skips scheduleUpdate when veto AND isQueuedForUpdate (falls through, already queued)', () => {
-      const instance = { componentShouldUpdate: vi.fn().mockReturnValue(false) };
-      const hostRef = makeHostRef({ $lazyInstance$: instance as any });
-      const cmpMeta = makeCmpMeta({ count: MEMBER_FLAGS.State });
+    it('accumulates entries for multiple signals changed synchronously', () => {
+      const instance = { componentShouldUpdate: vi.fn() };
+      const hostRef = makeHostRef({
+        $lazyInstance$: instance as any,
+        $instanceValues$: new Map([
+          ['count', 0],
+          ['other', 0],
+        ]),
+      });
+      const cmpMeta = makeCmpMeta({ count: MEMBER_FLAGS.State, other: MEMBER_FLAGS.State });
       initializeSignals(elm, hostRef, cmpMeta);
 
-      hostRef.$flags$ |= HOST_FLAGS.hasRendered | HOST_FLAGS.isQueuedForUpdate;
+      hostRef.$flags$ |= HOST_FLAGS.hasRendered;
       hostRef.$signalValues$!.get('count')!.value = 1;
+      // Simulate: the first scheduleUpdate queued the render
+      hostRef.$flags$ |= HOST_FLAGS.isQueuedForUpdate;
+      hostRef.$signalValues$!.get('other')!.value = 1;
 
-      // componentShouldUpdate veto is ignored when already queued,
-      // but scheduleUpdate is still not called (already queued guard)
-      expect(scheduleUpdate).not.toHaveBeenCalled();
+      expect(hostRef.$queuedPropChanges$).toEqual({
+        count: { newVal: 1, oldVal: 0 },
+        other: { newVal: 1, oldVal: 0 },
+      });
+      expect(scheduleUpdate).toHaveBeenCalledOnce();
     });
   });
 

--- a/packages/core/src/runtime/set-value.ts
+++ b/packages/core/src/runtime/set-value.ts
@@ -186,12 +186,10 @@ export const setValue = (
 
     if (BUILD.updatable && flags & HOST_FLAGS.hasRendered) {
       if (instance.componentShouldUpdate) {
-        const shouldUpdate = instance.componentShouldUpdate(newVal, oldVal, propName);
-        // skip scheduling if componentShouldUpdate returns false AND we're not already queued.
-        // If already queued, the render will happen anyway with all the batched prop changes.
-        if (shouldUpdate === false && !(flags & HOST_FLAGS.isQueuedForUpdate)) {
-          return;
-        }
+        // queue the change for a single batched `componentShouldUpdate` call
+        // right before the pending render, rather than calling it here per-prop
+        const changes = (hostRef.$queuedPropChanges$ ||= {});
+        changes[propName] = { newVal, oldVal: changes[propName]?.oldVal ?? oldVal };
       }
 
       // looks like this value actually changed, so we've got work to do!

--- a/packages/core/src/runtime/signals.ts
+++ b/packages/core/src/runtime/signals.ts
@@ -64,15 +64,13 @@ export const initializeSignals = (
         const newVal = sig.value;
         if (hostRef.$flags$ & HOST_FLAGS.hasRendered) {
           if (instance?.componentShouldUpdate) {
-            const shouldUpdate = instance.componentShouldUpdate(
+            // queue the change for a single batched `componentShouldUpdate` call
+            // right before the pending render, rather than calling it here per-signal
+            const changes = (hostRef.$queuedPropChanges$ ||= {});
+            changes[memberName] = {
               newVal,
-              prevScheduleVal,
-              memberName,
-            );
-            if (shouldUpdate === false && !(hostRef.$flags$ & HOST_FLAGS.isQueuedForUpdate)) {
-              prevScheduleVal = newVal;
-              return;
-            }
+              oldVal: changes[memberName]?.oldVal ?? prevScheduleVal,
+            };
           }
           if (!(hostRef.$flags$ & HOST_FLAGS.isQueuedForUpdate)) {
             scheduleUpdate(hostRef, false);

--- a/packages/core/src/runtime/update-component.ts
+++ b/packages/core/src/runtime/update-component.ts
@@ -138,6 +138,15 @@ const dispatchHooks = (hostRef: d.HostRef, isInitialLoad: boolean): Promise<void
     // declared above to hold a possible 'queueing' Promise
     maybePromise = safeCall(instance, 'componentWillLoad', undefined, elm);
   } else {
+    if (BUILD.updatable && hostRef.$queuedPropChanges$) {
+      const changes = hostRef.$queuedPropChanges$;
+      hostRef.$queuedPropChanges$ = undefined;
+      if (safeCall(instance, 'componentShouldUpdate', changes, elm) === false) {
+        hostRef.$flags$ &= ~HOST_FLAGS.isQueuedForUpdate;
+        return;
+      }
+    }
+
     if (BUILD.lifecycleDOMEvents) {
       emitLifecycleEvent(elm, 'componentWillUpdate');
     }

--- a/test/build/build-size/kitchen-sink/test-bundle-size.js
+++ b/test/build/build-size/kitchen-sink/test-bundle-size.js
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const distDir = path.join(__dirname, 'dist', 'loader-bundle', 'bundlesize-kitchen-sink');
-const maxBundleSize = 28 * 1024; // 28KB in bytes (~27KB non-gzipped, ~10KB gzipped)
+const maxBundleSize = 29 * 1024; // 29KB in bytes (~28KB non-gzipped, ~10KB gzipped)
 
 console.log('\nChecking bundle size (kitchen-sink)...');
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: https://github.com/stenciljs/core/issues/6759


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

`componentShouldUpdate` now fires once per render cycle instead of once per changed `@Prop`/`@State`. The callback signature changed from `(newVal, oldVal, propName)` to a single `changes` argument: a map of every prop/state name that changed since the last render to its `{ newVal, oldVal }`.

```ts
@Prop() prop1;

componentShouldUpdate(changes) {
  if (changes['prop1'].newVal === changes['prop1'].oldVal) {
    return false;
  }
}
```

Alternatively, you can get some typing via `ComponentShouldUpdateChanges`

```ts
@Prop() prop1;

componentShouldUpdate(changes: ComponentShouldUpdateChanges<this>) {
  if (changes['unknown'].newVal === changes['unknown'].oldVal) { // << will throw
    return false;
  }
}
```

### Migration pathway

Users should update their `componentShouldUpdate` method to accept the single `changes` argument (optionally typed as `ComponentShouldUpdateChanges<this>` for per-prop typing) and 2) rewrite any per-prop branching logic to key off `changes[propName]` instead of the old `propName` parameter.

Additionally, a compiler warning will throw when more than one argument is passed to `componentShouldUpdate`

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
