### PR TITLE
fix(runtime): guard against null parent in insertBefore

### DIFF
--- a/src/runtime/vdom/test/vdom-render.spec.tsx
+++ b/src/runtime/vdom/test/vdom-render.spec.tsx
@@ -1,5 +1,5 @@
 import { h, newVNode } from '../h';
-import { isSameVnode, patch } from '../vdom-render';
+import { insertBefore, isSameVnode, patch } from '../vdom-render';
 
 describe('template elements', () => {
   it('should append children to template.content, not template directly', () => {
@@ -105,5 +105,31 @@ describe('isSameVnode', () => {
     expect(isSameVnode(vnode1, vnode2)).toBe(false);
     expect(isSameVnode(vnode1, vnode2, true)).toBe(true);
     expect(vnode1.$key$).toBe('1');
+  });
+});
+
+describe('insertBefore', () => {
+  it('should not throw when the parent node is null', () => {
+    // Regression test for #6822: on iOS Safari, Reader/translation features can
+    // detach a slotted light-DOM node mid-render, leaving its `parentNode` null.
+    // The `__insertBefore` branch dereferenced `parent` without a guard, unlike
+    // the fallback branch, so a null parent threw
+    // "Cannot read properties of null (reading '__insertBefore')".
+    const newNode = document.createElement('div') as any;
+
+    expect(() => insertBefore(null as any, newNode)).not.toThrow();
+    expect(insertBefore(null as any, newNode)).toBeUndefined();
+  });
+
+  it('should still insert normally when the parent node is valid', () => {
+    const parent = document.createElement('div');
+    const reference = document.createElement('span');
+    parent.appendChild(reference);
+    const newNode = document.createElement('p') as any;
+
+    insertBefore(parent, newNode, reference as any);
+
+    expect(parent.childNodes[0]).toBe(newNode);
+    expect(parent.childNodes[1]).toBe(reference);
   });
 });

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -971,7 +971,7 @@ export const insertBefore = (
     }
   }
 
-  if ((parent as d.RenderNode)?.__insertBefore) {
+  if (BUILD.slotRelocation && (parent as d.RenderNode)?.__insertBefore) {
     return (parent as d.RenderNode).__insertBefore(newNode, reference) as d.RenderNode;
   } else {
     return parent?.insertBefore(newNode, reference) as d.RenderNode;

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -971,7 +971,7 @@ export const insertBefore = (
     }
   }
 
-  if ((parent as d.RenderNode).__insertBefore) {
+  if ((parent as d.RenderNode)?.__insertBefore) {
     return (parent as d.RenderNode).__insertBefore(newNode, reference) as d.RenderNode;
   } else {
     return parent?.insertBefore(newNode, reference) as d.RenderNode;


### PR DESCRIPTION
The `insertBefore` helper dereferenced `parent.__insertBefore` without a null check, while the fallback branch directly below already guarded the parent with `parent?.insertBefore`. When a slotted light-DOM node is detached mid-render e.g. iOS Safari's Reader/translation features mutate slotted nodes during re-renders, setting `parentNode` to null the unguarded branch threw "Cannot read properties of null (reading '__insertBefore')", crashing the render.

Add optional chaining to the `__insertBefore` branch so a null parent falls through to the already-guarded fallback, matching the existing pattern in the same function.

Fixes #6822

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6822

In `src/runtime/vdom/vdom-render.ts`, the `insertBefore` helper ends with two branches:

```ts
if ((parent as d.RenderNode).__insertBefore) {
  return (parent as d.RenderNode).__insertBefore(newNode, reference);
} else {
  return parent?.insertBefore(newNode, reference);
}