### PR TITLE
feat(jsx): add fetchpriority attribute to img, link, script, and iframe

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1181,6 +1181,8 @@ export namespace JSXBase {
     allowtransparency?: string | boolean;
     frameBorder?: number | string;
     frameborder?: number | string;
+    fetchPriority?: 'high' | 'low' | 'auto';
+    fetchpriority?: 'high' | 'low' | 'auto';
     importance?: 'low' | 'auto' | 'high';
     height?: number | string;
     loading?: 'lazy' | 'auto' | 'eager';
@@ -1204,6 +1206,8 @@ export namespace JSXBase {
     crossOrigin?: string;
     crossorigin?: string;
     decoding?: 'async' | 'auto' | 'sync';
+    fetchPriority?: 'high' | 'low' | 'auto';
+    fetchpriority?: 'high' | 'low' | 'auto';
     importance?: 'low' | 'auto' | 'high';
     height?: number | string;
     loading?: 'lazy' | 'auto' | 'eager';
@@ -1311,6 +1315,8 @@ export namespace JSXBase {
 
   export interface LinkHTMLAttributes<T> extends HTMLAttributes<T> {
     as?: string;
+    fetchPriority?: 'high' | 'low' | 'auto';
+    fetchpriority?: 'high' | 'low' | 'auto';
     href?: string;
     hrefLang?: string;
     hreflang?: string;
@@ -1450,6 +1456,8 @@ export namespace JSXBase {
     crossOrigin?: string;
     crossorigin?: string;
     defer?: boolean;
+    fetchPriority?: 'high' | 'low' | 'auto';
+    fetchpriority?: 'high' | 'low' | 'auto';
     importance?: 'low' | 'auto' | 'high';
     integrity?: string;
     nonce?: string;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The JSX type declarations in `stencil-public-runtime.ts` do not include the standardized `fetchpriority` attribute for `<img>`, `<link>`, `<script>`, or `<iframe>` elements. Using it in a Stencil JSX template produces a TypeScript error.

GitHub Issue Number: #6802


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Adds `fetchPriority?: 'high' | 'low' | 'auto'` and `fetchpriority?: 'high' | 'low' | 'auto'` to the following `JSXBase` interfaces:

- `IframeHTMLAttributes`
- `ImgHTMLAttributes`
- `LinkHTMLAttributes`
- `ScriptHTMLAttributes`

Both camelCase and lowercase variants are added to match Stencil's existing dual-property convention (e.g. `crossOrigin`/`crossorigin`, `srcSet`/`srcset`).

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

No documentation changes required — this is a type declaration update only.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

The change is a pure type-declaration addition with no runtime behavior. Verified by:
- Confirming TypeScript accepts `fetchpriority="high"` / `fetchPriority="high"` on the affected elements after the change.
- No existing tests required modification.

## Other information

- MDN reference: https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/fetchPriority
- `fetchpriority` is now broadly supported across Chrome, Edge, Firefox, and Safari.
- The older non-standard `importance` attribute already present in these interfaces is intentionally left unchanged for backward compatibility.