### PR TITLE
fix(docs): stop `toLowerCase()` shadow part names

### DIFF
--- a/src/compiler/transformers/static-to-meta/vdom.ts
+++ b/src/compiler/transformers/static-to-meta/vdom.ts
@@ -54,12 +54,7 @@ export const gatherVdomMeta = (m: d.Module | d.ComponentCompilerMeta, args: ts.N
           }
           ts.SyntaxKind.StringLiteral;
           if (attrName === 'part' && ts.isPropertyAssignment(prop) && ts.isStringLiteral(prop.initializer)) {
-            m.htmlParts.push(
-              ...prop.initializer.text
-                .toLowerCase()
-                .split(' ')
-                .filter((part) => part.length > 0),
-            );
+            m.htmlParts.push(...prop.initializer.text.split(' ').filter((part) => part.length > 0));
           }
           m.htmlAttrNames.push(attrName);
         }

--- a/src/compiler/transformers/test/parse-vdom.spec.ts
+++ b/src/compiler/transformers/test/parse-vdom.spec.ts
@@ -132,6 +132,19 @@ describe('parse vdom', () => {
     expect(t.cmp.hasVdomText).toBe(true);
   });
 
+  it('htmlParts preserves case and splits on whitespace', () => {
+    const t = transpileModule(`
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        render() {
+          return <some-cmp part="clickTarget otherPart"/>
+        }
+      }
+    `);
+
+    expect(t.cmp.htmlParts).toEqual(['clickTarget', 'otherPart']);
+  });
+
   it('hasSlot', () => {
     const t = transpileModule(`
       @Component({tag: 'cmp-a'})


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6671

Stencil's `part` extraction from the vdom, which then gets used in readme docs (for example) auto `toLowerCase()`. This appears to just be a bug as there's no obvious spec reason for changing the case.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes #6671

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
