### PR TITLE
fix(compiler): resolveVar follows import chain

### DIFF
--- a/src/compiler/transformers/decorators-to-static/decorator-utils.ts
+++ b/src/compiler/transformers/decorators-to-static/decorator-utils.ts
@@ -79,7 +79,11 @@ const resolveVariableValue = (
 ): string => {
   // Handle identifiers (const variables)
   if (ts.isIdentifier(node)) {
-    const symbol = typeChecker.getSymbolAtLocation(node);
+    let symbol = typeChecker.getSymbolAtLocation(node);
+    if (symbol && symbol.flags & ts.SymbolFlags.Alias) {
+      // Follow the import chain (e.g. `import { FOO } from './constants'`)
+      symbol = typeChecker.getAliasedSymbol(symbol);
+    }
     if (!symbol || !symbol.valueDeclaration) {
       const err = buildError(diagnostics);
       err.messageText = `resolveVar() cannot resolve the value of "${node.text}" at compile time. Only const variables and object properties with string literal values are supported.`;

--- a/src/compiler/transformers/test/decorator-utils.spec.ts
+++ b/src/compiler/transformers/test/decorator-utils.spec.ts
@@ -116,6 +116,47 @@ describe('decorator utils', () => {
         expect(result).toEqual(['myEvent']);
       });
 
+      it('should resolve const variable imported from another file', () => {
+        const myEventIdentifier = ts.factory.createIdentifier('MY_EVENT');
+        const variableDeclaration = ts.factory.createVariableDeclaration(
+          myEventIdentifier,
+          undefined,
+          undefined,
+          ts.factory.createStringLiteral('myEvent'),
+        );
+
+        // Import specifiers resolve to an alias symbol whose own `valueDeclaration`
+        // is undefined; the real declaration lives on the aliased symbol.
+        const aliasedSymbolMock = {
+          valueDeclaration: variableDeclaration,
+        };
+
+        const importSymbolMock = {
+          valueDeclaration: undefined,
+          flags: ts.SymbolFlags.Alias,
+        };
+
+        const typeCheckerMock = {
+          getSymbolAtLocation: jest.fn(() => importSymbolMock),
+          getAliasedSymbol: jest.fn(() => aliasedSymbolMock),
+          getTypeAtLocation: jest.fn(() => ({
+            value: 'myEvent',
+            isLiteral: () => true,
+          })),
+        } as unknown as ts.TypeChecker;
+
+        const decorator: ts.Decorator = {
+          expression: ts.factory.createCallExpression(ts.factory.createIdentifier('Listen'), undefined, [
+            ts.factory.createCallExpression(ts.factory.createIdentifier('resolveVar'), undefined, [myEventIdentifier]),
+          ]),
+        } as unknown as ts.Decorator;
+
+        const result = getDecoratorParameters(decorator, typeCheckerMock);
+
+        expect(result).toEqual(['myEvent']);
+        expect(typeCheckerMock.getAliasedSymbol).toHaveBeenCalledWith(importSymbolMock);
+      });
+
       it('should resolve object property', () => {
         const eventsIdentifier = ts.factory.createIdentifier('EVENTS');
         const myEventProperty = ts.factory.createPropertyAccessExpression(eventsIdentifier, 'MY_EVENT');

--- a/src/compiler/transformers/test/decorator-utils.spec.ts
+++ b/src/compiler/transformers/test/decorator-utils.spec.ts
@@ -131,7 +131,7 @@ describe('decorator utils', () => {
           valueDeclaration: variableDeclaration,
         };
 
-        const importSymbolMock = {
+        const importSymbolMock: { valueDeclaration: ts.Declaration | undefined; flags: ts.SymbolFlags } = {
           valueDeclaration: undefined,
           flags: ts.SymbolFlags.Alias,
         };

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -399,7 +399,11 @@ const resolveVarInObjectLiteral = (
 ): string => {
   // Handle identifiers (const variables)
   if (ts.isIdentifier(node)) {
-    const symbol = typeChecker.getSymbolAtLocation(node);
+    let symbol = typeChecker.getSymbolAtLocation(node);
+    if (symbol && symbol.flags & ts.SymbolFlags.Alias) {
+      // Follow the import chain (e.g. `import { FOO } from './constants'`)
+      symbol = typeChecker.getAliasedSymbol(symbol);
+    }
     if (!symbol || !symbol.valueDeclaration) {
       throw new Error(
         `resolveVar() cannot resolve the value of "${node.text}" at compile time. Only const variables and object properties with string literal values are supported.`,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6800


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes #6800 - we now use the typechecker to follow a symbol's potential import chain

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
