### PR TITLE
feat: added `closedby` and `focusgroup` properties

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1138,6 +1138,7 @@ export namespace JSXBase {
     onClose?: (event: Event) => void;
     open?: boolean;
     returnValue?: string;
+    closedby?: 'any' | 'closerequest' | 'none';
   }
 
   export interface EmbedHTMLAttributes<T> extends HTMLAttributes<T> {
@@ -1579,6 +1580,7 @@ export namespace JSXBase {
     // Developer must explicitly specify one of the valid popover values or it will fallback
     // to `manual` (following the HTML spec).
     popover?: string | null;
+    focusgroup?: string;
 
     // Unknown
     inputMode?: string;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?

`HTMLAttributes` is missing `focusgroup` and `DialogHTMLAttributes` is missing `closedby` properties, so this fails type-checking:

```html
<dialog
	…
	closedby="any">
```

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->


## What is the new behavior?

Adds `closedby?: 'any' | 'closerequest' | 'none';` and `focusgroup?: string;` in `src/declarations/stencil-public-runtime.ts`

<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

JSX type addition.

more information on these properties / attributes:

- https://chromestatus.com/feature/5637601087193088
- https://developer.mozilla.org/en-US/docs/Web/API/HTMLDialogElement/closedBy

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

`npm run build` succeeds.

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
