### PR TITLE
fix(runtime): stop forwarded named slot being added to nested default slot

### DIFF
--- a/src/runtime/slot-polyfill-utils.ts
+++ b/src/runtime/slot-polyfill-utils.ts
@@ -90,7 +90,9 @@ export function getHostSlotNodes(childNodes: NodeListOf<ChildNode>, hostName?: s
       slottedNodes.push(childNode);
       if (typeof slotName !== 'undefined') return slottedNodes;
     }
-    slottedNodes = [...slottedNodes, ...getHostSlotNodes(childNode.childNodes, hostName, slotName)];
+    // `internalCall`, not `childNode.childNodes`: a patched nested custom element's `childNodes`
+    // accessor returns slotted content only, hiding the `s-sr` nodes this recursion needs.
+    slottedNodes = [...slottedNodes, ...getHostSlotNodes(internalCall(childNode, 'childNodes'), hostName, slotName)];
   }
   return slottedNodes;
 }

--- a/src/runtime/test/nested-slot-forwarding.spec.tsx
+++ b/src/runtime/test/nested-slot-forwarding.spec.tsx
@@ -1,0 +1,90 @@
+import { Component, h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+import { patchPseudoShadowDom } from '../dom-extras';
+
+/**
+ * Regression test for https://github.com/stenciljs/core/issues/6770
+ *
+ * `cmp-b` forwards a named `<slot>` into nested `cmp-a`: `<cmp-a><slot name="named" /></cmp-a>`,
+ * where `cmp-a` also defines a slot named "named". Content assigned to `cmp-b`'s "named" slot
+ * must cascade into `cmp-a`'s "named" slot - for content already present on connect and for
+ * content added later via `appendChild`.
+ */
+describe('nested named slot forwarding', () => {
+  @Component({
+    tag: 'cmp-a',
+    shadow: false,
+    scoped: true,
+  })
+  class CmpA {
+    render() {
+      return (
+        <div class="cmp-a-outer">
+          <div class="default-slot">
+            <slot />
+          </div>
+          <div class="named-slot">
+            <slot name="named" />
+          </div>
+        </div>
+      );
+    }
+  }
+
+  @Component({
+    tag: 'cmp-b',
+    shadow: false,
+    scoped: true,
+  })
+  class CmpB {
+    render() {
+      return (
+        <cmp-a>
+          <slot />
+          <slot name="named" />
+        </cmp-a>
+      );
+    }
+  }
+
+  it('routes initial content into the forwarded named slot', async () => {
+    const page = await newSpecPage({
+      components: [CmpA, CmpB],
+      includeAnnotations: true,
+      html: `<cmp-b><span slot="named">initial</span></cmp-b>`,
+    });
+
+    const namedSlotDiv = page.doc.querySelector('.named-slot');
+    const defaultSlotDiv = page.doc.querySelector('.default-slot');
+
+    expect(namedSlotDiv.textContent).toContain('initial');
+    expect(defaultSlotDiv.textContent).not.toContain('initial');
+  });
+
+  it('routes appendChild()-ed content into the forwarded named slot', async () => {
+    const page = await newSpecPage({
+      components: [CmpA, CmpB],
+      includeAnnotations: true,
+      html: `<cmp-b><span slot="named">initial</span></cmp-b>`,
+    });
+
+    const cmpAEl = page.doc.querySelector('cmp-a');
+    const namedSlotDiv = page.doc.querySelector('.named-slot');
+    const defaultSlotDiv = page.doc.querySelector('.default-slot');
+
+    patchPseudoShadowDom(Object.getPrototypeOf(page.root));
+    patchPseudoShadowDom(Object.getPrototypeOf(cmpAEl));
+
+    const appended = page.doc.createElement('span');
+    appended.setAttribute('slot', 'named');
+    appended.textContent = 'appended';
+
+    page.root.appendChild(appended);
+    await page.waitForChanges();
+
+    expect(namedSlotDiv.textContent).toContain('initial');
+    expect(namedSlotDiv.textContent).toContain('appended');
+    expect(defaultSlotDiv.textContent).not.toContain('appended');
+  });
+});

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -17,6 +17,7 @@ import { NODE_TYPE, PLATFORM_FLAGS, VNODE_FLAGS } from '../runtime-constants';
 import {
   dispatchSlotChangeEvent,
   findSlotFromSlottedNode,
+  getSlotName,
   isNodeLocatedInSlot,
   patchSlotNode,
   updateFallbackSlotVisibility,
@@ -818,7 +819,9 @@ const markSlotContentForRelocation = (elm: d.RenderNode) => {
           !node['s-cn'] &&
           !node['s-nr'] &&
           node['s-hn'] !== childNode['s-hn'] &&
-          (!node['s-sh'] || node['s-sh'] !== childNode['s-hn'])
+          // an exact name match must still be able to override a same-host node that's only
+          // provisionally claimed a *different* slot (e.g. the default-slot fallback below)
+          (!node['s-sh'] || node['s-sh'] !== childNode['s-hn'] || getSlotName(node) === slotName)
         ) {
           // if `node` is located in the slot that `childNode` refers to (via the
           // `'s-sn'` property) then we need to relocate it from it's current spot

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -819,9 +819,10 @@ const markSlotContentForRelocation = (elm: d.RenderNode) => {
           !node['s-cn'] &&
           !node['s-nr'] &&
           node['s-hn'] !== childNode['s-hn'] &&
-          // an exact name match must still be able to override a same-host node that's only
-          // provisionally claimed a *different* slot (e.g. the default-slot fallback below)
-          (!node['s-sh'] || node['s-sh'] !== childNode['s-hn'] || getSlotName(node) === slotName)
+          // let an exact named-slot match override a stale default-slot claim. Skip this for
+          // `slotName === ''` itself - a matched default node's cached `s-sn` is `''` too, which
+          // would trivially "match" on every re-render and force pointless re-insertion.
+          (!node['s-sh'] || node['s-sh'] !== childNode['s-hn'] || (slotName !== '' && getSlotName(node) === slotName))
         ) {
           // if `node` is located in the slot that `childNode` refers to (via the
           // `'s-sn'` property) then we need to relocate it from it's current spot


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: https://github.com/stenciljs/core/pull/6770

A non-shadow slot optimisation piece of work I did (a while ago) uncovered a bug that was hidden by the (now removed) `experimentalSlotFixes` flag; forwarded `<slot name="thing">` would be 'grabbed' by the nested component and added to it's default slot

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes https://github.com/stenciljs/core/pull/6770

We now more accurately detect incoming forwarded `<slot>` nodes and make sure they're not automatically grabbed by the nested child's default slot.

Tested against the linked repro

*Note* - this fix uncovered that stencil non-slot forwarding does not match native behaviour. V5 (via https://github.com/stenciljs/core/pull/6814) will correctly fix the overall forwarding behaviour - it was deemed to large a behaviour change for v4

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
