### PR TITLE
fix(runtime): guard against render reentrancy under `taskQueue: 'immediate'`

### DIFF
--- a/cspell-wordlist.txt
+++ b/cspell-wordlist.txt
@@ -155,3 +155,4 @@ jsxmode
 jsxdev
 jsxs
 labelable
+reentrancy

--- a/src/runtime/test/update-component.spec.tsx
+++ b/src/runtime/test/update-component.spec.tsx
@@ -1,7 +1,45 @@
-import { Component, h, State } from '@stencil/core';
+import { Component, h, Prop, State } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 
 describe('update-component', () => {
+  describe('scheduleUpdate - reentrancy guard', () => {
+    it('should coalesce a state write during render() into a single follow-up render under taskQueue: immediate', async () => {
+      let renderCount = 0;
+
+      @Component({ tag: 'cmp-reentry' })
+      class CmpReentry {
+        @Prop() trigger = 0;
+        @State() measured = 0;
+
+        render() {
+          renderCount++;
+          // guards the test itself against hanging if the reentrancy guard regresses
+          if (renderCount > 10) {
+            throw new Error('render() re-entered unboundedly');
+          }
+          this.measured++;
+          return h('div', null, this.measured);
+        }
+      }
+
+      const page = await newSpecPage({
+        components: [CmpReentry],
+        html: `<cmp-reentry></cmp-reentry>`,
+      });
+
+      // simulate `taskQueue: 'immediate'`, where BUILD.taskQueue is `false`
+      page.build.taskQueue = false;
+
+      renderCount = 0;
+      page.rootInstance.trigger = 1;
+      await page.waitForChanges();
+
+      // one external update should cause exactly one follow-up render, even though
+      // `render()` writes state on every pass (the reentrancy guard should dedupe it)
+      expect(renderCount).toBe(1);
+    });
+  });
+
   describe('scheduleUpdate - initial load with queueMicrotask', () => {
     @Component({
       tag: 'test-cmp',

--- a/src/runtime/update-component.ts
+++ b/src/runtime/update-component.ts
@@ -24,7 +24,7 @@ export const attachToAncestor = (hostRef: d.HostRef, ancestorComponent?: d.HostE
 };
 
 export const scheduleUpdate = (hostRef: d.HostRef, isInitialLoad: boolean): Promise<void> | void => {
-  if (BUILD.taskQueue && BUILD.updatable) {
+  if (BUILD.updatable) {
     hostRef.$flags$ |= HOST_FLAGS.isQueuedForUpdate;
   }
   if (BUILD.asyncLoading && hostRef.$flags$ & HOST_FLAGS.isWaitingForChildren) {
@@ -284,7 +284,6 @@ const callRender = (hostRef: d.HostRef, instance: any, elm: HTMLElement, isIniti
   // https://rollupjs.org/guide/en/#treeshake tryCatchDeoptimization
   const allRenderFn = BUILD.allRenderFn ? true : false;
   const lazyLoad = BUILD.lazyLoad ? true : false;
-  const taskQueue = BUILD.taskQueue ? true : false;
   const updatable = BUILD.updatable ? true : false;
 
   try {
@@ -295,7 +294,7 @@ const callRender = (hostRef: d.HostRef, instance: any, elm: HTMLElement, isIniti
      */
     instance = allRenderFn ? instance.render() : instance.render && instance.render();
 
-    if (updatable && taskQueue) {
+    if (updatable) {
       hostRef.$flags$ &= ~HOST_FLAGS.isQueuedForUpdate;
     }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6787


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes #6787

Decoupled the reentrancy flag from `BUILD.taskQueue` (so `immediate`)

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
