### PR TITLE
fix(compiler): too many required props / "union type too complex"

### DIFF
--- a/src/compiler/types/generate-app-types.ts
+++ b/src/compiler/types/generate-app-types.ts
@@ -9,6 +9,13 @@ import { COMPONENTS_DTS_HEADER, sortImportNames } from './types-utils';
 import { updateReferenceTypeImports } from './update-import-refs';
 
 /**
+ * Above this many required props on a single component, the generated `OneOf<>` required-prop
+ * check is skipped entirely (falling back to unchecked optional `attr:`/`prop:` variants) rather
+ * than risking exponential failure in the TS checker - see the comment at its usage site.
+ */
+const MAX_ONE_OF_REQUIRED_PROPS = 8;
+
+/**
  * Generates and writes a `components.d.ts` file to disk. This file may be written to the `src` directory of a project,
  * or be written to a directory that is meant to be distributed (e.g. the output directory of `dist-custom-elements`).
  * @param config the Stencil configuration associated with the project being compiled
@@ -173,11 +180,21 @@ const generateComponentTypesFile = (
 
   c.push(`declare namespace LocalJSX {`);
 
-  // Add OneOf helper type for required prop unions
-  const hasAnyRequiredProps = modules.some((m) => m.requiredProps);
+  // Add OneOf helper type for required prop unions.
+  //
+  // This only distinguishes the bare key from `attr:` - `prop:` is intentionally left out of the
+  // union. Including it would make this a 3-way (rather than 2-way) exclusive union, and since
+  // required-prop enforcement combines one of these unions per required prop via intersection,
+  // TypeScript must distribute across all of them, which grows as (branch count)^(required prop
+  // count). At 3 branches this hits `TS2590` ("union type too complex") around 10-11 required
+  // props; capping at 2 branches roughly doubles that ceiling. `prop:` remains valid on required
+  // props via `baseOptional` below - it just can't single-handedly satisfy the required-prop check.
+  const hasAnyRequiredProps = modules.some(
+    (m) => m.requiredProps && m.requiredProps.length > 0 && m.requiredProps.length <= MAX_ONE_OF_REQUIRED_PROPS,
+  );
   if (hasAnyRequiredProps) {
     c.push(
-      `    type OneOf<K extends string, PropT, AttrT = PropT> = { [P in K]: PropT } & { [P in \`attr:\${K}\` | \`prop:\${K}\`]?: never } | { [P in \`attr:\${K}\`]: AttrT } & { [P in K | \`prop:\${K}\`]?: never } | { [P in \`prop:\${K}\`]: PropT } & { [P in K | \`attr:\${K}\`]?: never };`,
+      `    type OneOf<K extends string, PropT, AttrT = PropT> = { [P in K]: PropT } & { [P in \`attr:\${K}\`]?: never } | { [P in \`attr:\${K}\`]: AttrT } & { [P in K]?: never };`,
     );
     c.push(``);
   }
@@ -203,7 +220,7 @@ const generateComponentTypesFile = (
         // Base optional props (props without attributes or optional props with attributes)
         const baseOptional = `Omit<${m.tagNameAsPascal}, keyof ${m.tagNameAsPascal}Attributes> & { [K in keyof ${m.tagNameAsPascal} & keyof ${m.tagNameAsPascal}Attributes]?: ${m.tagNameAsPascal}[K] } & { [K in keyof ${m.tagNameAsPascal} & keyof ${m.tagNameAsPascal}Attributes as \`attr:\${K}\`]?: ${m.tagNameAsPascal}Attributes[K] } & { [K in keyof ${m.tagNameAsPascal} & keyof ${m.tagNameAsPascal}Attributes as \`prop:\${K}\`]?: ${m.tagNameAsPascal}[K] }`;
 
-        if (m.requiredProps && m.requiredProps.length > 0) {
+        if (m.requiredProps && m.requiredProps.length > 0 && m.requiredProps.length <= MAX_ONE_OF_REQUIRED_PROPS) {
           // Generate OneOf unions for each required prop
           const requiredUnions = m.requiredProps
             .map((prop) => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6799


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes #6799

Simplifies the `OneOf` union by dropping the `prop:my-prop` and `my-prop` discrimination. 
Additionally, sets a max required prop count (to 8) - so components with more than this will not crash (or slow down) typescript

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
