### PR TITLE
fix(runtime): v5 non-shadow slot forwarding to better match native behaviour

### DIFF
--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -1489,6 +1489,12 @@ export interface RenderNode extends HostElement {
   ['s-sn']?: string;
 
   /**
+   * `slot` attribute of a `<slot>` reference rendered as a text node (no fallback content),
+   * since text nodes can't carry real DOM attributes.
+   */
+  ['s-sa']?: string;
+
+  /**
    * Host element tag name:
    * The tag name of the host element that this
    * node was created in.

--- a/src/runtime/slot-polyfill-utils.ts
+++ b/src/runtime/slot-polyfill-utils.ts
@@ -90,7 +90,7 @@ export function getHostSlotNodes(childNodes: NodeListOf<ChildNode>, hostName?: s
       slottedNodes.push(childNode);
       if (typeof slotName !== 'undefined') return slottedNodes;
     }
-    slottedNodes = [...slottedNodes, ...getHostSlotNodes(childNode.childNodes, hostName, slotName)];
+    slottedNodes = [...slottedNodes, ...getHostSlotNodes(internalCall(childNode, 'childNodes'), hostName, slotName)];
   }
   return slottedNodes;
 }
@@ -122,11 +122,6 @@ export const getSlotChildSiblings = (slot: d.RenderNode, slotName: string, inclu
  */
 export const isNodeLocatedInSlot = (nodeToRelocate: d.RenderNode, slotName: string): boolean => {
   if (nodeToRelocate.nodeType === NODE_TYPE.ElementNode) {
-    if (nodeToRelocate['s-sr']) {
-      // `<slot>` forwarded from a nested component. Identified by its own slot
-      // name (`s-sn`), not `slot` attribute (which is only set on content assigned *into* a slot).
-      return nodeToRelocate['s-sn'] === slotName;
-    }
     if (nodeToRelocate.getAttribute('slot') === null && slotName === '') {
       // if the node doesn't have a slot attribute, and the slot we're checking
       // is not a named slot, then we assume the node should be within the slot
@@ -137,13 +132,10 @@ export const isNodeLocatedInSlot = (nodeToRelocate: d.RenderNode, slotName: stri
     }
     return false;
   }
-  if (nodeToRelocate['s-sn'] === slotName) {
-    return true;
+  if (typeof nodeToRelocate['s-sa'] === 'string') {
+    return nodeToRelocate['s-sa'] === slotName;
   }
-  // If the node has no slot name assigned yet, then we assume it belongs to the default slot.
-  // A node that already has a (different) slot name assigned - e.g. a forwarded `<slot name="x">`
-  // ref from a nested component - must not fall back to matching the default slot.
-  return slotName === '' && !nodeToRelocate['s-sn'];
+  return slotName === '';
 };
 
 /**

--- a/src/runtime/slot-polyfill-utils.ts
+++ b/src/runtime/slot-polyfill-utils.ts
@@ -122,6 +122,11 @@ export const getSlotChildSiblings = (slot: d.RenderNode, slotName: string, inclu
  */
 export const isNodeLocatedInSlot = (nodeToRelocate: d.RenderNode, slotName: string): boolean => {
   if (nodeToRelocate.nodeType === NODE_TYPE.ElementNode) {
+    if (nodeToRelocate['s-sr']) {
+      // `<slot>` forwarded from a nested component. Identified by its own slot
+      // name (`s-sn`), not `slot` attribute (which is only set on content assigned *into* a slot).
+      return nodeToRelocate['s-sn'] === slotName;
+    }
     if (nodeToRelocate.getAttribute('slot') === null && slotName === '') {
       // if the node doesn't have a slot attribute, and the slot we're checking
       // is not a named slot, then we assume the node should be within the slot
@@ -135,7 +140,10 @@ export const isNodeLocatedInSlot = (nodeToRelocate: d.RenderNode, slotName: stri
   if (nodeToRelocate['s-sn'] === slotName) {
     return true;
   }
-  return slotName === '';
+  // If the node has no slot name assigned yet, then we assume it belongs to the default slot.
+  // A node that already has a (different) slot name assigned - e.g. a forwarded `<slot name="x">`
+  // ref from a nested component - must not fall back to matching the default slot.
+  return slotName === '' && !nodeToRelocate['s-sn'];
 };
 
 /**

--- a/src/runtime/test/nested-slot-forwarding.spec.tsx
+++ b/src/runtime/test/nested-slot-forwarding.spec.tsx
@@ -24,7 +24,7 @@ describe('nested named slot forwarding', () => {
     }
   }
 
-  it('routes appendChild()-ed content through a forwarded named slot (text-node slot ref)', async () => {
+  it('routes appendChild()-ed content to the default slot when the forwarding tag has no explicit `slot` attribute', async () => {
     @Component({
       tag: 'cmp-b',
       shadow: false,
@@ -47,12 +47,53 @@ describe('nested named slot forwarding', () => {
       html: `<cmp-b><span slot="named">initial</span></cmp-b>`,
     });
 
-    const cmpAEl = page.doc.querySelector('cmp-a');
+    const namedSlotDiv = page.doc.querySelector('.named-slot');
+    const defaultSlotDiv = page.doc.querySelector('.default-slot');
+
+    expect(defaultSlotDiv.textContent).toContain('initial');
+    expect(namedSlotDiv.textContent).not.toContain('initial');
+
+    patchPseudoShadowDom(Object.getPrototypeOf(page.root));
+
+    const appended = page.doc.createElement('span');
+    appended.setAttribute('slot', 'named');
+    appended.textContent = 'appended';
+
+    page.root.appendChild(appended);
+    await page.waitForChanges();
+
+    expect(defaultSlotDiv.textContent).toContain('initial');
+    expect(defaultSlotDiv.textContent).toContain('appended');
+    expect(namedSlotDiv.textContent).not.toContain('appended');
+  });
+
+  it('routes appendChild()-ed content through a forwarding tag with an explicit `slot` attribute (text-node slot ref)', async () => {
+    @Component({
+      tag: 'cmp-b',
+      shadow: false,
+      scoped: true,
+    })
+    class CmpB {
+      render() {
+        return (
+          <cmp-a>
+            <slot />
+            <slot name="named" slot="named" />
+          </cmp-a>
+        );
+      }
+    }
+
+    const page = await newSpecPage({
+      components: [CmpA, CmpB],
+      includeAnnotations: true,
+      html: `<cmp-b><span slot="named">initial</span></cmp-b>`,
+    });
+
     const namedSlotDiv = page.doc.querySelector('.named-slot');
     const defaultSlotDiv = page.doc.querySelector('.default-slot');
 
     patchPseudoShadowDom(Object.getPrototypeOf(page.root));
-    patchPseudoShadowDom(Object.getPrototypeOf(cmpAEl));
 
     const appended = page.doc.createElement('span');
     appended.setAttribute('slot', 'named');
@@ -66,7 +107,7 @@ describe('nested named slot forwarding', () => {
     expect(defaultSlotDiv.textContent).not.toContain('appended');
   });
 
-  it('routes initial content through a forwarded named slot that has fallback content (element slot-fb ref)', async () => {
+  it('routes appendChild()-ed content through a forwarding tag with fallback content and an explicit `slot` attribute (element slot-fb ref)', async () => {
     @Component({
       tag: 'cmp-b',
       shadow: false,
@@ -77,7 +118,9 @@ describe('nested named slot forwarding', () => {
         return (
           <cmp-a>
             <slot />
-            <slot name="named">fallback</slot>
+            <slot name="named" slot="named">
+              fallback
+            </slot>
           </cmp-a>
         );
       }
@@ -89,11 +132,85 @@ describe('nested named slot forwarding', () => {
       html: `<cmp-b><span slot="named">initial</span></cmp-b>`,
     });
 
-    const namedSlotDiv = page.root.querySelector('.named-slot');
-    const defaultSlotDiv = page.root.querySelector('.default-slot');
+    const namedSlotDiv = page.doc.querySelector('.named-slot');
+    const defaultSlotDiv = page.doc.querySelector('.default-slot');
 
     expect(namedSlotDiv.textContent).toContain('initial');
-    expect(defaultSlotDiv.textContent).not.toContain('initial');
     expect(defaultSlotDiv.querySelector('slot-fb')).toBeNull();
+
+    patchPseudoShadowDom(Object.getPrototypeOf(page.root));
+
+    const appended = page.doc.createElement('span');
+    appended.setAttribute('slot', 'named');
+    appended.textContent = 'appended';
+
+    page.root.appendChild(appended);
+    await page.waitForChanges();
+
+    expect(namedSlotDiv.textContent).toContain('initial');
+    expect(namedSlotDiv.textContent).toContain('appended');
+    expect(defaultSlotDiv.textContent).not.toContain('appended');
+  });
+
+  it('hides content forwarded to a slot name that does not exist anywhere on the target', async () => {
+    @Component({
+      tag: 'cmp-b',
+      shadow: false,
+      scoped: true,
+    })
+    class CmpB {
+      render() {
+        return (
+          <cmp-a>
+            <slot />
+            {/* "nonexistent" isn't a slot cmp-a defines at all - not default, not named */}
+            <slot name="named" slot="nonexistent" />
+          </cmp-a>
+        );
+      }
+    }
+
+    const page = await newSpecPage({
+      components: [CmpA, CmpB],
+      includeAnnotations: true,
+      html: `<cmp-b><span slot="named">initial</span></cmp-b>`,
+    });
+
+    const span = page.doc.querySelector('span[slot="named"]');
+    expect(span.hidden).toBe(true);
+  });
+
+  it('does not sweep up a directly-authored slot="named" child that just happens to sit near an unrelated forwarding marker', async () => {
+    @Component({
+      tag: 'cmp-b',
+      shadow: false,
+      scoped: true,
+    })
+    class CmpB {
+      render() {
+        return (
+          <cmp-a>
+            <slot />
+            <slot name="named" />
+            {/* directly authored, not forwarded - must be unaffected by the <slot> above */}
+            <span slot="named" class="direct-named">
+              direct
+            </span>
+          </cmp-a>
+        );
+      }
+    }
+
+    const page = await newSpecPage({
+      components: [CmpA, CmpB],
+      includeAnnotations: true,
+      html: `<cmp-b></cmp-b>`,
+    });
+
+    const namedSlotDiv = page.doc.querySelector('.named-slot');
+    const defaultSlotDiv = page.doc.querySelector('.default-slot');
+
+    expect(namedSlotDiv.textContent).toContain('direct');
+    expect(defaultSlotDiv.textContent).not.toContain('direct');
   });
 });

