### PR TITLE
fix(runtime): non-shadow slot forwarding fixes

### DIFF
--- a/packages/core/src/client/__test__/client-task-queue.spec.ts
+++ b/packages/core/src/client/__test__/client-task-queue.spec.ts
@@ -1,4 +1,5 @@
 import { vi, it, describe, expect, beforeEach, afterEach } from 'vitest';
+
 import type { plt as pltType, win as winType } from '../client-window';
 
 describe('client task queue', () => {

--- a/packages/core/src/declarations/stencil-private.ts
+++ b/packages/core/src/declarations/stencil-private.ts
@@ -1466,6 +1466,12 @@ export interface RenderNode extends HostElement {
   ['s-sn']?: string;
 
   /**
+   * `slot` attribute of a `<slot>` reference rendered as a text node (no fallback content),
+   * since text nodes can't carry real DOM attributes.
+   */
+  ['s-sa']?: string;
+
+  /**
    * Host element tag name:
    * The tag name of the host element that this
    * node was created in.

--- a/packages/core/src/runtime/_test_/nested-slot-forwarding.spec.tsx
+++ b/packages/core/src/runtime/_test_/nested-slot-forwarding.spec.tsx
@@ -1,24 +1,25 @@
-import { it, describe, expect } from 'vitest';
 import { Component, h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
+import { it, describe, expect } from 'vitest';
 
 import { applyLightDomPatches } from '../dom-extras';
 
 describe('nested named slot forwarding', () => {
   @Component({
     tag: 'cmp-a',
-    shadow: false,
-    scoped: true,
+    encapsulation: {
+      type: 'scoped',
+    },
   })
   class CmpA {
     render() {
       return (
-        <div class="cmp-a-outer">
-          <div class="default-slot">
+        <div class='cmp-a-outer'>
+          <div class='default-slot'>
             <slot />
           </div>
-          <div class="named-slot">
-            <slot name="named" />
+          <div class='named-slot'>
+            <slot name='named' />
           </div>
         </div>
       );
@@ -28,15 +29,16 @@ describe('nested named slot forwarding', () => {
   it('routes appendChild()-ed content to the default slot when the forwarding tag has no explicit `slot` attribute', async () => {
     @Component({
       tag: 'cmp-b',
-      shadow: false,
-      scoped: true,
+      encapsulation: {
+        type: 'scoped',
+      },
     })
     class CmpB {
       render() {
         return (
           <cmp-a>
             <slot />
-            <slot name="named" />
+            <slot name='named' />
           </cmp-a>
         );
       }
@@ -71,15 +73,16 @@ describe('nested named slot forwarding', () => {
   it('routes appendChild()-ed content through a forwarding tag with an explicit `slot` attribute (text-node slot ref)', async () => {
     @Component({
       tag: 'cmp-b',
-      shadow: false,
-      scoped: true,
+      encapsulation: {
+        type: 'scoped',
+      },
     })
     class CmpB {
       render() {
         return (
           <cmp-a>
             <slot />
-            <slot name="named" slot="named" />
+            <slot name='named' slot='named' />
           </cmp-a>
         );
       }
@@ -111,15 +114,16 @@ describe('nested named slot forwarding', () => {
   it('routes appendChild()-ed content through a forwarding tag with fallback content and an explicit `slot` attribute (element slot-fb ref)', async () => {
     @Component({
       tag: 'cmp-b',
-      shadow: false,
-      scoped: true,
+      encapsulation: {
+        type: 'scoped',
+      },
     })
     class CmpB {
       render() {
         return (
           <cmp-a>
             <slot />
-            <slot name="named" slot="named">
+            <slot name='named' slot='named'>
               fallback
             </slot>
           </cmp-a>
@@ -156,8 +160,9 @@ describe('nested named slot forwarding', () => {
   it('hides content forwarded to a slot name that does not exist anywhere on the target', async () => {
     @Component({
       tag: 'cmp-b',
-      shadow: false,
-      scoped: true,
+      encapsulation: {
+        type: 'scoped',
+      },
     })
     class CmpB {
       render() {
@@ -165,7 +170,7 @@ describe('nested named slot forwarding', () => {
           <cmp-a>
             <slot />
             {/* "nonexistent" isn't a slot cmp-a defines at all - not default, not named */}
-            <slot name="named" slot="nonexistent" />
+            <slot name='named' slot='nonexistent' />
           </cmp-a>
         );
       }
