### PR TITLE
fix(runtime): VDOM should not process non-vnode objects

### DIFF
--- a/src/runtime/vdom/h.ts
+++ b/src/runtime/vdom/h.ts
@@ -8,7 +8,7 @@
  */
 
 import { BUILD } from '@app-data';
-import { consoleDevError, consoleDevWarn, transformTag } from '@platform';
+import { consoleDevError, consoleDevWarn, consoleError, transformTag } from '@platform';
 import { isComplexType } from '../../utils/helpers';
 
 import type * as d from '../../declarations';
@@ -36,12 +36,17 @@ export const h = (nodeName: any, vnodeData: any, ...children: d.ChildType[]): d.
         } else if (typeof nodeName !== 'function' && child.$flags$ === undefined) {
           // this isn't a primitive value and it isn't a VNode either (e.g. a
           // `Date`, plain object, etc. was passed as a child), so there's
-          // nothing sensible to render for it - warn in dev and drop it,
-          // the same way `null`/`undefined`/boolean children are dropped
+          // nothing sensible to render for it - drop it, the same way
+          // `null`/`undefined`/boolean children are dropped. Report it via
+          // `consoleError` (not just `consoleDevError`) since this can also
+          // happen at runtime from bad data, not only bad JSX authoring, and
+          // `consoleError` is still reachable in prod builds via `setErrorHandler`.
           if (BUILD.isDev) {
             consoleDevError(`vNode passed as children has unexpected type.
 Make sure it's using the correct h() function.
 Empty objects can also be the cause, look for JSX comments that became objects.`);
+          } else {
+            consoleError('invalid vNode child');
           }
           continue;
         }

--- a/src/runtime/vdom/h.ts
+++ b/src/runtime/vdom/h.ts
@@ -33,10 +33,17 @@ export const h = (nodeName: any, vnodeData: any, ...children: d.ChildType[]): d.
       } else if (child != null && typeof child !== 'boolean') {
         if ((simple = typeof nodeName !== 'function' && !isComplexType(child))) {
           child = String(child);
-        } else if (BUILD.isDev && typeof nodeName !== 'function' && child.$flags$ === undefined) {
-          consoleDevError(`vNode passed as children has unexpected type.
+        } else if (typeof nodeName !== 'function' && child.$flags$ === undefined) {
+          // this isn't a primitive value and it isn't a VNode either (e.g. a
+          // `Date`, plain object, etc. was passed as a child), so there's
+          // nothing sensible to render for it - warn in dev and drop it,
+          // the same way `null`/`undefined`/boolean children are dropped
+          if (BUILD.isDev) {
+            consoleDevError(`vNode passed as children has unexpected type.
 Make sure it's using the correct h() function.
 Empty objects can also be the cause, look for JSX comments that became objects.`);
+          }
+          continue;
         }
 
         if (simple && lastSimple) {

--- a/src/runtime/vdom/h.ts
+++ b/src/runtime/vdom/h.ts
@@ -46,7 +46,7 @@ export const h = (nodeName: any, vnodeData: any, ...children: d.ChildType[]): d.
 Make sure it's using the correct h() function.
 Empty objects can also be the cause, look for JSX comments that became objects.`);
           } else {
-            consoleError('invalid vNode child');
+            consoleError('Invalid vNode child');
           }
           continue;
         }

