### PR TITLE
fix(runtime): keep isQueuedForUpdate guard active under taskQueue: 'immediate'

### DIFF
--- a/src/runtime/test/immediate-reentrancy.spec.tsx
+++ b/src/runtime/test/immediate-reentrancy.spec.tsx
@@ -1,0 +1,87 @@
+import { BUILD } from '@app-data';
+import { Component, h, Prop, State } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+/**
+ * Regression test for the `taskQueue: 'immediate'` reentrancy hole.
+ *
+ * The re-render de-dup / reentrancy guard relies on `HOST_FLAGS.isQueuedForUpdate`.
+ * Previously BOTH its set (scheduleUpdate) and clear (callRender) were gated behind
+ * `BUILD.taskQueue`, so under `immediate` (BUILD.taskQueue === false) the flag was
+ * never set. Because scheduleUpdate dispatches synchronously in that mode, a state
+ * write during render() (e.g. the common "measure the DOM, then setState" pattern)
+ * re-entered the render synchronously and unbounded — and could corrupt an in-flight
+ * vdom patch.
+ *
+ * The guard is now gated on `BUILD.updatable` only, so a single external update
+ * triggers a single follow-up render in BOTH scheduling modes.
+ */
+describe("scheduleUpdate reentrancy guard (taskQueue: 'immediate')", () => {
+  const CAP = 60;
+  let renderCount = 0;
+
+  @Component({ tag: 'cmp-reentry' })
+  class CmpReentry {
+    // external re-render trigger
+    @Prop() trigger = 0;
+    // simulates "measure the DOM, then set state during render" (truncation pattern)
+    @State() measured = 0;
+
+    render() {
+      renderCount++;
+      // Ask for another render from within render(). The guard must coalesce this;
+      // the CAP only prevents a hang if the guard is broken.
+      if (renderCount <= CAP) {
+        this.measured++;
+      }
+      return <div>{this.measured}</div>;
+    }
+  }
+
+  const originalTaskQueue = BUILD.taskQueue;
+
+  beforeEach(() => {
+    renderCount = 0;
+  });
+
+  afterEach(() => {
+    BUILD.taskQueue = originalTaskQueue;
+  });
+
+  it('async: a state write during render() is coalesced — 1 render per external update', async () => {
+    BUILD.taskQueue = true;
+
+    const { root, waitForChanges } = await newSpecPage({
+      components: [CmpReentry],
+      html: `<cmp-reentry></cmp-reentry>`,
+    });
+    expect(renderCount).toBe(1);
+
+    (root as any).trigger = 1;
+    await waitForChanges();
+
+    expect(renderCount).toBe(2);
+  });
+
+  it('immediate: a state write during render() is coalesced — does NOT re-enter unbounded', async () => {
+    // mount in async mode so the initial render behaves identically
+    BUILD.taskQueue = true;
+    const { root, waitForChanges } = await newSpecPage({
+      components: [CmpReentry],
+      html: `<cmp-reentry></cmp-reentry>`,
+    });
+    await waitForChanges();
+    expect(renderCount).toBe(1);
+
+    // switch the platform to 'immediate' and fire a single external update
+    BUILD.taskQueue = false;
+    renderCount = 0;
+
+    (root as any).trigger = 1;
+    await waitForChanges();
+
+    // With the guard active, one external update == one follow-up render.
+    // Before the fix this was CAP + 1 (runaway synchronous reentrancy).
+    expect(renderCount).toBe(1);
+  });
+});

--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -24,7 +24,13 @@ export const attachToAncestor = (hostRef: d.HostRef, ancestorComponent?: d.HostE
 };
 
 export const scheduleUpdate = (hostRef: d.HostRef, isInitialLoad: boolean): Promise<void> | void => {
-  if (BUILD.taskQueue && BUILD.updatable) {
+  if (BUILD.updatable) {
+    // Mark this host as queued/rendering. This must NOT be gated on
+    // `BUILD.taskQueue`: under `taskQueue: 'immediate'` scheduleUpdate dispatches
+    // synchronously, so this flag is the only thing that stops a state write made
+    // during render() (e.g. a measure-then-setState pattern) from synchronously
+    // re-entering the render and corrupting the in-flight vdom patch. It is
+    // cleared in `callRender` once render() has run.
     hostRef.$flags$ |= HOST_FLAGS.isQueuedForUpdate;
   }
   if (BUILD.asyncLoading && hostRef.$flags$ & HOST_FLAGS.isWaitingForChildren) {
@@ -284,7 +290,6 @@ const callRender = (hostRef: d.HostRef, instance: any, elm: HTMLElement, isIniti
   // https://rollupjs.org/guide/en/#treeshake tryCatchDeoptimization
   const allRenderFn = BUILD.allRenderFn ? true : false;
   const lazyLoad = BUILD.lazyLoad ? true : false;
-  const taskQueue = BUILD.taskQueue ? true : false;
   const updatable = BUILD.updatable ? true : false;
 
   try {
@@ -295,7 +300,10 @@ const callRender = (hostRef: d.HostRef, instance: any, elm: HTMLElement, isIniti
      */
     instance = allRenderFn ? instance.render() : instance.render && instance.render();
 
-    if (updatable && taskQueue) {
+    if (updatable) {
+      // Clear the queued/rendering flag now that render() has produced the new
+      // tree. Not gated on `BUILD.taskQueue` so the reentrancy guard set in
+      // `scheduleUpdate` is balanced under `taskQueue: 'immediate'` too.
       hostRef.$flags$ &= ~HOST_FLAGS.isQueuedForUpdate;
     }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: [#6787](https://github.com/stenciljs/core/issues/6787)

Under `taskQueue: 'immediate'` the `HOST_FLAGS.isQueuedForUpdate` reentrancy/dedup guard is inert: both its set (`scheduleUpdate`) and clear (`callRender`) were gated behind `BUILD.taskQueue`, which is `false` in immediate mode. Since immediate dispatches renders synchronously, a state write during `render()` (e.g. measure DOM then set state for the final DOM for text middle truncation) synchronously re-enters the render — unbounded, and able to corrupt an in-flight vdom patch (`Cannot read properties of null (reading 'nodeType')`).

[#6673](https://github.com/stenciljs/core/pull/6673) patched one entry point (reflected bool attr removal); this further addresses the root cause.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
The set/clear of `isQueuedForUpdate` is now gated on `BUILD.updatable` only. The flag correctly reflects "an update is scheduled/in-progress" in every scheduling mode, so `setValue`/`forceUpdate` coalesce a state write made during render instead of re-entering.

- `async` / `congestionAsync`: **no** behavior change (`BUILD.taskQueue` is `true`, so both conditions evaluate the same as before).
- `immediate`: renders stay synchronous for external updates, but an in-render write no longer causes a synchronous reentrant re-render.


## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Immediate mode still dispatches renders synchronously; only removed the unbounded re-entry.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->
- New regression test `src/runtime/test/immediate-reentrancy.spec.tsx` asserts that one external update produces exactly one follow-up render in **both** `async` and `immediate` (drives the real runtime with `BUILD.taskQueue` toggled). Fails before the fix (unbounded), passes after.
- Full `npx jest src/runtime` — 651 tests / 64 suites green.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->