### PR TITLE
chore: v5 utilise `ts.SymbolFlags.Alias` in class-extension

### DIFF
--- a/packages/core/src/compiler/transformers/_test_/parse-extends.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/parse-extends.spec.ts
@@ -185,4 +185,36 @@ describe('transpile() – cross-file class extension', () => {
     const propNames = cmp.properties.map((p: any) => p.name);
     expect(propNames.filter((n: string) => n === 'baseProp')).toHaveLength(1);
   });
+
+  it('resolves a base class declared in the same file (full-compiler path)', async () => {
+    const results = await transpile(
+      `
+      import { Component, Prop, State, Method } from '@stencil/core';
+
+      class ExtendsBase {
+        @Prop() baseProp: string = 'base';
+        @State() baseState: string = 'base';
+        @Method() async baseMethod() {}
+      }
+
+      @Component({ tag: 'my-component' })
+      export class MyComponent extends ExtendsBase {
+        @Prop() ownProp: string = 'own';
+      }
+      `,
+      {
+        file: join(fixturesDir, 'my-component.tsx'),
+        target: 'es2022',
+        currentDirectory: fixturesDir,
+      },
+    );
+
+    expect(results.diagnostics).toHaveLength(0);
+    const cmp = results.data?.[0];
+    expect(cmp).toBeDefined();
+    expect(cmp.properties.map((p: any) => p.name)).toContain('ownProp');
+    expect(cmp.properties.map((p: any) => p.name)).toContain('baseProp');
+    expect(cmp.states.map((s: any) => s.name)).toContain('baseState');
+    expect(cmp.methods.map((m: any) => m.name)).toContain('baseMethod');
+  });
 });

--- a/packages/core/src/compiler/transformers/static-to-meta/class-extension.ts
+++ b/packages/core/src/compiler/transformers/static-to-meta/class-extension.ts
@@ -377,11 +377,13 @@ function buildExtendsTree(
     try {
       // happy path (normally 1 file level removed): the extends type resolves to a class declaration in another file
 
-      const symbol = typeChecker?.getSymbolAtLocation(extendee);
-      const aliasedSymbol = symbol ? typeChecker.getAliasedSymbol(symbol) : undefined;
+      let symbol = typeChecker?.getSymbolAtLocation(extendee);
+      if (symbol && symbol.flags & ts.SymbolFlags.Alias) {
+        symbol = typeChecker.getAliasedSymbol(symbol);
+      }
 
-      let source = aliasedSymbol?.declarations?.[0].getSourceFile();
-      let declarations: ts.Declaration[] | ts.Statement[] = aliasedSymbol?.declarations;
+      let source = symbol?.declarations?.[0].getSourceFile();
+      let declarations: ts.Declaration[] | ts.Statement[] = symbol?.declarations;
 
       if (source.fileName.endsWith('.d.ts')) {
         source = convertDtsToJs(source.fileName, compilerCtx);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
