### PR TITLE
feat(jsx): add global `translate` attribute to HTMLAttributes

### DIFF
--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1583,9 +1583,7 @@ export namespace JSXBase {
     tabIndex?: number;
     tabindex?: number | string;
     title?: string;
-    // The `'yes' | 'no'` literals provide autocomplete for the common values,
-    // while `(string & {})` keeps that autocomplete without rejecting values
-    // that are widened to `string` (e.g. spread from an object literal).
+    // `(string & {})` keeps autocomplete without rejecting vals spread from an object literal
     translate?: 'yes' | 'no' | (string & {});
     // These types don't allow you to use popover as a boolean attribute
     // so you can't write HTML like `<div popover>` and get the default value.

--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -1583,6 +1583,10 @@ export namespace JSXBase {
     tabIndex?: number;
     tabindex?: number | string;
     title?: string;
+    // The `'yes' | 'no'` literals provide autocomplete for the common values,
+    // while `(string & {})` keeps that autocomplete without rejecting values
+    // that are widened to `string` (e.g. spread from an object literal).
+    translate?: 'yes' | 'no' | (string & {});
     // These types don't allow you to use popover as a boolean attribute
     // so you can't write HTML like `<div popover>` and get the default value.
     // Developer must explicitly specify one of the valid popover values or it will fallback


### PR DESCRIPTION
## What is the current behavior?

Stencil's JSX typings (`JSXBase.HTMLAttributes`) include the standard global HTML attributes such as `dir`, `lang`, `hidden`, `spellcheck`, and `draggable`, but omit the global [`translate`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate) attribute.

As a result, `<p translate="no">…</p>` fails to type-check in a Stencil component, forcing consumers to work around it by spreading an untyped object.

GitHub Issue Number: #6807

## What is the new behavior?

Closes #6807

Adds `translate` to `JSXBase.HTMLAttributes` so it is available on every native and custom element, consistent with the other global HTML attributes already present:

```ts
translate?: 'yes' | 'no' | (string & {});
```

## Documentation

N/A — this mirrors the existing global HTML attributes already documented via the type definitions.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Purely additive to an interface; existing code continues to type-check.

## Testing

These JSX attribute typings are validated by TypeScript at compile time and have no dedicated runtime unit test (the same is true for the sibling global attributes like `spellcheck`, `dir`, and `lang`). Verified that:

- The change compiles.
- `prettier --check` passes for the modified file.