@@ -184,17 +189,18 @@ describe('nested named slot forwarding', () => {
   it('does not sweep up a directly-authored slot="named" child that just happens to sit near an unrelated forwarding marker', async () => {
     @Component({
       tag: 'cmp-b',
-      shadow: false,
-      scoped: true,
+      encapsulation: {
+        type: 'scoped',
+      },
     })
     class CmpB {
       render() {
         return (
           <cmp-a>
             <slot />
-            <slot name="named" />
+            <slot name='named' />
             {/* directly authored, not forwarded - must be unaffected by the <slot> above */}
-            <span slot="named" class="direct-named">
+            <span slot='named' class='direct-named'>
               direct
             </span>
           </cmp-a>

--- a/packages/core/src/runtime/_test_/nested-slot-forwarding.spec.tsx
+++ b/packages/core/src/runtime/_test_/nested-slot-forwarding.spec.tsx
@@ -1,0 +1,217 @@
+import { it, describe, expect } from 'vitest';
+import { Component, h } from '@stencil/core';
+import { newSpecPage } from '@stencil/core/testing';
+
+import { applyLightDomPatches } from '../dom-extras';
+
+describe('nested named slot forwarding', () => {
+  @Component({
+    tag: 'cmp-a',
+    shadow: false,
+    scoped: true,
+  })
+  class CmpA {
+    render() {
+      return (
+        <div class="cmp-a-outer">
+          <div class="default-slot">
+            <slot />
+          </div>
+          <div class="named-slot">
+            <slot name="named" />
+          </div>
+        </div>
+      );
+    }
+  }
+
+  it('routes appendChild()-ed content to the default slot when the forwarding tag has no explicit `slot` attribute', async () => {
+    @Component({
+      tag: 'cmp-b',
+      shadow: false,
+      scoped: true,
+    })
+    class CmpB {
+      render() {
+        return (
+          <cmp-a>
+            <slot />
+            <slot name="named" />
+          </cmp-a>
+        );
+      }
+    }
+
+    const page = await newSpecPage({
+      components: [CmpA, CmpB],
+      includeAnnotations: true,
+      html: `<cmp-b><span slot="named">initial</span></cmp-b>`,
+    });
+
+    const namedSlotDiv = page.doc.querySelector('.named-slot');
+    const defaultSlotDiv = page.doc.querySelector('.default-slot');
+
+    expect(defaultSlotDiv.textContent).toContain('initial');
+    expect(namedSlotDiv.textContent).not.toContain('initial');
+
+    applyLightDomPatches(Object.getPrototypeOf(page.root));
+
+    const appended = page.doc.createElement('span');
+    appended.setAttribute('slot', 'named');
+    appended.textContent = 'appended';
+
+    page.root.appendChild(appended);
+    await page.waitForChanges();
+
+    expect(defaultSlotDiv.textContent).toContain('initial');
+    expect(defaultSlotDiv.textContent).toContain('appended');
+    expect(namedSlotDiv.textContent).not.toContain('appended');
+  });
+
+  it('routes appendChild()-ed content through a forwarding tag with an explicit `slot` attribute (text-node slot ref)', async () => {
+    @Component({
+      tag: 'cmp-b',
+      shadow: false,
+      scoped: true,
+    })
+    class CmpB {
+      render() {
+        return (
+          <cmp-a>
+            <slot />
+            <slot name="named" slot="named" />
+          </cmp-a>
+        );
+      }
+    }
+
+    const page = await newSpecPage({
+      components: [CmpA, CmpB],
+      includeAnnotations: true,
+      html: `<cmp-b><span slot="named">initial</span></cmp-b>`,
+    });
+
+    const namedSlotDiv = page.doc.querySelector('.named-slot');
+    const defaultSlotDiv = page.doc.querySelector('.default-slot');
+
+    applyLightDomPatches(Object.getPrototypeOf(page.root));
+
+    const appended = page.doc.createElement('span');
+    appended.setAttribute('slot', 'named');
+    appended.textContent = 'appended';
+
+    page.root.appendChild(appended);
+    await page.waitForChanges();
+
+    expect(namedSlotDiv.textContent).toContain('initial');
+    expect(namedSlotDiv.textContent).toContain('appended');
+    expect(defaultSlotDiv.textContent).not.toContain('appended');
+  });
+
+  it('routes appendChild()-ed content through a forwarding tag with fallback content and an explicit `slot` attribute (element slot-fb ref)', async () => {
+    @Component({
+      tag: 'cmp-b',
+      shadow: false,
+      scoped: true,
+    })
+    class CmpB {
+      render() {
+        return (
+          <cmp-a>
+            <slot />
+            <slot name="named" slot="named">
+              fallback
+            </slot>
+          </cmp-a>
+        );
+      }
+    }
+
+    const page = await newSpecPage({
+      components: [CmpA, CmpB],
+      includeAnnotations: true,
+      html: `<cmp-b><span slot="named">initial</span></cmp-b>`,
+    });
+
+    const namedSlotDiv = page.doc.querySelector('.named-slot');
+    const defaultSlotDiv = page.doc.querySelector('.default-slot');
+
+    expect(namedSlotDiv.textContent).toContain('initial');
+    expect(defaultSlotDiv.querySelector('slot-fb')).toBeNull();
+
+    applyLightDomPatches(Object.getPrototypeOf(page.root));
+
+    const appended = page.doc.createElement('span');
+    appended.setAttribute('slot', 'named');
+    appended.textContent = 'appended';
+
+    page.root.appendChild(appended);
+    await page.waitForChanges();
+
+    expect(namedSlotDiv.textContent).toContain('initial');
+    expect(namedSlotDiv.textContent).toContain('appended');
+    expect(defaultSlotDiv.textContent).not.toContain('appended');
+  });
+
+  it('hides content forwarded to a slot name that does not exist anywhere on the target', async () => {
+    @Component({
+      tag: 'cmp-b',
+      shadow: false,
+      scoped: true,
+    })
+    class CmpB {
+      render() {
+        return (
+          <cmp-a>
+            <slot />
+            {/* "nonexistent" isn't a slot cmp-a defines at all - not default, not named */}
+            <slot name="named" slot="nonexistent" />
+          </cmp-a>
+        );
+      }
+    }
+
+    const page = await newSpecPage({
+      components: [CmpA, CmpB],
+      includeAnnotations: true,
+      html: `<cmp-b><span slot="named">initial</span></cmp-b>`,
+    });
+
+    const span = page.doc.querySelector('span[slot="named"]');
+    expect(span.hidden).toBe(true);
+  });
+
+  it('does not sweep up a directly-authored slot="named" child that just happens to sit near an unrelated forwarding marker', async () => {
+    @Component({
+      tag: 'cmp-b',
+      shadow: false,
+      scoped: true,
+    })
+    class CmpB {
+      render() {
+        return (
+          <cmp-a>
+            <slot />
+            <slot name="named" />
+            {/* directly authored, not forwarded - must be unaffected by the <slot> above */}
+            <span slot="named" class="direct-named">
+              direct
+            </span>
+          </cmp-a>
+        );
+      }
+    }
+
+    const page = await newSpecPage({
+      components: [CmpA, CmpB],
+      includeAnnotations: true,
+      html: `<cmp-b></cmp-b>`,
+    });
+
+    const namedSlotDiv = page.doc.querySelector('.named-slot');
+    const defaultSlotDiv = page.doc.querySelector('.default-slot');
+
+    expect(namedSlotDiv.textContent).toContain('direct');
+    expect(defaultSlotDiv.textContent).not.toContain('direct');
+  });
+});

--- a/packages/core/src/runtime/slot-polyfill-utils.ts
+++ b/packages/core/src/runtime/slot-polyfill-utils.ts
@@ -97,8 +97,6 @@ export function getHostSlotNodes(
       slottedNodes.push(childNode);
       if (typeof slotName !== 'undefined') return slottedNodes;
     }
-    // `internalCall`, not `childNode.childNodes`: a patched nested custom element's `childNodes`
-    // accessor returns slotted content only, hiding the `s-sr` nodes this recursion needs.
     slottedNodes = [
       ...slottedNodes,
       ...getHostSlotNodes(internalCall(childNode, 'childNodes'), hostName, slotName),
@@ -145,8 +143,8 @@ export const isNodeLocatedInSlot = (nodeToRelocate: d.RenderNode, slotName: stri
     }
     return false;
   }
-  if (nodeToRelocate['s-sn'] === slotName) {
-    return true;
+  if (typeof nodeToRelocate['s-sa'] === 'string') {
+    return nodeToRelocate['s-sa'] === slotName;
   }
   return slotName === '';
 };

--- a/packages/core/src/runtime/vdom/vdom-render.ts
+++ b/packages/core/src/runtime/vdom/vdom-render.ts
@@ -20,6 +20,7 @@ import { effect } from '../signals';
 import {
   dispatchSlotChangeEvent,
   findSlotFromSlottedNode,
+  getSlotChildSiblings,
   isNodeLocatedInSlot,
   patchSlotNode,
   updateFallbackSlotVisibility,
@@ -123,6 +124,10 @@ const createElm = (oldParentVNode: d.VNode, newParentVNode: d.VNode, childIndex:
       BUILD.isDebug || BUILD.hydrateServerSide
         ? slotReferenceDebugNode(newVNode)
         : (win.document.createTextNode('') as any);
+    // this text node can't hold a real `slot` attribute, so capture it as `s-sa` instead
+    if (typeof newVNode.$attrs$?.slot === 'string') {
+      (elm as d.RenderNode)['s-sa'] = newVNode.$attrs$.slot;
+    }
     // add css classes, attrs, props, listeners, etc.
     if (BUILD.vdomAttribute) {
       updateElement(null, newVNode, isSvgMode);
@@ -836,6 +841,37 @@ export const patch = (oldVNode: d.VNode, newVNode: d.VNode, isInitialRender = fa
 const relocateNodes: RelocateNodeData[] = [];
 
 /**
+ * When a forwarded `<slot>` gets relocated, drag along any content already forwarded through it,
+ * to wherever it just landed (or nowhere, to be hidden, if it didn't match anything).
+ *
+ * Runs as its own pass after {@link markSlotContentForRelocation} rather than inside it, so that
+ * function's matching order - which hydration's node/comment ordering depends on - is untouched.
+ */
+const carryContentWithRelocatedSlotRefs = () => {
+  for (const relocateData of relocateNodes.slice()) {
+    const marker = relocateData.$nodeToRelocate$;
+    if (!marker['s-sr']) continue;
+
+    const carriedSiblings = getSlotChildSiblings(marker, marker['s-sn'] || '', false);
+    for (const carriedSibling of carriedSiblings) {
+      // `s-ol` means it was already relocated once, i.e. it's genuinely forwarded content, not
+      // just something authored nearby that happens to share a slot name.
+      if (!carriedSibling['s-ol']) continue;
+
+      let siblingRelocateData = relocateNodes.find((r) => r.$nodeToRelocate$ === carriedSibling);
+      if (!siblingRelocateData) {
+        siblingRelocateData = { $nodeToRelocate$: carriedSibling };
+        relocateNodes.push(siblingRelocateData);
+      }
+      siblingRelocateData.$slotRefNode$ = relocateData.$slotRefNode$;
+      if (relocateData.$slotRefNode$) {
+        carriedSibling['s-sh'] = relocateData.$slotRefNode$['s-hn'];
+      }
+    }
+  }
+};
+
+/**
  * Mark the contents of a slot for relocation via adding references to them to
  * the {@link relocateNodes} data structure. The actual work of relocating them
  * will then be handled in {@link renderVdom}.
@@ -1229,6 +1265,7 @@ render() {
 
     if (checkSlotRelocate) {
       markSlotContentForRelocation(rootVnode.$elm$);
+      carryContentWithRelocatedSlotRefs();
 
       for (const relocateData of relocateNodes) {
         const nodeToRelocate = relocateData.$nodeToRelocate$;
@@ -1390,7 +1427,8 @@ render() {
   ) {
     const children = rootVnode.$elm$.__childNodes || rootVnode.$elm$.childNodes;
     for (const childNode of children) {
-      if (childNode['s-hn'] !== hostTagName && !childNode['s-sh']) {
+      // `s-sh` must match *this* host - it may be stale, carried over from an earlier host
+      if (childNode['s-hn'] !== hostTagName && childNode['s-sh'] !== hostTagName) {
         // Store the initial value of `hidden` so we can reset it later when
         // moving nodes around.
         if (isInitialLoad && childNode['s-ih'] == null) {

--- a/test/build/build-size/light/test-bundle-size.js
+++ b/test/build/build-size/light/test-bundle-size.js
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const distDir = path.join(__dirname, 'dist', 'loader-bundle', 'bundlesize-non-shadow');
-const maxBundleSize = 20 * 1024; // 20KB in bytes (non-gzipped - ~7KB gzipped)
+const maxBundleSize = 21 * 1024; // 21KB in bytes (non-gzipped - ~7KB gzipped)
 
 console.log('\nChecking bundle size (non-shadow)...');
 

--- a/test/runtime/src/components/slots/slot-fallback-with-forwarded-slot/slot-forward-root.tsx
+++ b/test/runtime/src/components/slots/slot-fallback-with-forwarded-slot/slot-forward-root.tsx
@@ -16,7 +16,7 @@ export class SlotForwardRoot {
     return (
       <Host>
         <slot-forward-child-fallback label={this.label}>
-          <slot name="label" slot="label" />
+          <slot name='label' slot='label' />
         </slot-forward-child-fallback>
       </Host>
     );

--- a/test/runtime/src/components/slots/slot-fallback-with-forwarded-slot/slot-forward-root.tsx
+++ b/test/runtime/src/components/slots/slot-fallback-with-forwarded-slot/slot-forward-root.tsx
@@ -16,7 +16,7 @@ export class SlotForwardRoot {
     return (
       <Host>
         <slot-forward-child-fallback label={this.label}>
-          <slot name='label' />
+          <slot name="label" slot="label" />
         </slot-forward-child-fallback>
       </Host>
     );


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6770   

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes #6770 

Tackling this issue raised lots of rough edges around non-shadow `<slot>` forwarding - all of which lead to unexpected / non-native behaviour. 

slot forwarding logic revolved around corresponding `name` attributes.. i.e.

```
cmp-a > slot name=a
  cmp-b  > slot name=a
```

cmp-a's slot would try be forwarded to cmp-b's slot (and dynamically fail as per the linked issue). 
This is incorrect - cmp-a's slot must *also* have a corresponding `slot` to forward.. otherwise it should go to the default slot, or be hidden if there is no default slot.

This PR roles in a number of small fixes to better align slot forwarding to the spec with 3 scenarios tested for:

1) named slot forwarding to corresponding named slot
2) named slot forwarding to default slot
3) named slot having no slot to forward to and so hiding

This was tested for and fixed for initial hydration and dynamic insertion and removal

Tested against the linked repro

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Strictly not, but if users were relying on the broken behaviour then it could be perceived as breaking ... so I'm going to roll into v5 

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