--- a/src/runtime/vdom/h.ts
+++ b/src/runtime/vdom/h.ts
@@ -34,13 +34,7 @@ export const h = (nodeName: any, vnodeData: any, ...children: d.ChildType[]): d.
         if ((simple = typeof nodeName !== 'function' && !isComplexType(child))) {
           child = String(child);
         } else if (typeof nodeName !== 'function' && child.$flags$ === undefined) {
-          // this isn't a primitive value and it isn't a VNode either (e.g. a
-          // `Date`, plain object, etc. was passed as a child), so there's
-          // nothing sensible to render for it - drop it, the same way
-          // `null`/`undefined`/boolean children are dropped. Report it via
-          // `consoleError` (not just `consoleDevError`) since this can also
-          // happen at runtime from bad data, not only bad JSX authoring, and
-          // `consoleError` is still reachable in prod builds via `setErrorHandler`.
+          // not a primitive and not a VNode - drop it
           if (BUILD.isDev) {
             consoleDevError(`vNode passed as children has unexpected type.
 Make sure it's using the correct h() function.

--- a/src/runtime/vdom/test/h.spec.ts
+++ b/src/runtime/vdom/test/h.spec.ts
@@ -277,6 +277,21 @@ describe('h()', () => {
     expect(vnode.$children$).toBe(null);
   });
 
+  it('should not render a non-VNode complex value (e.g. a Date)', () => {
+    // a `Date` (or any other non-VNode object) passed as a child isn't a
+    // primitive we can stringify, nor is it an actual VNode, so there's
+    // nothing sensible to render - it should be dropped just like
+    // null/undefined/boolean children are
+    const vnode = h('a', null, [new Date()] as any);
+    expect(vnode.$children$).toBe(null);
+  });
+
+  it('should ignore a non-VNode complex value in between simple children', () => {
+    const vnode = h('a', null, 'one', new Date() as any, 'two');
+    expect(vnode.$children$.length).toBe(1);
+    expect(vnode.$children$[0].$text$).toBe('onetwo');
+  });
+
   it('should merge with booleans around', () => {
     const vnode = h('a', null, [false, 'one', true] as any, 'word');
     expect(vnode.$children$.length).toBe(1);

--- a/src/runtime/vdom/test/h.spec.ts
+++ b/src/runtime/vdom/test/h.spec.ts
@@ -278,10 +278,6 @@ describe('h()', () => {
   });
 
   it('should not render a non-VNode complex value (e.g. a Date)', () => {
-    // a `Date` (or any other non-VNode object) passed as a child isn't a
-    // primitive we can stringify, nor is it an actual VNode, so there's
-    // nothing sensible to render - it should be dropped just like
-    // null/undefined/boolean children are
     const vnode = h('a', null, [new Date()] as any);
     expect(vnode.$children$).toBe(null);
   });

--- a/src/runtime/vdom/test/patch.spec.ts
+++ b/src/runtime/vdom/test/patch.spec.ts
@@ -848,6 +848,18 @@ describe('renderer', () => {
     });
   });
 
+  describe('non-VNode complex child (e.g. a Date)', () => {
+    it('does not throw when re-rendering an element whose only child was an invalid value', () => {
+      const vnode1 = h('div', null, new Date('2026-01-15') as any);
+      patch(vnode0, vnode1);
+      expect(hostElm.innerHTML).toBe('');
+
+      const vnode2 = h('div', null, new Date('2026-03-22') as any);
+      expect(() => patch(vnode1, vnode2)).not.toThrow();
+      expect(hostElm.innerHTML).toBe('');
+    });
+  });
+
   function prop(name: any) {
     return function (obj: any) {
       return obj[name];

--- a/test/wdio/dom-reattach-clone/cmp.test.tsx
+++ b/test/wdio/dom-reattach-clone/cmp.test.tsx
@@ -12,7 +12,7 @@ describe('dom-reattach-clone', function () {
     render({
       template: () => (
         <>
-          <style>button {{ display: 'block' }}</style>
+          <style>{'button { display: block; }'}</style>
           <div id="simple-parent">
             <button onClick={() => clone('simple')} id="clone-simple">
               Clone simple


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6747

At present, Stencil's VDOM implementation attempts to handle / render non-vnode objects which throws an error.
Before Stencil v4.41.2 Stencil accidentally handled this by `toString` any complex object. After v4.41.2 a more strict string check broke this accidental handling and now such objects throw an error.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes #6747

Stencil no-longer tries to handle these unexpected objects and just ignores them. Additionally, a warning is now thrown in both dev *and* prod builds

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
