### PR TITLE
fix(runtime): async load order improvements; guarantee parent / child order contract

### DIFF
--- a/packages/core/src/client/client-host-ref.ts
+++ b/packages/core/src/client/client-host-ref.ts
@@ -60,15 +60,18 @@ export const registerHost = (hostElement: d.HostElement, cmpMeta: d.ComponentRun
   }
   if (BUILD.asyncLoading) {
     hostRef.$onReadyPromise$ = new Promise((r) => (hostRef.$onReadyResolve$ = r));
-    // Expose the ready promise on the element itself under a stable string key
-    // ('s-rp') so the autoloader can access it without going through the
+    hostRef.$onFirstConnectPromise$ = new Promise((r) => (hostRef.$onFirstConnectResolve$ = r));
+    // Expose the ready/first-connect promises on the element itself under stable string keys
+    // ('s-rp'/'s-fc') so the autoloader can access them without going through the
     // minified hostRef internals
     hostElement['s-rp'] = hostRef.$onReadyPromise$;
-    // Preserve any existing s-p/s-rc arrays (e.g. pre-set by the autoloader
+    hostElement['s-fc'] = hostRef.$onFirstConnectPromise$;
+    // Preserve any existing s-p/s-rc/s-pc arrays (e.g. pre-set by the autoloader
     // before this element was upgraded) so that promises pushed by children
     // that connected before this element's constructor ran are not lost.
     if (!hostElement['s-p']) hostElement['s-p'] = [];
     if (!hostElement['s-rc']) hostElement['s-rc'] = [];
+    if (!hostElement['s-pc']) hostElement['s-pc'] = [];
   }
   if (BUILD.lazyLoad) {
     hostRef.$fetchedCbList$ = [];

--- a/packages/core/src/client/client-host-ref.ts
+++ b/packages/core/src/client/client-host-ref.ts
@@ -60,12 +60,18 @@ export const registerHost = (hostElement: d.HostElement, cmpMeta: d.ComponentRun
   }
   if (BUILD.asyncLoading) {
     hostRef.$onReadyPromise$ = new Promise((r) => (hostRef.$onReadyResolve$ = r));
-    hostRef.$onFirstConnectPromise$ = new Promise((r) => (hostRef.$onFirstConnectResolve$ = r));
-    // Expose the ready/first-connect promises on the element itself under stable string keys
-    // ('s-rp'/'s-fc') so the autoloader can access them without going through the
+    // Expose the ready promise on the element itself under a stable string key
+    // ('s-rp') so the autoloader can access it without going through the
     // minified hostRef internals
     hostElement['s-rp'] = hostRef.$onReadyPromise$;
-    hostElement['s-fc'] = hostRef.$onFirstConnectPromise$;
+    if (!BUILD.lazyLoad) {
+      // Standalone's autoloader needs a not-yet-upgraded element's first-connect promise
+      // before a `HostRef` even exists for it, so it's created eagerly here and exposed
+      // as 's-fc' (see `generate-loader-module.ts`). Lazy has no such pre-upgrade gap -
+      // `ensureFirstConnectPromise` creates it lazily there, on first actual use.
+      hostRef.$onFirstConnectPromise$ = new Promise((r) => (hostRef.$onFirstConnectResolve$ = r));
+      hostElement['s-fc'] = hostRef.$onFirstConnectPromise$;
+    }
     // Preserve any existing s-p/s-rc/s-pc arrays (e.g. pre-set by the autoloader
     // before this element was upgraded) so that promises pushed by children
     // that connected before this element's constructor ran are not lost.

--- a/packages/core/src/compiler/output-targets/standalone/generate-loader-module.ts
+++ b/packages/core/src/compiler/output-targets/standalone/generate-loader-module.ts
@@ -74,13 +74,13 @@ let observer;
 /**
  * Scan a root element for undefined custom elements and load them.
  *
- * Before any modules are imported we do two things to guarantee the documented
- * Stencil lifecycle ordering (componentWillLoad top-down, componentDidLoad
- * bottom-up) regardless of module-load race conditions:
+ * Before any modules are imported we do 3 things to guarantee the documented
+ * Stencil lifecycle ordering (connectedCallback/componentWillLoad top-down,
+ * componentDidLoad bottom-up) regardless of which tag's chunk happens to resolve first:
  *
- * 1. Pre-mark every not-yet-upgraded Stencil element with empty \`s-p\`/\`s-rc\`
- *    arrays so the runtime's connectedCallback ancestor walk can always find a
- *    parent element even before it has been upgraded.
+ * 1. Pre-mark every not-yet-upgraded Stencil element with empty \`s-p\`/\`s-rc\`/\`s-pc\`
+ *    arrays so the runtime's connectedCallback ancestor walk can always find a parent
+ *    element even before it has been upgraded (see \`connected-callback.ts\`).
  *
  * 2. For every child Stencil element, push a Promise into its nearest Stencil
  *    ancestor's \`s-p\` array. That Promise resolves only after the child's full
@@ -88,6 +88,15 @@ let observer;
  *    ancestor from calling its own \`componentDidLoad\` before all its
  *    descendants are ready - even when a descendant's module loads *after* the
  *    ancestor has already started rendering.
+ *
+ * 3. Likewise, push a Promise into the ancestor's \`s-pc\` array that resolves once the
+ *    child's real \`connectedCallback\` has fired (\`s-fc\`). Without this, an ancestor
+ *    whose own module resolves before an unconnected child's would check \`s-pc\` (see
+ *    \`scheduleUpdate\` in \`update-component.ts\`) before that child ever got a chance to
+ *    register itself via \`attachToAncestor\` - since a not-yet-defined child doesn't
+ *    connect (and self-register) until its own module import resolves. Pre-registering
+ *    here means the ancestor's \`componentWillLoad\` always waits for it, however long
+ *    that import takes.
  *
  * @param root - The root element to scan
  */
@@ -101,6 +110,7 @@ async function load(root) {
     if (lookup[rootTag]) {
       if (!root['s-p']) root['s-p'] = [];
       if (!root['s-rc']) root['s-rc'] = [];
+      if (!root['s-pc']) root['s-pc'] = [];
       if (!defined.has(rootTag)) pending.add(rootTag);
       elements.push(root);
     }
@@ -112,6 +122,7 @@ async function load(root) {
     if (lookup[tag]) {
       if (!el['s-p']) el['s-p'] = [];
       if (!el['s-rc']) el['s-rc'] = [];
+      if (!el['s-pc']) el['s-pc'] = [];
       if (!defined.has(tag)) pending.add(tag);
       elements.push(el);
     }
@@ -133,6 +144,11 @@ async function load(root) {
         // at which point __s_ghr and $onReadyPromise$ are set.
         ancestor['s-p'].push(
           reg.whenDefined(tag).then(() => el['s-rp'])
+        );
+        // Same idea, but resolving once the child's real connectedCallback has fired
+        // rather than once its full initial lifecycle has completed.
+        ancestor['s-pc'].push(
+          reg.whenDefined(tag).then(() => el['s-fc'])
         );
         break;
       }

--- a/packages/core/src/compiler/transformers/component-build-conditionals.ts
+++ b/packages/core/src/compiler/transformers/component-build-conditionals.ts
@@ -64,7 +64,9 @@ export const setComponentBuildConditionals = (cmpMeta: d.ComponentCompilerMeta) 
     cmpMeta.hasComponentWillUpdateFn ||
     cmpMeta.hasComponentDidUpdateFn ||
     cmpMeta.hasComponentWillRenderFn ||
-    cmpMeta.hasComponentDidRenderFn;
+    cmpMeta.hasComponentDidRenderFn ||
+    cmpMeta.hasConnectedCallbackFn ||
+    cmpMeta.hasDisconnectedCallbackFn;
   cmpMeta.isPlain =
     !cmpMeta.hasMember &&
     !cmpMeta.hasStyle &&

--- a/packages/core/src/declarations/stencil-private.ts
+++ b/packages/core/src/declarations/stencil-private.ts
@@ -1192,6 +1192,16 @@ export interface HostElement extends HTMLElement {
    */
   ['s-p']?: Promise<void>[];
 
+  /**
+   * Pending Connects:
+   * A list of {@link HostRef.$onFirstConnectPromise$} promises for descendants that
+   * were already registered with this component (their nearest Stencil ancestor) by
+   * the time this component's own initial `componentWillLoad` was scheduled. Awaited
+   * so this component's `componentWillLoad` can't fire before those descendants'
+   * real `connectedCallback`s have.
+   */
+  ['s-pc']?: Promise<void>[];
+
   componentOnReady?: () => Promise<this>;
 }
 
@@ -1852,15 +1862,26 @@ export interface HostRef {
    * It is called after {@link HostRef.$onInstancePromise$} resolves.
    */
   $onRenderResolve$?: () => void;
+  /**
+   * A promise that resolves once this component's real `connectedCallback` has fired
+   * for the first time. Created lazily - either by a descendant that needs to wait for
+   * this component's connection before firing its own real `connectedCallback`
+   * ({@link HOST_FLAGS.hasFiredConnected}), or by this component registering itself
+   * with its nearest Stencil ancestor's `s-pc` list. This is what lets a component's
+   * real `connectedCallback` (and, transitively, a pending ancestor's initial
+   * `componentWillLoad`) stay ordered correctly regardless of which of an
+   * ancestor/descendant pair's lazy module happens to resolve first.
+   */
+  $onFirstConnectPromise$?: Promise<void>;
+  /**
+   * A callback which resolves {@link HostRef.$onFirstConnectPromise$}
+   */
+  $onFirstConnectResolve$?: () => void;
   $vnode$?: VNode;
   $queuedListeners$?: [string, any][];
   $rmListeners$?: (() => void)[];
   $modeName$?: string;
   $renderCount$?: number;
-  /**
-   * Defer connectedCallback until after first render for components with slot relocation.
-   */
-  $deferredConnectedCallback$?: boolean;
 }
 
 export interface PlatformRuntime {

--- a/packages/core/src/runtime/bootstrap-standalone.ts
+++ b/packages/core/src/runtime/bootstrap-standalone.ts
@@ -4,6 +4,7 @@ import {
   consoleError,
   forceUpdate,
   getHostRef,
+  plt,
   registerHost,
   styles,
   transformTag,
@@ -30,8 +31,10 @@ import { hmrStart } from './hmr-component';
 import { computeMode } from './mode';
 import { normalizeWatchers } from './normalize-watchers';
 import { proxyComponent } from './proxy-component';
+import { PLATFORM_FLAGS } from './runtime-constants';
 import { PROXY_FLAGS } from './runtime-constants';
 import { attachStyles, getScopeId, hydrateScopedToShadow, registerStyle } from './styles';
+import { awaitAncestorConnected, markFirstConnected } from './update-component';
 
 export const defineCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMetaCompact) => {
   const tag = transformTag(compactMeta[1]);
@@ -134,9 +137,11 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
       componentOnReady(this: d.HostElement) {
         return getHostRef(this)?.$onReadyPromise$;
       },
-      connectedCallback(this: d.HostElement & { __hasHostListenerAttached: boolean }) {
-        if (!this.__hasHostListenerAttached) {
-          const hostRef = getHostRef(this);
+      async connectedCallback(this: d.HostElement & { __hasHostListenerAttached: boolean }) {
+        const isFirstConnect = !this.__hasHostListenerAttached;
+        let hostRef: d.HostRef | undefined;
+        if (isFirstConnect) {
+          hostRef = getHostRef(this);
           if (!hostRef) {
             return;
           }
@@ -145,13 +150,37 @@ export const proxyCustomElement = (Cstr: any, compactMeta: d.ComponentRuntimeMet
         }
 
         connectedCallback(this);
-        if (originalConnectedCallback) {
+
+        if (BUILD.asyncLoading && hostRef && hostRef.$ancestorComponent$) {
+          // Never fire before our nearest Stencil ancestor's real connectedCallback,
+          // regardless of load order. Gated on having an ancestor since `awaitAncestorConnected`
+          // is `async` - calling it unconditionally would cost every component a wasted tick.
+          await awaitAncestorConnected(hostRef.$ancestorComponent$);
+
+          // If disconnected while suspended above, `disconnectedCallback` already ran - firing
+          // the author's callback now would leak, with no matching disconnect left to follow.
+          if (!this.isConnected) {
+            return;
+          }
+        }
+
+        // Slot relocation (`vdom-render.ts`) moves connected nodes via native insertBefore/
+        // appendChild, which fires spurious disconnect+reconnect; `isTmpDisconnected` pauses
+        // that so author lifecycle methods don't double-fire.
+        if (originalConnectedCallback && (plt.$flags$ & PLATFORM_FLAGS.isTmpDisconnected) === 0) {
           originalConnectedCallback.call(this);
+        }
+
+        if (BUILD.asyncLoading && hostRef) {
+          markFirstConnected(hostRef);
         }
       },
       disconnectedCallback(this: d.HostElement) {
         disconnectedCallback(this);
-        if (originalDisconnectedCallback) {
+        if (
+          originalDisconnectedCallback &&
+          (plt.$flags$ & PLATFORM_FLAGS.isTmpDisconnected) === 0
+        ) {
           originalDisconnectedCallback.call(this);
         }
       },

--- a/packages/core/src/runtime/disconnected-callback.ts
+++ b/packages/core/src/runtime/disconnected-callback.ts
@@ -2,9 +2,10 @@ import { BUILD } from 'virtual:app-data';
 import { getHostRef, plt } from 'virtual:platform';
 import type * as d from '@stencil/core';
 
+import { HOST_FLAGS } from '../utils/constants';
 import { PLATFORM_FLAGS } from './runtime-constants';
 import { rootAppliedStyles } from './styles';
-import { safeCall } from './update-component';
+import { markFirstConnected, safeCall } from './update-component';
 
 const disconnectInstance = (instance: any, elm?: d.HostElement) => {
   if (BUILD.lazyLoad) {
@@ -26,6 +27,13 @@ export const disconnectedCallback = async (elm: d.HostElement) => {
     if (BUILD.vdomSignals && hostRef?.$signalCleanup$) {
       hostRef.$signalCleanup$();
       hostRef.$signalCleanup$ = undefined;
+    }
+
+    // A component removed before its real `connectedCallback` has fired (module still in
+    // flight, or an autoloader hasn't defined its class yet) will now never fire it - release
+    // anything waiting on that (so it doesn't hang forever)
+    if (BUILD.asyncLoading && hostRef && !(hostRef.$flags$ & HOST_FLAGS.hasFiredConnected)) {
+      markFirstConnected(hostRef);
     }
 
     if (!BUILD.lazyLoad) {

--- a/packages/core/src/runtime/initialize-component.ts
+++ b/packages/core/src/runtime/initialize-component.ts
@@ -11,7 +11,12 @@ import { proxyComponent } from './proxy-component';
 import { PROXY_FLAGS } from './runtime-constants';
 import { initializeEffects, initializeSignals } from './signals';
 import { getScopeId, registerStyle } from './styles';
-import { safeCall, scheduleUpdate } from './update-component';
+import {
+  awaitAncestorConnected,
+  markFirstConnected,
+  safeCall,
+  scheduleUpdate,
+} from './update-component';
 
 /**
  * Initialize a Stencil component given a reference to its host element, its
@@ -95,14 +100,33 @@ export const initializeComponent = async (
         // per lifecycle docs that @Watch should only fire on subsequent prop changes.
         endNewInstance();
 
-        // For components that relocate slots, defer connectedCallback until after first render
-        // so that slotted content is available
+        if (BUILD.asyncLoading && hostRef.$ancestorComponent$) {
+          // Only call through (and thus only ever suspend) when there's actually an
+          // ancestor to wait on - `awaitAncestorConnected` is itself `async`, so awaiting
+          // it unconditionally would cost every component an extra microtask tick even
+          // when there's nothing to wait for.
+          await awaitAncestorConnected(hostRef.$ancestorComponent$);
+        }
+
+        // For components that relocate slots, defer connectedCallback to the next microtask
+        // so that slotted content is available. By the time any microtask runs, whichever
+        // synchronous vdom insertion pass created this component (and any of its own
+        // vdom-composed children, e.g. slotted content) has necessarily already finished,
+        // since nothing here awaits that pass directly.
         const needsDeferredCallback =
           BUILD.slotRelocation && cmpMeta.$flags$ & CMP_FLAGS.hasSlotRelocation;
         if (!needsDeferredCallback) {
           fireConnectedCallback(hostRef.$lazyInstance$, elm);
+          if (BUILD.asyncLoading) {
+            markFirstConnected(hostRef);
+          }
         } else {
-          hostRef.$deferredConnectedCallback$ = true;
+          queueMicrotask(() => {
+            fireConnectedCallback(hostRef.$lazyInstance$, elm);
+            if (BUILD.asyncLoading) {
+              markFirstConnected(hostRef);
+            }
+          });
         }
       } else {
         // sync constructor component
@@ -211,6 +235,13 @@ export const initializeComponent = async (
     if (BUILD.asyncLoading && hostRef.$onRenderResolve$) {
       hostRef.$onRenderResolve$();
       hostRef.$onRenderResolve$ = undefined;
+    }
+    // Same idea, but for a pending ancestor's `s-pc` wait (see `scheduleUpdate`) or a
+    // pending descendant's own connectedCallback-ordering wait (see the `s-pc` block
+    // above): a component that fails to initialize can still never fire its real
+    // `connectedCallback`, so anything waiting on that needs to be released too.
+    if (BUILD.asyncLoading) {
+      markFirstConnected(hostRef);
     }
     // Also resolve the component's ready promise so any code waiting on
     // componentOnReady() doesn't hang forever

--- a/packages/core/src/runtime/update-component.ts
+++ b/packages/core/src/runtime/update-component.ts
@@ -5,9 +5,64 @@ import type * as d from '@stencil/core';
 import { CMP_FLAGS, HOST_FLAGS } from '../utils/constants';
 import { emitEvent } from './event-emitter';
 import { createTime } from './profile';
+import { getRegistry } from './registry';
 import { PLATFORM_FLAGS } from './runtime-constants';
 import { attachStyles } from './styles';
 import { renderVdom } from './vdom/vdom-render';
+
+/**
+ * Get (creating on demand) a promise that resolves once `hostRef`'s real
+ * `connectedCallback` has fired for the first time. Two call sites share this for the
+ * same `hostRef`, in either order - whichever asks first creates it, the other reuses it.
+ *
+ * @param hostRef the component's host reference
+ * @returns a promise that resolves once the component's real `connectedCallback` has fired
+ */
+export const ensureFirstConnectPromise = (hostRef: d.HostRef): Promise<void> => {
+  if (!hostRef.$onFirstConnectPromise$) {
+    hostRef.$onFirstConnectPromise$ = new Promise((r) => (hostRef.$onFirstConnectResolve$ = r));
+  }
+  return hostRef.$onFirstConnectPromise$;
+};
+
+/**
+ * Resolve `hostRef`'s first-connect promise and flag it connected. Called once this
+ * component's real `connectedCallback` fires, plus from error/disconnect cleanup so a
+ * component that never connects can't hang an ancestor or descendant forever.
+ *
+ * @param hostRef the component's host reference
+ */
+export const markFirstConnected = (hostRef: d.HostRef) => {
+  hostRef.$flags$ |= HOST_FLAGS.hasFiredConnected;
+  hostRef.$onFirstConnectResolve$?.();
+  hostRef.$onFirstConnectResolve$ = undefined;
+};
+
+/**
+ * Wait for `ancestorElm` (if given) to be defined and its real `connectedCallback` to have
+ * completed. Shared by the lazy ({@link initializeComponent}) and standalone
+ * (`bootstrap-standalone.ts`) `connectedCallback` paths so a component never connects before
+ * its nearest Stencil ancestor, regardless of load order. Lazy's proxy classes are always
+ * pre-defined, so the `whenDefined` wait is a no-op there - it only does real work for
+ * standalone's autoloader, where the ancestor tag may not be defined yet.
+ *
+ * @param ancestorElm the nearest Stencil ancestor element, if any
+ */
+export const awaitAncestorConnected = async (
+  ancestorElm: d.HostElement | undefined,
+): Promise<void> => {
+  if (!BUILD.asyncLoading || !ancestorElm) {
+    return;
+  }
+  let ancestorHostRef = getHostRef(ancestorElm);
+  if (!ancestorHostRef) {
+    await getRegistry().whenDefined(ancestorElm.tagName.toLowerCase());
+    ancestorHostRef = getHostRef(ancestorElm);
+  }
+  if (ancestorHostRef && !(ancestorHostRef.$flags$ & HOST_FLAGS.hasFiredConnected)) {
+    await ensureFirstConnectPromise(ancestorHostRef);
+  }
+};
 
 export const attachToAncestor = (hostRef: d.HostRef, ancestorComponent?: d.HostElement) => {
   if (
@@ -25,6 +80,10 @@ export const attachToAncestor = (hostRef: d.HostRef, ancestorComponent?: d.HostE
           }),
       ),
     );
+    // Resolved by `markFirstConnected` once this component's real `connectedCallback` fires.
+    if (ancestorComponent['s-pc']) {
+      ancestorComponent['s-pc'].push(ensureFirstConnectPromise(hostRef));
+    }
   }
 };
 
@@ -47,6 +106,13 @@ export const scheduleUpdate = (
   const dispatch = () => dispatchHooks(hostRef, isInitialLoad);
 
   if (isInitialLoad) {
+    // `s-pc` holds pending children's first-connect promises (registered via
+    // `attachToAncestor`). `componentWillLoad` must not fire before a pending child's real
+    // `connectedCallback` has, regardless of which module resolves first.
+    const pendingConnects = BUILD.asyncLoading ? hostRef.$hostElement$['s-pc'] : undefined;
+    if (pendingConnects && pendingConnects.length > 0) {
+      return Promise.all(pendingConnects).then(dispatch).catch(dispatch);
+    }
     queueMicrotask(() => {
       dispatch();
     });
@@ -107,12 +173,6 @@ const dispatchHooks = (hostRef: d.HostRef, isInitialLoad: boolean): Promise<void
 
   if (isInitialLoad) {
     if (BUILD.lazyLoad) {
-      // Fire deferred connectedCallback before componentWillLoad
-      if (BUILD.slotRelocation && hostRef.$deferredConnectedCallback$) {
-        hostRef.$deferredConnectedCallback$ = false;
-        safeCall(instance, 'connectedCallback', undefined, elm);
-      }
-
       if (BUILD.hostListener) {
         hostRef.$flags$ |= HOST_FLAGS.isListenReady;
         if (hostRef.$queuedListeners$) {

--- a/packages/core/src/runtime/update-component.ts
+++ b/packages/core/src/runtime/update-component.ts
@@ -11,14 +11,12 @@ import { attachStyles } from './styles';
 import { renderVdom } from './vdom/vdom-render';
 
 /**
- * Get (creating on demand) a promise that resolves once `hostRef`'s real
- * `connectedCallback` has fired for the first time. Two call sites share this for the
- * same `hostRef`, in either order - whichever asks first creates it, the other reuses it.
+ * Get a promise that resolves once `hostRef`'s real `connectedCallback` has fired for the first time.
  *
  * @param hostRef the component's host reference
  * @returns a promise that resolves once the component's real `connectedCallback` has fired
  */
-export const ensureFirstConnectPromise = (hostRef: d.HostRef): Promise<void> => {
+const ensureFirstConnectPromise = (hostRef: d.HostRef): Promise<void> => {
   if (!hostRef.$onFirstConnectPromise$) {
     hostRef.$onFirstConnectPromise$ = new Promise((r) => (hostRef.$onFirstConnectResolve$ = r));
   }
@@ -39,23 +37,19 @@ export const markFirstConnected = (hostRef: d.HostRef) => {
 };
 
 /**
- * Wait for `ancestorElm` (if given) to be defined and its real `connectedCallback` to have
- * completed. Shared by the lazy ({@link initializeComponent}) and standalone
- * (`bootstrap-standalone.ts`) `connectedCallback` paths so a component never connects before
- * its nearest Stencil ancestor, regardless of load order. Lazy's proxy classes are always
- * pre-defined, so the `whenDefined` wait is a no-op there - it only does real work for
- * standalone's autoloader, where the ancestor tag may not be defined yet.
+ * Wait for `ancestorElm` to be defined and its real `connectedCallback` to have completed.
+ * Shared by the lazy ({@link initializeComponent}) and standalone (`bootstrap-standalone.ts`)
+ * `connectedCallback` paths so a component never connects before its nearest Stencil
+ * ancestor, regardless of load order. Both call sites already check `BUILD.asyncLoading` and
+ * that an ancestor exists before calling this. Lazy's proxy classes are always pre-defined,
+ * so the `whenDefined` wait is a no-op there - it only does real work for standalone's
+ * autoloader, where the ancestor tag may not be defined yet.
  *
- * @param ancestorElm the nearest Stencil ancestor element, if any
+ * @param ancestorElm the nearest Stencil ancestor element
  */
-export const awaitAncestorConnected = async (
-  ancestorElm: d.HostElement | undefined,
-): Promise<void> => {
-  if (!BUILD.asyncLoading || !ancestorElm) {
-    return;
-  }
+export const awaitAncestorConnected = async (ancestorElm: d.HostElement): Promise<void> => {
   let ancestorHostRef = getHostRef(ancestorElm);
-  if (!ancestorHostRef) {
+  if (!BUILD.lazyLoad && !ancestorHostRef) {
     await getRegistry().whenDefined(ancestorElm.tagName.toLowerCase());
     ancestorHostRef = getHostRef(ancestorElm);
   }

--- a/packages/core/src/utils/constants.ts
+++ b/packages/core/src/utils/constants.ts
@@ -59,10 +59,16 @@ export const HOST_FLAGS = {
   isWatchReady: 1 << 7,
   isListenReady: 1 << 8,
   needsRerender: 1 << 9,
+  /**
+   * Set once this component's real (lazy-loaded) `connectedCallback` has fired for
+   * the first time. Lets a descendant skip creating/awaiting a connect-promise for
+   * an ancestor that's already connected. See {@link HostRef.$onFirstConnectResolve$}.
+   */
+  hasFiredConnected: 1 << 10,
 
   // DEV ONLY
-  devOnRender: 1 << 10,
-  devOnDidLoad: 1 << 11,
+  devOnRender: 1 << 11,
+  devOnDidLoad: 1 << 12,
 } as const;
 
 // CMP_FLAGS base values

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,7 +92,7 @@ importers:
         version: link:../core
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.0(@tsdown/css@0.22.0)(oxc-resolver@11.21.3)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.34(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0))
+        version: 0.22.0(@tsdown/css@0.22.0)(oxc-resolver@11.21.3)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.34(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       vitest:
         specifier: 'catalog:'
         version: 4.1.7(@types/node@25.9.1)(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(vite@8.1.0(@types/node@25.9.1)(esbuild@0.27.3)(jiti@2.7.0)(less@4.6.7)(sass-embedded@1.97.3)(sass@1.101.0)(terser@5.48.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -208,7 +208,7 @@ importers:
         version: 8.18.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.0(@tsdown/css@0.22.0)(oxc-resolver@11.21.3)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.34(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0))
+        version: 0.22.0(@tsdown/css@0.22.0)(oxc-resolver@11.21.3)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.34(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -233,7 +233,7 @@ importers:
         version: 1.12.1(@vitest/browser-playwright@4.1.7)(jsdom@28.0.0)(playwright@1.60.0)(vitest@4.1.7)
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.0(@tsdown/css@0.22.0)(oxc-resolver@11.21.3)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.34(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0))
+        version: 0.22.0(@tsdown/css@0.22.0)(oxc-resolver@11.21.3)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.34(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -249,7 +249,7 @@ importers:
     devDependencies:
       tsdown:
         specifier: 'catalog:'
-        version: 0.22.0(@tsdown/css@0.22.0)(oxc-resolver@11.21.3)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.34(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0))
+        version: 0.22.0(@tsdown/css@0.22.0)(oxc-resolver@11.21.3)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.34(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -413,6 +413,8 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
+
+  test/end-to-end/hydrate: {}
 
   test/integration: {}
 
@@ -733,10 +735,6 @@ importers:
       file-saver:
         specifier: ^2.0.5
         version: 2.0.5
-
-  test/wdio/hydrate: {}
-
-  test/wdio/test-ts-target-output/hydrate: {}
 
 packages:
 
@@ -7375,14 +7373,6 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-    optional: true
-
   '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
@@ -7632,7 +7622,7 @@ snapshots:
       lightningcss: 1.32.0
       postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.21.0)(yaml@2.9.0)
       rolldown: 1.0.2
-      tsdown: 0.22.0(@tsdown/css@0.22.0)(oxc-resolver@11.21.3)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.34(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))
+      tsdown: 0.22.0(@tsdown/css@0.22.0)(oxc-resolver@11.21.3)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.34(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
     optionalDependencies:
       postcss: 8.5.15
       sass: 1.101.0
@@ -10163,31 +10153,6 @@ snapshots:
       - '@emnapi/runtime'
     optional: true
 
-  rolldown@1.0.0-rc.12(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0):
-    dependencies:
-      '@oxc-project/types': 0.122.0
-      '@rolldown/pluginutils': 1.0.0-rc.12
-    optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-    optional: true
-
   rolldown@1.0.0-rc.12(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1):
     dependencies:
       '@oxc-project/types': 0.122.0
@@ -10767,34 +10732,6 @@ snapshots:
       - oxc-resolver
       - vue-tsc
 
-  tsdown@0.22.0(@tsdown/css@0.22.0)(oxc-resolver@11.21.3)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.34(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)):
-    dependencies:
-      ansis: 4.3.0
-      cac: 7.0.0
-      defu: 6.1.7
-      empathic: 2.0.1
-      hookable: 6.1.1
-      import-without-cache: 0.4.0
-      obug: 2.1.1
-      picomatch: 4.0.4
-      rolldown: 1.0.2
-      rolldown-plugin-dts: 0.25.1(oxc-resolver@11.21.3)(rolldown@1.0.2)(typescript@6.0.3)
-      semver: 7.8.0
-      tinyexec: 1.1.2
-      tinyglobby: 0.2.16
-      tree-kill: 1.2.2
-      unconfig-core: 7.5.0
-    optionalDependencies:
-      '@tsdown/css': 0.22.0(jiti@2.7.0)(postcss@8.5.15)(sass-embedded@1.97.3)(sass@1.101.0)(tsdown@0.22.0)(tsx@4.21.0)(yaml@2.9.0)
-      tsx: 4.21.0
-      typescript: 6.0.3
-      unrun: 0.2.34(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
-    transitivePeerDependencies:
-      - '@ts-macro/tsc'
-      - '@typescript/native-preview'
-      - oxc-resolver
-      - vue-tsc
-
   tsdown@0.22.0(@tsdown/css@0.22.0)(oxc-resolver@11.21.3)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.34(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)):
     dependencies:
       ansis: 4.3.0
@@ -10889,14 +10826,6 @@ snapshots:
   unrun@0.2.34(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
     dependencies:
       rolldown: 1.0.0-rc.12(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-    optional: true
-
-  unrun@0.2.34(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0):
-    dependencies:
-      rolldown: 1.0.0-rc.12(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'

--- a/test/runtime/src/components.d.ts
+++ b/test/runtime/src/components.d.ts
@@ -205,6 +205,14 @@ export namespace Components {
     }
     interface ConditionalRerenderRoot {
     }
+    interface ConnectedCallbackRaceChild {
+    }
+    interface ConnectedCallbackRaceDeferredChild {
+    }
+    interface ConnectedCallbackRaceDeferredParent {
+    }
+    interface ConnectedCallbackRaceParent {
+    }
     interface CrossDocumentStyle {
     }
     interface CspNonceCmp {
@@ -1571,6 +1579,30 @@ declare global {
     var HTMLConditionalRerenderRootElement: {
         prototype: HTMLConditionalRerenderRootElement;
         new (): HTMLConditionalRerenderRootElement;
+    };
+    interface HTMLConnectedCallbackRaceChildElement extends Components.ConnectedCallbackRaceChild, HTMLStencilElement {
+    }
+    var HTMLConnectedCallbackRaceChildElement: {
+        prototype: HTMLConnectedCallbackRaceChildElement;
+        new (): HTMLConnectedCallbackRaceChildElement;
+    };
+    interface HTMLConnectedCallbackRaceDeferredChildElement extends Components.ConnectedCallbackRaceDeferredChild, HTMLStencilElement {
+    }
+    var HTMLConnectedCallbackRaceDeferredChildElement: {
+        prototype: HTMLConnectedCallbackRaceDeferredChildElement;
+        new (): HTMLConnectedCallbackRaceDeferredChildElement;
+    };
+    interface HTMLConnectedCallbackRaceDeferredParentElement extends Components.ConnectedCallbackRaceDeferredParent, HTMLStencilElement {
+    }
+    var HTMLConnectedCallbackRaceDeferredParentElement: {
+        prototype: HTMLConnectedCallbackRaceDeferredParentElement;
+        new (): HTMLConnectedCallbackRaceDeferredParentElement;
+    };
+    interface HTMLConnectedCallbackRaceParentElement extends Components.ConnectedCallbackRaceParent, HTMLStencilElement {
+    }
+    var HTMLConnectedCallbackRaceParentElement: {
+        prototype: HTMLConnectedCallbackRaceParentElement;
+        new (): HTMLConnectedCallbackRaceParentElement;
     };
     interface HTMLCrossDocumentStyleElement extends Components.CrossDocumentStyle, HTMLStencilElement {
     }
@@ -3078,6 +3110,10 @@ declare global {
         "conditional-basic": HTMLConditionalBasicElement;
         "conditional-rerender": HTMLConditionalRerenderElement;
         "conditional-rerender-root": HTMLConditionalRerenderRootElement;
+        "connected-callback-race-child": HTMLConnectedCallbackRaceChildElement;
+        "connected-callback-race-deferred-child": HTMLConnectedCallbackRaceDeferredChildElement;
+        "connected-callback-race-deferred-parent": HTMLConnectedCallbackRaceDeferredParentElement;
+        "connected-callback-race-parent": HTMLConnectedCallbackRaceParentElement;
         "cross-document-style": HTMLCrossDocumentStyleElement;
         "csp-nonce-cmp": HTMLCspNonceCmpElement;
         "css-cmp": HTMLCssCmpElement;
@@ -3282,7 +3318,7 @@ declare global {
     }
 }
 declare namespace LocalJSX {
-    type OneOf<K extends string, PropT, AttrT = PropT> = { [P in K]: PropT } & { [P in `attr:${K}` | `prop:${K}`]?: never } | { [P in `attr:${K}`]: AttrT } & { [P in K | `prop:${K}`]?: never } | { [P in `prop:${K}`]: PropT } & { [P in K | `attr:${K}`]?: never };
+    type OneOf<K extends string, PropT, AttrT = PropT> = { [P in K]: PropT } & { [P in `attr:${K}`]?: never } | { [P in `attr:${K}`]: AttrT } & { [P in K]?: never };
 
     interface AsyncRerender {
     }
@@ -3467,6 +3503,14 @@ declare namespace LocalJSX {
     interface ConditionalRerender {
     }
     interface ConditionalRerenderRoot {
+    }
+    interface ConnectedCallbackRaceChild {
+    }
+    interface ConnectedCallbackRaceDeferredChild {
+    }
+    interface ConnectedCallbackRaceDeferredParent {
+    }
+    interface ConnectedCallbackRaceParent {
     }
     interface CrossDocumentStyle {
     }
@@ -4705,6 +4749,10 @@ declare namespace LocalJSX {
         "conditional-basic": ConditionalBasic;
         "conditional-rerender": ConditionalRerender;
         "conditional-rerender-root": ConditionalRerenderRoot;
+        "connected-callback-race-child": ConnectedCallbackRaceChild;
+        "connected-callback-race-deferred-child": ConnectedCallbackRaceDeferredChild;
+        "connected-callback-race-deferred-parent": ConnectedCallbackRaceDeferredParent;
+        "connected-callback-race-parent": ConnectedCallbackRaceParent;
         "cross-document-style": CrossDocumentStyle;
         "csp-nonce-cmp": CspNonceCmp;
         "css-cmp": CssCmp;
@@ -4959,6 +5007,10 @@ declare module "@stencil/core" {
             "conditional-basic": LocalJSX.IntrinsicElements["conditional-basic"] & JSXBase.HTMLAttributes<HTMLConditionalBasicElement>;
             "conditional-rerender": LocalJSX.IntrinsicElements["conditional-rerender"] & JSXBase.HTMLAttributes<HTMLConditionalRerenderElement>;
             "conditional-rerender-root": LocalJSX.IntrinsicElements["conditional-rerender-root"] & JSXBase.HTMLAttributes<HTMLConditionalRerenderRootElement>;
+            "connected-callback-race-child": LocalJSX.IntrinsicElements["connected-callback-race-child"] & JSXBase.HTMLAttributes<HTMLConnectedCallbackRaceChildElement>;
+            "connected-callback-race-deferred-child": LocalJSX.IntrinsicElements["connected-callback-race-deferred-child"] & JSXBase.HTMLAttributes<HTMLConnectedCallbackRaceDeferredChildElement>;
+            "connected-callback-race-deferred-parent": LocalJSX.IntrinsicElements["connected-callback-race-deferred-parent"] & JSXBase.HTMLAttributes<HTMLConnectedCallbackRaceDeferredParentElement>;
+            "connected-callback-race-parent": LocalJSX.IntrinsicElements["connected-callback-race-parent"] & JSXBase.HTMLAttributes<HTMLConnectedCallbackRaceParentElement>;
             "cross-document-style": LocalJSX.IntrinsicElements["cross-document-style"] & JSXBase.HTMLAttributes<HTMLCrossDocumentStyleElement>;
             "csp-nonce-cmp": LocalJSX.IntrinsicElements["csp-nonce-cmp"] & JSXBase.HTMLAttributes<HTMLCspNonceCmpElement>;
             "css-cmp": LocalJSX.IntrinsicElements["css-cmp"] & JSXBase.HTMLAttributes<HTMLCssCmpElement>;

--- a/test/runtime/src/components/lifecycle/connected-callback-race/connected-callback-race-child.tsx
+++ b/test/runtime/src/components/lifecycle/connected-callback-race/connected-callback-race-child.tsx
@@ -1,0 +1,19 @@
+import { Component, Element } from '@stencil/core';
+
+import output from './output';
+
+@Component({
+  tag: 'connected-callback-race-child',
+})
+export class ConnectedCallbackRaceChild {
+  @Element() el!: HTMLElement;
+
+  connectedCallback() {
+    this.el.setAttribute('data-connected', '');
+    output('child-connectedCallback');
+  }
+
+  render() {
+    return 'child';
+  }
+}

--- a/test/runtime/src/components/lifecycle/connected-callback-race/connected-callback-race-deferred-child.tsx
+++ b/test/runtime/src/components/lifecycle/connected-callback-race/connected-callback-race-deferred-child.tsx
@@ -1,0 +1,22 @@
+import { Component, Element, h } from '@stencil/core';
+
+import output from './output';
+
+// Non-shadow + its own `<slot>` gives this component `hasSlotRelocation`, which defers
+// firing its real `connectedCallback` - see initialize-component.ts. Regression coverage
+// for that deferred path specifically, as distinct from `connected-callback-race-child`.
+@Component({
+  tag: 'connected-callback-race-deferred-child',
+})
+export class ConnectedCallbackRaceDeferredChild {
+  @Element() el!: HTMLElement;
+
+  connectedCallback() {
+    this.el.setAttribute('data-connected', '');
+    output('deferred-child-connectedCallback', 'connected-callback-race-deferred-log');
+  }
+
+  render() {
+    return <slot />;
+  }
+}

--- a/test/runtime/src/components/lifecycle/connected-callback-race/connected-callback-race-deferred-parent.tsx
+++ b/test/runtime/src/components/lifecycle/connected-callback-race/connected-callback-race-deferred-parent.tsx
@@ -1,0 +1,29 @@
+import { Component, Element } from '@stencil/core';
+
+import output from './output';
+
+@Component({
+  tag: 'connected-callback-race-deferred-parent',
+})
+export class ConnectedCallbackRaceDeferredParent {
+  @Element() el!: HTMLElement;
+
+  connectedCallback() {
+    output('deferred-parent-connectedCallback', 'connected-callback-race-deferred-log');
+  }
+
+  componentWillLoad() {
+    const sawChild =
+      this.el
+        .querySelector('connected-callback-race-deferred-child')
+        ?.hasAttribute('data-connected') ?? false;
+    output(
+      `deferred-parent-componentWillLoad saw-child=${sawChild}`,
+      'connected-callback-race-deferred-log',
+    );
+  }
+
+  render() {
+    return 'deferred-parent';
+  }
+}

--- a/test/runtime/src/components/lifecycle/connected-callback-race/connected-callback-race-parent.tsx
+++ b/test/runtime/src/components/lifecycle/connected-callback-race/connected-callback-race-parent.tsx
@@ -1,0 +1,25 @@
+import { Component, Element } from '@stencil/core';
+
+import output from './output';
+
+@Component({
+  tag: 'connected-callback-race-parent',
+})
+export class ConnectedCallbackRaceParent {
+  @Element() el!: HTMLElement;
+
+  connectedCallback() {
+    output('parent-connectedCallback');
+  }
+
+  componentWillLoad() {
+    const sawChild =
+      this.el.querySelector('connected-callback-race-child')?.hasAttribute('data-connected') ??
+      false;
+    output(`parent-componentWillLoad saw-child=${sawChild}`);
+  }
+
+  render() {
+    return 'parent';
+  }
+}

--- a/test/runtime/src/components/lifecycle/connected-callback-race/connected-callback-race.spec.tsx
+++ b/test/runtime/src/components/lifecycle/connected-callback-race/connected-callback-race.spec.tsx
@@ -1,0 +1,34 @@
+import { render, describe, it, expect, waitForStable } from '@stencil/vitest';
+
+// Regression test for https://github.com/stenciljs/core/issues/6636
+describe('connected-callback-race', () => {
+  it("parent's componentWillLoad observes a pre-existing (slotted) child's connectedCallback, even when the child's module resolves after the parent's", async () => {
+    const { waitForChanges } = await render(
+      '<div><ol id="connected-callback-race-log"></ol><connected-callback-race-parent><connected-callback-race-child></connected-callback-race-child></connected-callback-race-parent></div>',
+    );
+
+    await waitForChanges();
+    await waitForStable('#connected-callback-race-log');
+
+    const logs = document.querySelectorAll('#connected-callback-race-log li');
+    expect(logs).toHaveLength(3);
+    expect(logs[0]).toHaveTextContent('parent-connectedCallback');
+    expect(logs[1]).toHaveTextContent('child-connectedCallback');
+    expect(logs[2]).toHaveTextContent('parent-componentWillLoad saw-child=true');
+  });
+
+  it("parent's componentWillLoad observes a deferred (non-shadow, own-slot) child's connectedCallback", async () => {
+    const { waitForChanges } = await render(
+      '<div><ol id="connected-callback-race-deferred-log"></ol><connected-callback-race-deferred-parent><connected-callback-race-deferred-child></connected-callback-race-deferred-child></connected-callback-race-deferred-parent></div>',
+    );
+
+    await waitForChanges();
+    await waitForStable('#connected-callback-race-deferred-log');
+
+    const logs = document.querySelectorAll('#connected-callback-race-deferred-log li');
+    expect(logs).toHaveLength(3);
+    expect(logs[0]).toHaveTextContent('deferred-parent-connectedCallback');
+    expect(logs[1]).toHaveTextContent('deferred-child-connectedCallback');
+    expect(logs[2]).toHaveTextContent('deferred-parent-componentWillLoad saw-child=true');
+  });
+});

--- a/test/runtime/src/components/lifecycle/connected-callback-race/output.ts
+++ b/test/runtime/src/components/lifecycle/connected-callback-race/output.ts
@@ -1,0 +1,5 @@
+export default function (msg: string, id = 'connected-callback-race-log') {
+  const listEntry = document.createElement('li');
+  listEntry.innerText = msg;
+  document.getElementById(id)!.appendChild(listEntry);
+}

--- a/test/runtime/src/components/lifecycle/connected-callback-race/readme.md
+++ b/test/runtime/src/components/lifecycle/connected-callback-race/readme.md
@@ -1,0 +1,10 @@
+# connected-callback-race-child
+
+
+
+<!-- Auto Generated Below -->
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*


### PR DESCRIPTION

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: https://github.com/stenciljs/core/issues/6636 (and more)

For any tree of Stencil components, regardless of which output is used, this should be the order:

- `connectedCallback` fires top-down - never before the nearest Stencil ancestor's has fully completed.
- `componentWillLoad` fires top-down, after descendants have connected - never before every already-present Stencil descendant's `connectedCallback` has fired. (The core #6636 fix.)
- `componentDidLoad` fires bottom-up — never before all descendants' componentDidLoads have

This should be true no-matter if using the lazy loader, standalone components or the standalone auto-loader .. at present this is not the case. Network latency (for example) can cause this lifecycle of events to fire out-of-order.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The contract is enforced

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

Not strictly - but could be a change in expectation if someone is currently relying on a particular order.

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