--- a/src/runtime/test/nested-slot-forwarding.spec.tsx
+++ b/src/runtime/test/nested-slot-forwarding.spec.tsx
@@ -1,0 +1,102 @@
+import { Component, h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+import { patchPseudoShadowDom } from '../dom-extras';
+
+describe('nested named slot forwarding', () => {
+  @Component({
+    tag: 'cmp-a',
+    shadow: false,
+    scoped: true,
+  })
+  class CmpA {
+    render() {
+      return (
+        <div class="cmp-a-outer">
+          <div class="default-slot">
+            <slot />
+          </div>
+          <div class="named-slot">
+            <slot name="named" />
+          </div>
+        </div>
+      );
+    }
+  }
+
+  it('routes appendChild()-ed content through a forwarded named slot (text-node slot ref)', async () => {
+    @Component({
+      tag: 'cmp-b',
+      shadow: false,
+      scoped: true,
+    })
+    class CmpB {
+      render() {
+        return (
+          <cmp-a>
+            <slot />
+            <slot name="named" />
+          </cmp-a>
+        );
+      }
+    }
+
+    const page = await newSpecPage({
+      components: [CmpA, CmpB],
+      includeAnnotations: true,
+      html: `<cmp-b><span slot="named">initial</span></cmp-b>`,
+    });
+
+    // grab references before patching `childNodes`/`children` on the host elements below,
+    // since `patchPseudoShadowDom` narrows those accessors to slotted content only, which
+    // breaks `querySelector`'s ability to traverse into (and past) cmp-a/cmp-b afterwards.
+    const cmpAEl = page.doc.querySelector('cmp-a');
+    const namedSlotDiv = page.doc.querySelector('.named-slot');
+    const defaultSlotDiv = page.doc.querySelector('.default-slot');
+
+    patchPseudoShadowDom(Object.getPrototypeOf(page.root));
+    patchPseudoShadowDom(Object.getPrototypeOf(cmpAEl));
+
+    const appended = page.doc.createElement('span');
+    appended.setAttribute('slot', 'named');
+    appended.textContent = 'appended';
+
+    page.root.appendChild(appended);
+    await page.waitForChanges();
+
+    expect(namedSlotDiv.textContent).toContain('initial');
+    expect(namedSlotDiv.textContent).toContain('appended');
+    expect(defaultSlotDiv.textContent).not.toContain('appended');
+  });
+
+  it('routes initial content through a forwarded named slot that has fallback content (element slot-fb ref)', async () => {
+    @Component({
+      tag: 'cmp-b',
+      shadow: false,
+      scoped: true,
+    })
+    class CmpB {
+      render() {
+        return (
+          <cmp-a>
+            <slot />
+            <slot name="named">fallback</slot>
+          </cmp-a>
+        );
+      }
+    }
+
+    const page = await newSpecPage({
+      components: [CmpA, CmpB],
+      includeAnnotations: true,
+      html: `<cmp-b><span slot="named">initial</span></cmp-b>`,
+    });
+
+    const namedSlotDiv = page.root.querySelector('.named-slot');
+    const defaultSlotDiv = page.root.querySelector('.default-slot');
+
+    expect(namedSlotDiv.textContent).toContain('initial');
+    expect(defaultSlotDiv.textContent).not.toContain('initial');
+    expect(defaultSlotDiv.querySelector('slot-fb')).toBeNull();
+  });
+});

--- a/src/runtime/test/nested-slot-forwarding.spec.tsx
+++ b/src/runtime/test/nested-slot-forwarding.spec.tsx
@@ -47,9 +47,6 @@ describe('nested named slot forwarding', () => {
       html: `<cmp-b><span slot="named">initial</span></cmp-b>`,
     });
 
-    // grab references before patching `childNodes`/`children` on the host elements below,
-    // since `patchPseudoShadowDom` narrows those accessors to slotted content only, which
-    // breaks `querySelector`'s ability to traverse into (and past) cmp-a/cmp-b afterwards.
     const cmpAEl = page.doc.querySelector('cmp-a');
     const namedSlotDiv = page.doc.querySelector('.named-slot');
     const defaultSlotDiv = page.doc.querySelector('.default-slot');

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -17,6 +17,7 @@ import { NODE_TYPE, PLATFORM_FLAGS, VNODE_FLAGS } from '../runtime-constants';
 import {
   dispatchSlotChangeEvent,
   findSlotFromSlottedNode,
+  getSlotChildSiblings,
   isNodeLocatedInSlot,
   patchSlotNode,
   updateFallbackSlotVisibility,
@@ -91,6 +92,10 @@ const createElm = (oldParentVNode: d.VNode, newParentVNode: d.VNode, childIndex:
       BUILD.isDebug || BUILD.hydrateServerSide
         ? slotReferenceDebugNode(newVNode)
         : (win.document.createTextNode('') as any);
+    // this text node can't hold a real `slot` attribute, so capture it as `s-sa` instead
+    if (typeof newVNode.$attrs$?.slot === 'string') {
+      (elm as d.RenderNode)['s-sa'] = newVNode.$attrs$.slot;
+    }
     // add css classes, attrs, props, listeners, etc.
     if (BUILD.vdomAttribute) {
       updateElement(null, newVNode, isSvgMode);
@@ -780,6 +785,37 @@ export const patch = (oldVNode: d.VNode, newVNode: d.VNode, isInitialRender = fa
 const relocateNodes: RelocateNodeData[] = [];
 
 /**
+ * When a forwarded `<slot>` gets relocated, drag along any content already forwarded through it,
+ * to wherever it just landed (or nowhere, to be hidden, if it didn't match anything).
+ *
+ * Runs as its own pass after {@link markSlotContentForRelocation} rather than inside it, so that
+ * function's matching order - which hydration's node/comment ordering depends on - is untouched.
+ */
+const carryContentWithRelocatedSlotRefs = () => {
+  for (const relocateData of relocateNodes.slice()) {
+    const marker = relocateData.$nodeToRelocate$;
+    if (!marker['s-sr']) continue;
+
+    const carriedSiblings = getSlotChildSiblings(marker, marker['s-sn'] || '', false);
+    for (const carriedSibling of carriedSiblings) {
+      // `s-ol` means it was already relocated once, i.e. it's genuinely forwarded content, not
+      // just something authored nearby that happens to share a slot name.
+      if (!carriedSibling['s-ol']) continue;
+
+      let siblingRelocateData = relocateNodes.find((r) => r.$nodeToRelocate$ === carriedSibling);
+      if (!siblingRelocateData) {
+        siblingRelocateData = { $nodeToRelocate$: carriedSibling };
+        relocateNodes.push(siblingRelocateData);
+      }
+      siblingRelocateData.$slotRefNode$ = relocateData.$slotRefNode$;
+      if (relocateData.$slotRefNode$) {
+        carriedSibling['s-sh'] = relocateData.$slotRefNode$['s-hn'];
+      }
+    }
+  }
+};
+
+/**
  * Mark the contents of a slot for relocation via adding references to them to
  * the {@link relocateNodes} data structure. The actual work of relocating them
  * will then be handled in {@link renderVdom}.
@@ -1142,6 +1178,7 @@ render() {
 
     if (checkSlotRelocate) {
       markSlotContentForRelocation(rootVnode.$elm$);
+      carryContentWithRelocatedSlotRefs();
 
       for (const relocateData of relocateNodes) {
         const nodeToRelocate = relocateData.$nodeToRelocate$;
@@ -1286,7 +1323,8 @@ render() {
   ) {
     const children = rootVnode.$elm$.__childNodes || rootVnode.$elm$.childNodes;
     for (const childNode of children) {
-      if (childNode['s-hn'] !== hostTagName && !childNode['s-sh']) {
+      // `s-sh` must match *this* host - it may be stale, carried over from an earlier host
+      if (childNode['s-hn'] !== hostTagName && childNode['s-sh'] !== hostTagName) {
         // Store the initial value of `hidden` so we can reset it later when
         // moving nodes around.
         if (isInitialLoad && childNode['s-ih'] == null) {

--- a/test/wdio/slot-fallback-with-forwarded-slot/parent-component.tsx
+++ b/test/wdio/slot-fallback-with-forwarded-slot/parent-component.tsx
@@ -16,7 +16,7 @@ export class MyComponent {
     return (
       <Host>
         <slot-forward-child-fallback label={this.label}>
-          <slot name="label" />
+          <slot name="label" slot="label" />
         </slot-forward-child-fallback>
       </Host>
     );


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6770   

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes #6770 

Tackling this issue raised lots of rough edges around non-shadow `<slot>` forwarding - all of which lead to unexpected / non-native behaviour. 

slot forwarding logic revolved around corresponding `name` attributes.. i.e.

```
cmp-a > slot name=a
  cmp-b  > slot name=a
```

cmp-a's slot would try be forwarded to cmp-b's slot (and dynamically fail as per the linked issue). 
This is incorrect - cmp-a's slot must *also* have a corresponding `slot` to forward.. otherwise it should go to the default slot, or be hidden if there is no default slot.

This PR roles in a number of small fixes to better align slot forwarding to the spec with 3 scenarios tested for:

1) named slot forwarding to corresponding named slot
2) named slot forwarding to default slot
3) named slot having no slot to forward to and so hiding

This was tested for and fixed for initial hydration and dynamic insertion and removal

Tested against the linked repro

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Strictly not, but if users were relying on the broken behaviour then it could be perceived as breaking ... so I'm going to roll into v5 

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
