### PR TITLE
fix(runtime): memory leak on document.hidden

### DIFF
--- a/src/client/client-task-queue.ts
+++ b/src/client/client-task-queue.ts
@@ -12,7 +12,6 @@ const queueDomReads: d.RafCallback[] = [];
 const queueDomWrites: d.RafCallback[] = [];
 const queueDomWritesLow: d.RafCallback[] = [];
 
-
 // Fallback to microtask when `document.hidden`: `requestAnimationFrame` callbacks
 // do not fire so scheduling flush queues tasks indefinitely.
 const scheduleFlush = () => (win.document?.hidden ? nextTick(flush) : plt.raf(flush));

--- a/src/client/client-task-queue.ts
+++ b/src/client/client-task-queue.ts
@@ -12,10 +12,9 @@ const queueDomReads: d.RafCallback[] = [];
 const queueDomWrites: d.RafCallback[] = [];
 const queueDomWritesLow: d.RafCallback[] = [];
 
-/**
- * Fallback to microtask when `document.hidden`: `requestAnimationFrame` callbacks
- * do not fire so scheduling flush queues tasks indefinitely.
- */
+
+// Fallback to microtask when `document.hidden`: `requestAnimationFrame` callbacks
+// do not fire so scheduling flush queues tasks indefinitely.
 const scheduleFlush = () => (win.document?.hidden ? nextTick(flush) : plt.raf(flush));
 
 const queueTask = (queue: d.RafCallback[], write: boolean) => (cb: d.RafCallback) => {

--- a/src/client/client-task-queue.ts
+++ b/src/client/client-task-queue.ts
@@ -3,7 +3,7 @@ import { BUILD } from '@app-data';
 import type * as d from '../declarations';
 import { PLATFORM_FLAGS } from '../runtime/runtime-constants';
 import { consoleError } from './client-log';
-import { plt, promiseResolve } from './client-window';
+import { plt, promiseResolve, win } from './client-window';
 
 let queueCongestion = 0;
 let queuePending = false;
@@ -11,6 +11,14 @@ let queuePending = false;
 const queueDomReads: d.RafCallback[] = [];
 const queueDomWrites: d.RafCallback[] = [];
 const queueDomWritesLow: d.RafCallback[] = [];
+
+/**
+ * `requestAnimationFrame` callbacks do not fire while the document is
+ * hidden, so scheduling a flush through it here would let queued tasks (and
+ * everything they reference) pile up indefinitely on a backgrounded tab.
+ * Fall back to a microtask in that case instead.
+ */
+const scheduleFlush = () => (win.document?.hidden ? nextTick(flush) : plt.raf(flush));
 
 const queueTask = (queue: d.RafCallback[], write: boolean) => (cb: d.RafCallback) => {
   queue.push(cb);
@@ -20,7 +28,7 @@ const queueTask = (queue: d.RafCallback[], write: boolean) => (cb: d.RafCallback
     if (write && plt.$flags$ & PLATFORM_FLAGS.queueSync) {
       nextTick(flush);
     } else {
-      plt.raf(flush);
+      scheduleFlush();
     }
   }
 };
@@ -82,7 +90,7 @@ const flush = () => {
     if ((queuePending = queueDomReads.length + queueDomWrites.length + queueDomWritesLow.length > 0)) {
       // still more to do yet, but we've run out of time
       // let's let this thing cool off and try again in the next tick
-      plt.raf(flush);
+      scheduleFlush();
     } else {
       queueCongestion = 0;
     }
@@ -91,7 +99,7 @@ const flush = () => {
     if ((queuePending = queueDomReads.length > 0)) {
       // still more to do yet, but we've run out of time
       // let's let this thing cool off and try again in the next tick
-      plt.raf(flush);
+      scheduleFlush();
     }
   }
 };

--- a/src/client/client-task-queue.ts
+++ b/src/client/client-task-queue.ts
@@ -13,10 +13,8 @@ const queueDomWrites: d.RafCallback[] = [];
 const queueDomWritesLow: d.RafCallback[] = [];
 
 /**
- * `requestAnimationFrame` callbacks do not fire while the document is
- * hidden, so scheduling a flush through it here would let queued tasks (and
- * everything they reference) pile up indefinitely on a backgrounded tab.
- * Fall back to a microtask in that case instead.
+ * Fallback to microtask when `document.hidden`: `requestAnimationFrame` callbacks
+ * do not fire so scheduling flush queues tasks indefinitely.
  */
 const scheduleFlush = () => (win.document?.hidden ? nextTick(flush) : plt.raf(flush));
 

--- a/src/client/test/client-task-queue.spec.ts
+++ b/src/client/test/client-task-queue.spec.ts
@@ -1,0 +1,60 @@
+import type { plt as pltType, win as winType } from '../client-window';
+
+describe('client task queue', () => {
+  let plt: typeof pltType;
+  let win: typeof winType;
+  let writeTask: typeof import('../client-task-queue').writeTask;
+
+  beforeEach(() => {
+    // each test gets an isolated module instance, since `queuePending` and
+    // the queued task arrays are private, file-scoped state that would
+    // otherwise leak between tests
+    jest.resetModules();
+    ({ plt, win } = require('../client-window'));
+    ({ writeTask } = require('../client-task-queue'));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('flushes a queued write task via a microtask when the document is hidden, without ever calling rAF', async () => {
+    (win as any).document = { hidden: true };
+    const rafSpy = jest.spyOn(plt, 'raf').mockImplementation(() => 0);
+
+    let called = false;
+    writeTask(() => {
+      called = true;
+    });
+
+    expect(called).toBe(false);
+
+    // let the microtask queue drain
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(called).toBe(true);
+    expect(rafSpy).not.toHaveBeenCalled();
+  });
+
+  it('still schedules the flush via rAF when the document is visible', async () => {
+    (win as any).document = { hidden: false };
+    let rafCallback: FrameRequestCallback | undefined;
+    const rafSpy = jest.spyOn(plt, 'raf').mockImplementation((cb: FrameRequestCallback) => {
+      rafCallback = cb;
+      return 0;
+    });
+
+    let called = false;
+    writeTask(() => {
+      called = true;
+    });
+
+    expect(rafSpy).toHaveBeenCalledTimes(1);
+    expect(called).toBe(false);
+
+    rafCallback!(performance.now());
+
+    expect(called).toBe(true);
+  });
+});

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -186,11 +186,8 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
            * Also remove the reference from `deferredConnectedCallbacks` array
            * otherwise removed instances won't get garbage collected.
            *
-           * This bookkeeping is deferred with `nextTick` rather than `plt.raf`
-           * since `requestAnimationFrame` callbacks do not fire while the
-           * document is hidden, which would otherwise pin every disconnected
-           * host element (and everything it references) in memory for as
-           * long as the tab stays in the background.
+           * Use `nextTick` (microtask) rather than `plt.raf` since
+           * `requestAnimationFrame` callbacks do not fire while `document.hidden`
            */
           nextTick(() => {
             const hostRef = getHostRef(this);

--- a/src/runtime/bootstrap-lazy.ts
+++ b/src/runtime/bootstrap-lazy.ts
@@ -1,5 +1,5 @@
 import { BUILD } from '@app-data';
-import { getHostRef, plt, registerHost, supportsShadow, transformTag, win } from '@platform';
+import { getHostRef, nextTick, plt, registerHost, supportsShadow, transformTag, win } from '@platform';
 import { addHostEventListeners } from '@runtime';
 
 import type * as d from '../declarations';
@@ -185,8 +185,14 @@ export const bootstrapLazy = (lazyBundles: d.LazyBundlesRuntimeData, options: d.
            *
            * Also remove the reference from `deferredConnectedCallbacks` array
            * otherwise removed instances won't get garbage collected.
+           *
+           * This bookkeeping is deferred with `nextTick` rather than `plt.raf`
+           * since `requestAnimationFrame` callbacks do not fire while the
+           * document is hidden, which would otherwise pin every disconnected
+           * host element (and everything it references) in memory for as
+           * long as the tab stays in the background.
            */
-          plt.raf(() => {
+          nextTick(() => {
             const hostRef = getHostRef(this);
             if (!hostRef) {
               return;

--- a/src/runtime/test/bootstrap-lazy.spec.tsx
+++ b/src/runtime/test/bootstrap-lazy.spec.tsx
@@ -1,4 +1,6 @@
-import { win } from '@platform';
+import { Component } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+import { getHostRef, win } from '@stencil/core/internal/testing';
 
 import { LazyBundlesRuntimeData } from '../../internal';
 import { bootstrapLazy } from '../bootstrap-lazy';
@@ -59,5 +61,34 @@ describe('bootstrap lazy', () => {
       }),
       null,
     );
+  });
+
+  describe('disconnectedCallback', () => {
+    it('cleans up host references without waiting on requestAnimationFrame', async () => {
+      @Component({ tag: 'leak-cmp' })
+      class LeakCmp {}
+
+      // a hidden tab never runs rAF callbacks - mock it to never invoke its
+      // callback to prove cleanup doesn't depend on one ever firing
+      const rafSpy = jest.spyOn(global, 'requestAnimationFrame').mockImplementation(() => 0);
+
+      const { root, waitForChanges } = await newSpecPage({
+        components: [LeakCmp],
+        html: `<leak-cmp></leak-cmp>`,
+      });
+
+      const hostRef = getHostRef(root)!;
+      expect(hostRef.$vnode$?.$elm$).toBe(root);
+
+      root.remove();
+      expect(hostRef.$vnode$?.$elm$).toBe(root);
+
+      await waitForChanges();
+
+      expect(hostRef.$vnode$?.$elm$).toBeUndefined();
+      expect(rafSpy).not.toHaveBeenCalled();
+
+      rafSpy.mockRestore();
+    });
   });
 });

--- a/src/runtime/test/bootstrap-lazy.spec.tsx
+++ b/src/runtime/test/bootstrap-lazy.spec.tsx
@@ -1,6 +1,6 @@
 import { Component } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { getHostRef, win } from '@stencil/core/internal/testing';
+import { newSpecPage } from '@stencil/core/testing';
 
 import { LazyBundlesRuntimeData } from '../../internal';
 import { bootstrapLazy } from '../bootstrap-lazy';


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6762

requestAnimationFrame never fires when `document.hidden` (e.g. when a tab isn't open). 
This means:

1) all flushed tasks can build up indefinitely
2) any disconnected elements are not properly cleaned-up / garbage collected


In both cases (esp disconnected cleanup) the indiscriminate use of requestAnimationFrame was never a design decision, just an oversight

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes #6762

1) flushed tasks detect if `document.hidden` - if true will use microtask instead of RaF
2) disconnected elements always run cleanup via microtask

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
