### PR TITLE
fix(compiler): track type query references

### DIFF
--- a/src/compiler/transformers/test/parse-props.spec.ts
+++ b/src/compiler/transformers/test/parse-props.spec.ts
@@ -1,6 +1,6 @@
-import { mockBuildCtx, mockConfig, mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerSystem, mockConfig, mockValidatedConfig } from '@stencil/core/testing';
 import { normalizePath } from '@utils';
-import { join, resolve } from 'path';
+import { join, relative, resolve } from 'path';
 import * as ts from 'typescript';
 
 import { createCompiler } from '../../compiler';
@@ -156,16 +156,17 @@ describe('parse props', () => {
   });
 
   it('generates imports for default and aliased exports used by type queries', async () => {
-    const rootDir = normalizePath(process.cwd(), false);
-    const fixtureDir = join(rootDir, '.stencil-type-query-exports');
-    const srcDir = join(fixtureDir, 'src');
+    const sys = mockCompilerSystem();
+    const rootDir = '/';
+    const srcDir = join(rootDir, 'src');
     const config = mockConfig({
       buildDocs: true,
+      sys,
       rootDir,
       srcDir,
-      outputTargets: [{ type: 'docs-json', file: join('.stencil-type-query-exports', 'docs.json') }],
+      outputTargets: [{ type: 'docs-json', file: join(rootDir, 'docs.json') }],
     });
-    const tsconfigPath = join(fixtureDir, 'tsconfig.json');
+    const tsconfigPath = join(rootDir, 'tsconfig.json');
     const componentDir = join(srcDir, 'components');
 
     await config.sys.createDir(componentDir, { recursive: true });
@@ -399,7 +400,7 @@ describe('parse props', () => {
         [],
       );
 
-      const docsJson = JSON.parse(await compiler.sys.readFile(join(fixtureDir, 'docs.json')));
+      const docsJson = JSON.parse(await compiler.sys.readFile(join(rootDir, 'docs.json')));
       const barrelComponent = docsJson.components.find((component: { tag: string }) => component.tag === 'cmp-barrel');
       const getBarrelReference = (propertyName: string, referenceName: string) =>
         barrelComponent.props.find((property: { name: string }) => property.name === propertyName).complexType
@@ -419,12 +420,12 @@ describe('parse props', () => {
       expect(firstModeReference.id).not.toBe(secondModeReference.id);
       expect(docsJson.typeLibrary[firstModeReference.id]).toMatchObject({
         declaration: expect.stringContaining('enum Mode'),
-        path: '.stencil-type-query-exports/src/components/a.ts',
+        path: normalizePath(relative(process.cwd(), join(componentDir, 'a.ts')), false),
       });
       expect(docsJson.typeLibrary[firstModeReference.id].declaration).toContain("A = 'a'");
       expect(docsJson.typeLibrary[secondModeReference.id]).toMatchObject({
         declaration: expect.stringContaining('enum Mode'),
-        path: '.stencil-type-query-exports/src/components/b.ts',
+        path: normalizePath(relative(process.cwd(), join(componentDir, 'b.ts')), false),
       });
       expect(docsJson.typeLibrary[secondModeReference.id].declaration).toContain("B = 'b'");
 

--- a/src/compiler/transformers/test/parse-props.spec.ts
+++ b/src/compiler/transformers/test/parse-props.spec.ts
@@ -1,7 +1,11 @@
-import { mockBuildCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockConfig, mockValidatedConfig } from '@stencil/core/testing';
+import { normalizePath } from '@utils';
+import { join, resolve } from 'path';
 import * as ts from 'typescript';
 
+import { createCompiler } from '../../compiler';
 import { convertDecoratorsToStatic } from '../decorators-to-static/convert-decorators';
+import { getAttributeTypeInfo } from '../transform-utils';
 import { getStaticGetter, transpileModule } from './transpile';
 import { c, formatCode } from './utils';
 
@@ -76,6 +80,395 @@ describe('parse props', () => {
       getter: false,
       setter: false,
     });
+  });
+
+  it('tracks local enum and class references used by type queries', () => {
+    const t = transpileModule(`
+      export enum LocalEnum {
+        Default = 'default'
+      }
+      export class LocalClass {
+        static value = 'value';
+      }
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() enumValue: keyof typeof LocalEnum;
+        @Prop() classValue: keyof typeof LocalClass;
+      }
+    `);
+
+    expect(t.properties.find((prop) => prop.name === 'enumValue')?.complexType.references).toEqual({
+      LocalEnum: { location: 'local', path: 'module.tsx', id: 'module.tsx::LocalEnum' },
+    });
+    expect(t.properties.find((prop) => prop.name === 'classValue')?.complexType.references).toEqual({
+      LocalClass: { location: 'local', path: 'module.tsx', id: 'module.tsx::LocalClass' },
+    });
+  });
+
+  it('tracks imported enum and class references used by type queries', () => {
+    const inputFileName = normalizePath(resolve('src/compiler/transformers/test/type-query-module.ts'), false);
+    const input = `
+      import { BestEnum as ImportedEnum } from './fixtures/meal-entry';
+      import { ObjectMap as ImportedClass } from '../transform-utils';
+      class TypeQueryFixture {
+        enumValue: keyof typeof ImportedEnum;
+        classValue: keyof typeof ImportedClass;
+      }
+    `;
+    const options: ts.CompilerOptions = {
+      ...ts.getDefaultCompilerOptions(),
+      module: ts.ModuleKind.ESNext,
+      moduleResolution: ts.ModuleResolutionKind.Node10,
+      target: ts.ScriptTarget.Latest,
+    };
+    const host = ts.createCompilerHost(options);
+    const getSourceFile = host.getSourceFile.bind(host);
+    const fileExists = host.fileExists.bind(host);
+    const readFile = host.readFile.bind(host);
+    host.getSourceFile = (fileName, languageVersion, onError, shouldCreateNewSourceFile) =>
+      fileName === inputFileName
+        ? ts.createSourceFile(fileName, input, languageVersion, true, ts.ScriptKind.TS)
+        : getSourceFile(fileName, languageVersion, onError, shouldCreateNewSourceFile);
+    host.fileExists = (fileName) => fileName === inputFileName || fileExists(fileName);
+    host.readFile = (fileName) => (fileName === inputFileName ? input : readFile(fileName));
+
+    const program = ts.createProgram([inputFileName], options, host);
+    const sourceFile = program.getSourceFile(inputFileName)!;
+    const fixture = sourceFile.statements.find(ts.isClassDeclaration)!;
+    const getReferences = (propertyName: string) => {
+      const property = fixture.members.find(
+        (member): member is ts.PropertyDeclaration =>
+          ts.isPropertyDeclaration(member) && member.name.getText() === propertyName,
+      )!;
+      return getAttributeTypeInfo(property, sourceFile, program.getTypeChecker(), program);
+    };
+
+    expect(getReferences('enumValue').ImportedEnum).toMatchObject({
+      location: 'import',
+      path: './fixtures/meal-entry',
+      referenceLocation: 'BestEnum',
+    });
+    expect(getReferences('classValue').ImportedClass).toMatchObject({
+      location: 'import',
+      path: '../transform-utils',
+      referenceLocation: 'ObjectMap',
+    });
+  });
+
+  it('generates imports for default and aliased exports used by type queries', async () => {
+    const rootDir = normalizePath(process.cwd(), false);
+    const fixtureDir = join(rootDir, '.stencil-type-query-exports');
+    const srcDir = join(fixtureDir, 'src');
+    const config = mockConfig({
+      buildDocs: true,
+      rootDir,
+      srcDir,
+      outputTargets: [{ type: 'docs-json', file: join('.stencil-type-query-exports', 'docs.json') }],
+    });
+    const tsconfigPath = join(fixtureDir, 'tsconfig.json');
+    const componentDir = join(srcDir, 'components');
+
+    await config.sys.createDir(componentDir, { recursive: true });
+    await config.sys.writeFile(
+      tsconfigPath,
+      JSON.stringify({
+        compilerOptions: {
+          experimentalDecorators: true,
+          jsx: 'react',
+          jsxFactory: 'h',
+          module: 'esnext',
+          moduleResolution: 'node',
+          target: 'es2017',
+        },
+        include: ['src'],
+      }),
+    );
+    await config.sys.writeFile(
+      join('bin', 'lib.es2017.full.d.ts'),
+      `
+        interface Array<T> {}
+        interface Boolean {}
+        interface Function {}
+        interface IArguments {}
+        interface Number {}
+        interface Object {}
+        interface RegExp {}
+        interface String {}
+      `,
+    );
+    await config.sys.writeFile(join('internal', 'stencil-public-docs.d.ts'), 'export interface JsonDocs {}');
+    await config.sys.writeFile(
+      join(componentDir, 'assigned-class.ts'),
+      `
+        class AssignedClass {
+          static value = 'value';
+        }
+        export default AssignedClass;
+      `,
+    );
+    await config.sys.writeFile(
+      join(componentDir, 'direct-class.ts'),
+      `
+        export default class DirectClass {
+          static value = 'value';
+        }
+      `,
+    );
+    await config.sys.writeFile(
+      join(componentDir, 'default-enum.ts'),
+      `
+        enum DefaultEnum {
+          Value = 'value'
+        }
+        export default DefaultEnum;
+      `,
+    );
+    await config.sys.writeFile(
+      join(componentDir, 'shared-class.ts'),
+      `
+        export default class SharedClass {
+          static value = 'value';
+        }
+      `,
+    );
+    await config.sys.writeFile(
+      join(componentDir, 'shared-enum.ts'),
+      `
+        enum SharedEnum {
+          Value = 'value'
+        }
+        export default SharedEnum;
+      `,
+    );
+    await config.sys.writeFile(
+      join(componentDir, 'named.ts'),
+      `
+        export enum NamedEnum {
+          Value = 'value'
+        }
+        export class OriginalClass {
+          static value = 'external';
+        }
+      `,
+    );
+    await config.sys.writeFile(
+      join(componentDir, 'a.ts'),
+      `
+        export enum Mode {
+          A = 'a'
+        }
+      `,
+    );
+    await config.sys.writeFile(
+      join(componentDir, 'b.ts'),
+      `
+        export enum Mode {
+          B = 'b'
+        }
+      `,
+    );
+    await config.sys.writeFile(
+      join(componentDir, 'barrel.ts'),
+      `
+        export { Mode as FirstMode } from './a';
+        export { Mode as SecondMode } from './b';
+      `,
+    );
+    await config.sys.writeFile(
+      join(srcDir, 'stencil-core.d.ts'),
+      `
+        declare module '@stencil/core' {
+          export function Component(options: any): any;
+          export function Prop(): any;
+        }
+      `,
+    );
+    await config.sys.writeFile(
+      join(componentDir, 'cmp-a.tsx'),
+      `
+        import { Component, Prop } from '@stencil/core';
+        import AssignedAlias from './assigned-class';
+        import DirectAlias from './direct-class';
+        import EnumAlias from './default-enum';
+
+        export default class LocalDefault {
+          static value = 'value';
+        }
+        class LocalAlias {
+          static value = 'value';
+        }
+        export { LocalAlias as PublicAlias };
+
+        @Component({ tag: 'cmp-a' })
+        export class CmpA {
+          @Prop() assigned: Array<keyof typeof AssignedAlias>;
+          @Prop() direct: keyof typeof DirectAlias;
+          @Prop() enumValue: keyof typeof EnumAlias;
+          @Prop() localDefault: keyof typeof LocalDefault;
+          @Prop() localAlias: keyof typeof LocalAlias;
+        }
+      `,
+    );
+    await config.sys.writeFile(
+      join(componentDir, 'cmp-first.tsx'),
+      `
+        import { Component, Prop } from '@stencil/core';
+        import FirstClass from './shared-class';
+        import FirstEnum from './shared-enum';
+
+        @Component({ tag: 'cmp-first' })
+        export class CmpFirst {
+          @Prop() firstClass: keyof typeof FirstClass;
+          @Prop() firstEnum: keyof typeof FirstEnum;
+        }
+      `,
+    );
+    await config.sys.writeFile(
+      join(componentDir, 'cmp-second.tsx'),
+      `
+        import { Component, Prop } from '@stencil/core';
+        import SecondClass from './shared-class';
+        import SecondEnum from './shared-enum';
+
+        @Component({ tag: 'cmp-second' })
+        export class CmpSecond {
+          @Prop() secondClass: keyof typeof SecondClass;
+          @Prop() secondEnum: keyof typeof SecondEnum;
+        }
+      `,
+    );
+    await config.sys.writeFile(
+      join(componentDir, 'cmp-shadow.tsx'),
+      `
+        import { Component, Prop } from '@stencil/core';
+        import { NamedEnum as NamedAlias } from './named';
+        export { OriginalClass as PublicShadow } from './named';
+
+        export class OriginalClass {
+          static value = 'local';
+        }
+
+        @Component({ tag: 'cmp-shadow' })
+        export class CmpShadow {
+          @Prop() namedEnum: keyof typeof NamedAlias;
+          @Prop() localClass: keyof typeof OriginalClass;
+        }
+      `,
+    );
+    await config.sys.writeFile(
+      join(componentDir, 'cmp-barrel.tsx'),
+      `
+        import { Component, Prop } from '@stencil/core';
+        import { FirstMode, SecondMode } from './barrel';
+
+        @Component({ tag: 'cmp-barrel' })
+        export class CmpBarrel {
+          @Prop() firstMode: keyof typeof FirstMode;
+          @Prop() secondMode: keyof typeof SecondMode;
+        }
+      `,
+    );
+
+    const compiler = await createCompiler({ ...config, tsconfig: tsconfigPath });
+    try {
+      const results = await compiler.build();
+      expect(results.diagnostics.filter((diagnostic) => diagnostic.level === 'error')).toEqual([]);
+
+      const componentsDts = await compiler.sys.readFile(join(srcDir, 'components.d.ts'));
+      expect(componentsDts).toContain('import AssignedAlias from "./components/assigned-class";');
+      expect(componentsDts).toContain('import DirectAlias from "./components/direct-class";');
+      expect(componentsDts).toContain('import EnumAlias from "./components/default-enum";');
+      expect(componentsDts).toContain('import LocalDefault, { PublicAlias as LocalAlias } from "./components/cmp-a";');
+      expect(componentsDts).toContain('import FirstClass from "./components/shared-class";');
+      expect(componentsDts).toContain('import SecondClass from "./components/shared-class";');
+      expect(componentsDts).toContain('import FirstEnum from "./components/shared-enum";');
+      expect(componentsDts).toContain('import SecondEnum from "./components/shared-enum";');
+      expect(componentsDts).toContain('import { NamedEnum as NamedAlias } from "./components/named";');
+      expect(componentsDts).toContain('import { FirstMode, SecondMode } from "./components/barrel";');
+      expect(componentsDts).not.toContain(', { } from');
+      expect(componentsDts).toContain('"firstClass": keyof typeof FirstClass;');
+      expect(componentsDts).toContain('"secondClass": keyof typeof SecondClass;');
+      expect(componentsDts).toContain('"firstEnum": keyof typeof FirstEnum;');
+      expect(componentsDts).toContain('"secondEnum": keyof typeof SecondEnum;');
+
+      const generatedDiagnostics = ts.transpileModule(componentsDts, {
+        fileName: 'components.ts',
+        reportDiagnostics: true,
+      }).diagnostics;
+      expect(generatedDiagnostics?.filter((diagnostic) => diagnostic.category === ts.DiagnosticCategory.Error)).toEqual(
+        [],
+      );
+
+      const docsJson = JSON.parse(await compiler.sys.readFile(join(fixtureDir, 'docs.json')));
+      const barrelComponent = docsJson.components.find((component: { tag: string }) => component.tag === 'cmp-barrel');
+      const getBarrelReference = (propertyName: string, referenceName: string) =>
+        barrelComponent.props.find((property: { name: string }) => property.name === propertyName).complexType
+          .references[referenceName];
+      const firstModeReference = getBarrelReference('firstMode', 'FirstMode');
+      const secondModeReference = getBarrelReference('secondMode', 'SecondMode');
+      expect(firstModeReference).toMatchObject({
+        location: 'import',
+        path: './barrel',
+        referenceLocation: 'FirstMode',
+      });
+      expect(secondModeReference).toMatchObject({
+        location: 'import',
+        path: './barrel',
+        referenceLocation: 'SecondMode',
+      });
+      expect(firstModeReference.id).not.toBe(secondModeReference.id);
+      expect(docsJson.typeLibrary[firstModeReference.id]).toMatchObject({
+        declaration: expect.stringContaining('enum Mode'),
+        path: '.stencil-type-query-exports/src/components/a.ts',
+      });
+      expect(docsJson.typeLibrary[firstModeReference.id].declaration).toContain("A = 'a'");
+      expect(docsJson.typeLibrary[secondModeReference.id]).toMatchObject({
+        declaration: expect.stringContaining('enum Mode'),
+        path: '.stencil-type-query-exports/src/components/b.ts',
+      });
+      expect(docsJson.typeLibrary[secondModeReference.id].declaration).toContain("B = 'b'");
+
+      const getTypeDeclaration = (typeName: string): string | undefined => {
+        const typeEntry = Object.entries(docsJson.typeLibrary).find(([id]) => id.endsWith(`::${typeName}`))?.[1] as
+          | { declaration?: string }
+          | undefined;
+        return typeEntry?.declaration;
+      };
+      expect(getTypeDeclaration('AssignedClass')).toContain('class AssignedClass');
+      expect(getTypeDeclaration('DirectClass')).toContain('class DirectClass');
+      expect(getTypeDeclaration('DefaultEnum')).toContain('enum DefaultEnum');
+      expect(getTypeDeclaration('NamedEnum')).toContain('enum NamedEnum');
+      expect(getTypeDeclaration('AssignedClass')).not.toBe('any');
+      expect(componentsDts).toContain('import { OriginalClass } from "./components/cmp-shadow";');
+      expect(componentsDts).not.toContain('PublicShadow as OriginalClass');
+    } finally {
+      await compiler.destroy();
+    }
+  });
+
+  it('ignores type queries for arbitrary values and value aliases', () => {
+    const t = transpileModule(`
+      const LocalValue = { value: 'value' } as const;
+      function LocalFunction() {
+        return 'value';
+      }
+      class SomeClass {
+        static value = 'value';
+      }
+      const ClassAlias = SomeClass;
+      @Component({tag: 'cmp-a'})
+      export class CmpA {
+        @Prop() objectValue: keyof typeof LocalValue;
+        @Prop() functionValue: keyof typeof LocalFunction;
+        @Prop() classAlias: keyof typeof ClassAlias;
+      }
+    `);
+
+    const getReferences = (propertyName: string) =>
+      t.properties.find((property) => property.name === propertyName)?.complexType.references;
+    expect(getReferences('objectValue')).toEqual({});
+    expect(getReferences('functionValue')).toEqual({});
+    expect(getReferences('classAlias')).toEqual({});
   });
 
   it('should correctly parse a prop with an unresolved type', () => {

--- a/src/compiler/transformers/test/parse-props.spec.ts
+++ b/src/compiler/transformers/test/parse-props.spec.ts
@@ -1,6 +1,6 @@
 import { mockBuildCtx, mockCompilerSystem, mockConfig, mockValidatedConfig } from '@stencil/core/testing';
 import { normalizePath } from '@utils';
-import { join, relative, resolve } from 'path';
+import { join as pathJoin, relative, resolve } from 'path';
 import * as ts from 'typescript';
 
 import { createCompiler } from '../../compiler';
@@ -8,6 +8,8 @@ import { convertDecoratorsToStatic } from '../decorators-to-static/convert-decor
 import { getAttributeTypeInfo } from '../transform-utils';
 import { getStaticGetter, transpileModule } from './transpile';
 import { c, formatCode } from './utils';
+
+const join = (...segments: string[]): string => normalizePath(pathJoin(...segments), false);
 
 describe('parse props', () => {
   it('prop optional', () => {
@@ -370,6 +372,7 @@ describe('parse props', () => {
       `,
     );
 
+    const originalCwd = process.cwd();
     const compiler = await createCompiler({ ...config, tsconfig: tsconfigPath });
     try {
       const results = await compiler.build();
@@ -443,6 +446,7 @@ describe('parse props', () => {
       expect(componentsDts).toContain('import { OriginalClass } from "./components/cmp-shadow";');
       expect(componentsDts).not.toContain('PublicShadow as OriginalClass');
     } finally {
+      process.chdir(originalCwd);
       await compiler.destroy();
     }
   });

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -572,6 +572,9 @@ interface TypeReferenceIR {
   type: ts.Type;
 }
 
+const resolveAliasedSymbol = (checker: ts.TypeChecker, symbol: ts.Symbol | undefined): ts.Symbol | undefined =>
+  symbol && (symbol.flags & ts.SymbolFlags.Alias) !== 0 ? checker.getAliasedSymbol(symbol) : symbol;
+
 /**
  * Recursively walks the provided AST to collect all TypeScript type references that are found
  *
@@ -606,6 +609,18 @@ export const getAllTypeReferences = (checker: ts.TypeChecker, node: ts.Node): Re
               });
             }
           });
+      }
+    } else if (ts.isTypeQueryNode(node) && ts.isIdentifier(node.exprName)) {
+      const referencedSymbol = resolveAliasedSymbol(checker, checker.getSymbolAtLocation(node.exprName));
+      const isEnumOrClass = referencedSymbol?.declarations?.some(
+        (declaration) => ts.isEnumDeclaration(declaration) || ts.isClassDeclaration(declaration),
+      );
+
+      if (isEnumOrClass) {
+        referencedTypes.push({
+          name: getEntityName(node.exprName),
+          type: checker.getTypeAtLocation(node.exprName),
+        });
       }
     }
     return ts.forEachChild(node, visit);
@@ -676,10 +691,23 @@ const getTypeReferenceLocation = (
       // For "import { XAxisOption as moo }", propertyName is "XAxisOption"
       const importedAs = importElement.propertyName ? importElement.propertyName.getText() : typeName;
 
-      const typeDecl = findTypeWithName(importHomeModule, originalTypeName);
-      type = checker.getTypeAtLocation(typeDecl);
+      const importedSymbol = resolveAliasedSymbol(checker, checker.getSymbolAtLocation(importName));
+      const declaration = importedSymbol?.valueDeclaration ?? importedSymbol?.declarations?.[0];
+      const enumOrClassDeclaration =
+        declaration && (ts.isClassDeclaration(declaration) || ts.isEnumDeclaration(declaration))
+          ? declaration
+          : undefined;
+      if (importedSymbol && enumOrClassDeclaration) {
+        type = checker.getTypeOfSymbolAtLocation(importedSymbol, enumOrClassDeclaration);
+      } else {
+        const typeDecl = findTypeWithName(importHomeModule, originalTypeName);
+        if (typeDecl) {
+          type = checker.getTypeAtLocation(typeDecl);
+        }
+      }
 
-      const id = addToLibrary(type, originalTypeName, checker, normalizePath(importHomeModule.fileName, false));
+      const typeSourceFile = enumOrClassDeclaration?.getSourceFile() ?? importHomeModule;
+      const id = addToLibrary(type, originalTypeName, checker, normalizePath(typeSourceFile.fileName, false));
       return {
         location: 'import',
         path: localImportPath,
@@ -690,36 +718,68 @@ const getTypeReferenceLocation = (
   }
 
   // Loop through all top level exports to find if any reference to the type for 'local' reference location
-  const isExported = sourceFile.statements.some((st) => {
-    const statementModifiers = retrieveTsModifiers(st);
+  const localExport = sourceFile.statements.reduce<{ isDefault?: boolean; referenceLocation?: string } | undefined>(
+    (exportInfo, st) => {
+      if (exportInfo) {
+        return exportInfo;
+      }
 
-    const isDeclarationExported = (statement: ts.InterfaceDeclaration | ts.TypeAliasDeclaration | ts.EnumDeclaration) =>
-      (<ts.Identifier>statement.name).getText() === typeName &&
-      Array.isArray(statementModifiers) &&
-      statementModifiers.some((mod) => mod.kind === ts.SyntaxKind.ExportKeyword);
+      if (
+        ts.isExportAssignment(st) &&
+        !st.isExportEquals &&
+        ts.isIdentifier(st.expression) &&
+        st.expression.getText() === typeName
+      ) {
+        return { isDefault: true };
+      }
 
-    // Is the interface defined in the file and exported
-    const isInterfaceDeclarationExported = ts.isInterfaceDeclaration(st) && isDeclarationExported(st);
+      if (ts.isExportDeclaration(st) && !st.moduleSpecifier && ts.isNamedExports(st.exportClause)) {
+        const exportSpecifier = st.exportClause.elements.find(
+          (element) => (element.propertyName ?? element.name).getText() === typeName,
+        );
+        if (exportSpecifier) {
+          const exportedName = exportSpecifier.name.getText();
+          return exportedName === 'default'
+            ? { isDefault: true }
+            : { referenceLocation: exportedName === typeName ? undefined : exportedName };
+        }
+      }
 
-    const isTypeAliasDeclarationExported = ts.isTypeAliasDeclaration(st) && isDeclarationExported(st);
+      const statementModifiers = retrieveTsModifiers(st);
 
-    const isEnumDeclarationExported = ts.isEnumDeclaration(st) && isDeclarationExported(st);
+      const isDeclarationExported = (
+        statement: ts.InterfaceDeclaration | ts.TypeAliasDeclaration | ts.EnumDeclaration | ts.ClassDeclaration,
+      ) =>
+        statement.name?.getText() === typeName &&
+        Array.isArray(statementModifiers) &&
+        statementModifiers.some((mod) => mod.kind === ts.SyntaxKind.ExportKeyword);
 
-    // Is the interface exported through a named export
-    const isTypeInExportDeclaration =
-      ts.isExportDeclaration(st) &&
-      ts.isNamedExports(st.exportClause) &&
-      st.exportClause.elements.some((nee) => nee.name.getText() === typeName);
+      // Is the interface defined in the file and exported
+      const isInterfaceDeclarationExported = ts.isInterfaceDeclaration(st) && isDeclarationExported(st);
 
-    return (
-      isInterfaceDeclarationExported ||
-      isTypeAliasDeclarationExported ||
-      isEnumDeclarationExported ||
-      isTypeInExportDeclaration
-    );
-  });
+      const isTypeAliasDeclarationExported = ts.isTypeAliasDeclaration(st) && isDeclarationExported(st);
 
-  if (isExported) {
+      const isEnumDeclarationExported = ts.isEnumDeclaration(st) && isDeclarationExported(st);
+
+      const isClassDeclarationExported = ts.isClassDeclaration(st) && isDeclarationExported(st);
+
+      const isExported =
+        isInterfaceDeclarationExported ||
+        isTypeAliasDeclarationExported ||
+        isEnumDeclarationExported ||
+        isClassDeclarationExported;
+
+      if (!isExported) {
+        return undefined;
+      }
+
+      const isDefault = statementModifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.DefaultKeyword);
+      return isDefault ? { isDefault: true } : {};
+    },
+    undefined,
+  );
+
+  if (localExport) {
     const id = addToLibrary(type, typeName, checker, sourceFile.fileName);
 
     return {
@@ -734,6 +794,8 @@ const getTypeReferenceLocation = (
       // will not be used for component event definitions
       path: sourceFile.fileName,
       id,
+      ...(localExport.isDefault ? { isDefault: true } : {}),
+      ...(localExport.referenceLocation ? { referenceLocation: localExport.referenceLocation } : {}),
     };
   }
 
@@ -749,33 +811,32 @@ const getTypeReferenceLocation = (
 
   if (defaultImportDeclaration) {
     const localImportPath = (<ts.StringLiteral>defaultImportDeclaration.moduleSpecifier).text;
-    const options = program.getCompilerOptions();
-    const compilerHost = ts.createCompilerHost(options);
-    const importHomeModule = getHomeModule(sourceFile, localImportPath, options, compilerHost, program);
+    const defaultImportName = defaultImportDeclaration.importClause.name;
+    const importedSymbol = resolveAliasedSymbol(checker, checker.getSymbolAtLocation(defaultImportName));
+    const declaration = importedSymbol?.valueDeclaration ?? importedSymbol?.declarations?.[0];
 
-    if (importHomeModule) {
-      // For default imports, the original type name is 'default' in the module's exports
-      // But we want to use the actual type name from the module
-      const defaultExport = importHomeModule.statements.find(
-        (st) =>
-          ts.isExportAssignment(st) &&
-          !st.isExportEquals &&
-          ts.isIdentifier(st.expression) &&
-          st.expression.getText() === typeName,
-      );
-
-      if (defaultExport) {
-        const typeDecl = findTypeWithName(importHomeModule, typeName);
-        type = checker.getTypeAtLocation(typeDecl);
-
-        const id = addToLibrary(type, typeName, checker, normalizePath(importHomeModule.fileName, false));
-        return {
-          location: 'import',
-          path: localImportPath,
-          id,
-          isDefault: true,
-        };
+    if (importedSymbol && declaration) {
+      if (ts.isClassDeclaration(declaration) || ts.isEnumDeclaration(declaration)) {
+        type = checker.getTypeOfSymbolAtLocation(importedSymbol, declaration);
       }
+      const declarationNodeName = (declaration as ts.NamedDeclaration).name;
+      const declarationName =
+        declarationNodeName && ts.isIdentifier(declarationNodeName)
+          ? declarationNodeName.getText()
+          : importedSymbol.getName();
+      const originalTypeName = declarationName === 'default' ? typeName : declarationName;
+      const id = addToLibrary(
+        type,
+        originalTypeName,
+        checker,
+        normalizePath(declaration.getSourceFile().fileName, false),
+      );
+      return {
+        location: 'import',
+        path: localImportPath,
+        id,
+        isDefault: true,
+      };
     }
   }
 

--- a/src/compiler/transformers/transform-utils.ts
+++ b/src/compiler/transformers/transform-utils.ts
@@ -572,7 +572,14 @@ interface TypeReferenceIR {
   type: ts.Type;
 }
 
-const resolveAliasedSymbol = (checker: ts.TypeChecker, symbol: ts.Symbol | undefined): ts.Symbol | undefined =>
+/**
+ * Resolve a TypeScript alias to its original symbol.
+ *
+ * @param checker a TypeScript type checker
+ * @param symbol the symbol to resolve, if one was found
+ * @returns the original symbol for an alias, the provided symbol otherwise, or `undefined`
+ */
+export const resolveAliasedSymbol = (checker: ts.TypeChecker, symbol: ts.Symbol | undefined): ts.Symbol | undefined =>
   symbol && (symbol.flags & ts.SymbolFlags.Alias) !== 0 ? checker.getAliasedSymbol(symbol) : symbol;
 
 /**
@@ -730,10 +737,12 @@ const getTypeReferenceLocation = (
         ts.isIdentifier(st.expression) &&
         st.expression.getText() === typeName
       ) {
+        // `export default TypeName`
         return { isDefault: true };
       }
 
       if (ts.isExportDeclaration(st) && !st.moduleSpecifier && ts.isNamedExports(st.exportClause)) {
+        // `export { TypeName }`, including renamed and default exports
         const exportSpecifier = st.exportClause.elements.find(
           (element) => (element.propertyName ?? element.name).getText() === typeName,
         );
@@ -773,6 +782,7 @@ const getTypeReferenceLocation = (
         return undefined;
       }
 
+      // Direct export declarations, with an optional default modifier
       const isDefault = statementModifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.DefaultKeyword);
       return isDefault ? { isDefault: true } : {};
     },

--- a/src/compiler/transformers/type-library.ts
+++ b/src/compiler/transformers/type-library.ts
@@ -3,7 +3,7 @@ import ts from 'typescript';
 
 import type * as d from '../../declarations';
 import { ValidatedConfig } from '../../declarations';
-import { typeToString } from './transform-utils';
+import { resolveAliasedSymbol, typeToString } from './transform-utils';
 
 /**
  * This is a {@link d.JsonDocsTypeLibrary} cache which is used to store a
@@ -231,22 +231,9 @@ export function getOriginalTypeName(identifier: ts.Node, checker: ts.TypeChecker
   if (!possiblyAliasedSymbol) {
     return undefined;
   }
-  const unaliasedSymbol = unalias(possiblyAliasedSymbol, checker);
+  const unaliasedSymbol = resolveAliasedSymbol(checker, possiblyAliasedSymbol);
   const name = unaliasedSymbol.getName();
   return name;
-}
-
-/**
- * Check if a symbol is an alias of another symbol and, if so, use the
- * {@link ts.TypeChecker} to resolve the original. If not, just return the same
- * symbol.
- *
- * @param symbol the symbol of interest
- * @param checker a {@link ts.TypeChecker}
- * @returns a de-aliased symbol
- */
-function unalias(symbol: ts.Symbol, checker: ts.TypeChecker): ts.Symbol {
-  return symbol.flags & ts.SymbolFlags.Alias ? checker.getAliasedSymbol(symbol) : symbol;
 }
 
 /**

--- a/src/compiler/types/generate-app-types.ts
+++ b/src/compiler/types/generate-app-types.ts
@@ -114,6 +114,7 @@ const generateComponentTypesFile = (
       importFilePath = normalizePath('./' + relative(config.srcDir, filePath)).replace(/\.(tsx|ts)$/, '');
     }
 
+    // A module may have multiple local aliases for its default export.
     const defaultImports = typeData.filter((td) => td.isDefault);
 
     if (defaultImports.length > 0) {
@@ -132,14 +133,17 @@ const generateComponentTypesFile = (
         })
         .join(`, `);
 
+      // Combine the first default alias with named imports when both are present.
       if (namedImports.length > 0) {
         imports.push(`import ${defaultImport.importName}, { ${namedPart} } from "${importFilePath}";`);
         exports.push(`export { default as ${defaultImport.importName}, ${namedPart} } from "${importFilePath}";`);
       } else {
+        // Emit the first default alias by itself when there are no named imports.
         imports.push(`import ${defaultImport.importName} from "${importFilePath}";`);
         exports.push(`export { default as ${defaultImport.importName} } from "${importFilePath}";`);
       }
 
+      // Each additional default alias needs its own import statement.
       additionalDefaultImports.forEach((td) => {
         imports.push(`import ${td.importName} from "${importFilePath}";`);
         exports.push(`export { default as ${td.importName} } from "${importFilePath}";`);

--- a/src/compiler/types/generate-app-types.ts
+++ b/src/compiler/types/generate-app-types.ts
@@ -114,17 +114,10 @@ const generateComponentTypesFile = (
       importFilePath = normalizePath('./' + relative(config.srcDir, filePath)).replace(/\.(tsx|ts)$/, '');
     }
 
-    // Check if this file has any default imports
-    const hasDefaultImport = typeData.some((td) => td.isDefault);
+    const defaultImports = typeData.filter((td) => td.isDefault);
 
-    if (hasDefaultImport && typeData.length === 1) {
-      // Pure default import
-      const td = typeData[0];
-      imports.push(`import ${td.importName} from "${importFilePath}";`);
-      exports.push(`export { default as ${td.importName} } from "${importFilePath}";`);
-    } else if (hasDefaultImport) {
-      // Mixed default and named imports
-      const defaultImport = typeData.find((td) => td.isDefault);
+    if (defaultImports.length > 0) {
+      const [defaultImport, ...additionalDefaultImports] = defaultImports;
       const namedImports = typeData.filter((td) => !td.isDefault);
       const namedPart = namedImports
         .sort(sortImportNames)
@@ -138,8 +131,19 @@ const generateComponentTypesFile = (
           }
         })
         .join(`, `);
-      imports.push(`import ${defaultImport.importName}, { ${namedPart} } from "${importFilePath}";`);
-      exports.push(`export { default as ${defaultImport.importName}, ${namedPart} } from "${importFilePath}";`);
+
+      if (namedImports.length > 0) {
+        imports.push(`import ${defaultImport.importName}, { ${namedPart} } from "${importFilePath}";`);
+        exports.push(`export { default as ${defaultImport.importName}, ${namedPart} } from "${importFilePath}";`);
+      } else {
+        imports.push(`import ${defaultImport.importName} from "${importFilePath}";`);
+        exports.push(`export { default as ${defaultImport.importName} } from "${importFilePath}";`);
+      }
+
+      additionalDefaultImports.forEach((td) => {
+        imports.push(`import ${td.importName} from "${importFilePath}";`);
+        exports.push(`export { default as ${td.importName} } from "${importFilePath}";`);
+      });
     } else {
       // Named imports only
       const namedPart = typeData


### PR DESCRIPTION
## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Class and enum names used in identifier-based `keyof typeof` prop types are not collected as type references. As a result, generated `components.d.ts` files can omit required imports. Aliases and re-exports can also produce incorrect imports or colliding docs type-library IDs.

GitHub Issue Number: Fixes #2482


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The compiler now collects identifier-based `TypeQueryNode` references when they resolve to classes or enums. It preserves local, named, default, and re-exported aliases in generated component declarations, supports multiple local names for the same default export, and derives docs type-library IDs from the resolved declaration source.



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

N/A. This is a compiler fix covered by regression tests.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

- `npm run test.jest -- src/compiler/transformers/test/parse-props.spec.ts --runInBand` (48 tests)
- `npm run test.jest -- src/compiler/transformers/test --runInBand` (356 tests)
- `npm run test.jest -- src/compiler/types/tests/generate-app-types.spec.ts --runInBand` (16 tests, 16 snapshots)
- `npm run tsc.prod`
- `npm run lint`
- `npm run prettier.dry-run`
- `npm run build`

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

Qualified namespace expressions are outside this change's scope; this addresses identifier-based enum and class queries such as the one reported in #2482.
