### PR TITLE
feat(runtime): support the clonable shadow root option

### DIFF
--- a/cspell-wordlist.txt
+++ b/cspell-wordlist.txt
@@ -151,6 +151,8 @@ yourpackage
 fdir
 shadowrootmode
 shadowrootdelegatesfocus
+shadowrootclonable
+clonable
 jsxmode
 jsxdev
 jsxs

--- a/src/app-data/index.ts
+++ b/src/app-data/index.ts
@@ -94,6 +94,7 @@ export const BUILD: BuildConditionals = {
   devTools: false,
   shadowDelegatesFocus: true,
   shadowSlotAssignmentManual: false,
+  shadowClonable: true,
   initializeNextTick: false,
   asyncLoading: true,
   asyncQueue: false,

--- a/src/compiler/app-core/app-data.ts
+++ b/src/compiler/app-core/app-data.ts
@@ -53,6 +53,7 @@ export const getBuildFeatures = (cmps: ComponentCompilerMeta[]): BuildFeatures =
     shadowDom,
     shadowDelegatesFocus: shadowDom && cmps.some((c) => c.shadowDelegatesFocus),
     shadowSlotAssignmentManual: shadowDom && cmps.some((c) => c.slotAssignment === 'manual'),
+    shadowClonable: shadowDom && cmps.some((c) => c.shadowClonable),
     slot,
     slotRelocation,
     state: cmps.some((c) => c.hasState),

--- a/src/compiler/transformers/decorators-to-static/component-decorator.ts
+++ b/src/compiler/transformers/decorators-to-static/component-decorator.ts
@@ -56,6 +56,9 @@ export const componentDecoratorToStatic = (
       if (componentOptions.shadow.slotAssignment === 'manual') {
         newMembers.push(createStaticGetter('slotAssignment', convertValueToLiteral('manual')));
       }
+      if (componentOptions.shadow.clonable === true) {
+        newMembers.push(createStaticGetter('clonable', convertValueToLiteral(true)));
+      }
     }
   } else if (componentOptions.scoped) {
     newMembers.push(createStaticGetter('encapsulation', convertValueToLiteral('scoped')));

--- a/src/compiler/transformers/decorators-to-static/decorators-constants.ts
+++ b/src/compiler/transformers/decorators-to-static/decorators-constants.ts
@@ -49,6 +49,7 @@ export const STATIC_GETTER_NAMES = [
   'assetsDirs',
   'attachInternalsCustomStates',
   'attachInternalsMemberName',
+  'clonable',
   'cmpMeta',
   'delegatesFocus',
   'elementRef',

--- a/src/compiler/transformers/static-to-meta/component.ts
+++ b/src/compiler/transformers/static-to-meta/component.ts
@@ -11,7 +11,7 @@ import { parseAttachInternals, parseAttachInternalsCustomStates } from './attach
 import { parseCallExpression } from './call-expression';
 import { parseClassMethods } from './class-methods';
 import { parseStaticElementRef } from './element-ref';
-import { parseStaticEncapsulation, parseStaticShadowDelegatesFocus, parseStaticSlotAssignment } from './encapsulation';
+import { parseStaticEncapsulation, parseStaticShadowClonable, parseStaticShadowDelegatesFocus, parseStaticSlotAssignment } from './encapsulation';
 import { parseFormAssociated } from './form-associated';
 import { parseStringLiteral } from './string-literal';
 import { parseStaticStyles } from './styles';
@@ -92,6 +92,7 @@ export const parseStaticComponentMeta = (
     elementRef: parseStaticElementRef(staticMembers),
     encapsulation,
     shadowDelegatesFocus: !!parseStaticShadowDelegatesFocus(encapsulation, staticMembers),
+    shadowClonable: !!parseStaticShadowClonable(encapsulation, staticMembers),
     slotAssignment: parseStaticSlotAssignment(encapsulation, staticMembers),
     properties,
     virtualProperties: parseVirtualProps(docs),

--- a/src/compiler/transformers/static-to-meta/encapsulation.ts
+++ b/src/compiler/transformers/static-to-meta/encapsulation.ts
@@ -48,6 +48,24 @@ export const parseStaticShadowDelegatesFocus = (
 };
 
 /**
+ * Find and return if `clonable` is enabled for a component based on the return value of its static getter of the
+ * same name.
+ *
+ * @param encapsulation the encapsulation mode to use for a component
+ * @param staticMembers a collection of static getters to search
+ * @returns when `encapsulation` is 'shadow', return `true` if the static getter returns true. If the static getter
+ * returns `false` or does not exist, return `false`. If `encapsulation` is not 'shadow', return `null`, regardless of
+ * the static getter's existence/return value.
+ */
+export const parseStaticShadowClonable = (encapsulation: string, staticMembers: ts.ClassElement[]): boolean | null => {
+  if (encapsulation === 'shadow') {
+    const clonable: boolean = getStaticValue(staticMembers, 'clonable');
+    return !!clonable;
+  }
+  return null;
+};
+
+/**
  * Find and return the `slotAssignment` mode for a component.
  *
  * @param encapsulation the encapsulation mode to use for a component

--- a/src/compiler/transformers/test/parse-clonable.spec.ts
+++ b/src/compiler/transformers/test/parse-clonable.spec.ts
@@ -1,0 +1,107 @@
+import { getStaticGetter, transpileModule } from './transpile';
+
+describe('parse clonable', () => {
+  it('shadow without clonable', () => {
+    const t = transpileModule(`
+      @Component({
+        tag: 'cmp-a',
+        shadow: true
+      })
+      export class CmpA {}
+    `);
+
+    expect(getStaticGetter(t.outputText, 'encapsulation')).toEqual('shadow');
+    expect(getStaticGetter(t.outputText, 'clonable')).toEqual(undefined);
+
+    expect(t.cmp.encapsulation).toBe('shadow');
+    expect(t.cmp.shadowClonable).toBe(false);
+  });
+
+  it('clonable true', () => {
+    const t = transpileModule(`
+      @Component({
+        tag: 'cmp-a',
+        shadow: {
+          clonable: true
+        }
+      })
+      export class CmpA {}
+    `);
+
+    expect(getStaticGetter(t.outputText, 'encapsulation')).toEqual('shadow');
+    expect(getStaticGetter(t.outputText, 'clonable')).toEqual(true);
+
+    expect(t.cmp.encapsulation).toBe('shadow');
+    expect(t.cmp.shadowClonable).toBe(true);
+  });
+
+  it('clonable false (explicit)', () => {
+    const t = transpileModule(`
+      @Component({
+        tag: 'cmp-a',
+        shadow: {
+          clonable: false
+        }
+      })
+      export class CmpA {}
+    `);
+
+    expect(getStaticGetter(t.outputText, 'encapsulation')).toEqual('shadow');
+    expect(getStaticGetter(t.outputText, 'clonable')).toEqual(undefined);
+
+    expect(t.cmp.encapsulation).toBe('shadow');
+    expect(t.cmp.shadowClonable).toBe(false);
+  });
+
+  it('clonable true alongside delegatesFocus', () => {
+    const t = transpileModule(`
+      @Component({
+        tag: 'cmp-a',
+        shadow: {
+          delegatesFocus: true,
+          clonable: true
+        }
+      })
+      export class CmpA {}
+    `);
+
+    expect(getStaticGetter(t.outputText, 'encapsulation')).toEqual('shadow');
+    expect(getStaticGetter(t.outputText, 'delegatesFocus')).toEqual(true);
+    expect(getStaticGetter(t.outputText, 'clonable')).toEqual(true);
+
+    expect(t.cmp.encapsulation).toBe('shadow');
+    expect(t.cmp.shadowDelegatesFocus).toBe(true);
+    expect(t.cmp.shadowClonable).toBe(true);
+  });
+
+  it('scoped does not support clonable', () => {
+    const t = transpileModule(`
+      @Component({
+        tag: 'cmp-a',
+        scoped: true
+      })
+      export class CmpA {}
+    `);
+
+    expect(getStaticGetter(t.outputText, 'encapsulation')).toEqual('scoped');
+    expect(getStaticGetter(t.outputText, 'clonable')).toEqual(undefined);
+
+    expect(t.cmp.encapsulation).toBe('scoped');
+    expect(t.cmp.shadowClonable).toBe(false);
+  });
+
+  it('no encapsulation does not support clonable', () => {
+    const t = transpileModule(`
+      @Component({
+        tag: 'cmp-a'
+      })
+      export class CmpA {}
+    `);
+
+    expect(t.outputText).not.toContain(`static get encapsulation()`);
+    expect(getStaticGetter(t.outputText, 'clonable')).toEqual(undefined);
+
+    expect(t.cmp.encapsulation).toBe('none');
+    expect(t.cmp.shadowClonable).toBe(false);
+  });
+});

--- a/src/compiler/types/tests/ComponentCompilerMeta.stub.ts
+++ b/src/compiler/types/tests/ComponentCompilerMeta.stub.ts
@@ -89,6 +89,7 @@ export const stubComponentCompilerMeta = (
   properties: [],
   serializers: [],
   shadowDelegatesFocus: false,
+  shadowClonable: false,
   slotAssignment: null,
   sourceFilePath: '/some/stubbed/path/my-component.tsx',
   sourceMapPath: '/some/stubbed/path/my-component.js.map',

--- a/src/declarations/stencil-private.ts
+++ b/src/declarations/stencil-private.ts
@@ -95,6 +95,7 @@ export interface BuildFeatures {
   shadowDom: boolean;
   shadowDelegatesFocus: boolean;
   shadowSlotAssignmentManual: boolean;
+  shadowClonable: boolean;
   scoped: boolean;
 
   // render
@@ -675,6 +676,11 @@ export interface ComponentCompilerMeta extends ComponentCompilerFeatures {
   properties: ComponentCompilerProperty[];
   serializers: ComponentCompilerChangeHandler[];
   shadowDelegatesFocus: boolean;
+  /**
+   * Whether the shadow root is cloneable. Enabled via `shadow: { clonable: true }`.
+   * Only applicable when encapsulation is 'shadow'.
+   */
+  shadowClonable: boolean;
   /**
    * Slot assignment mode for shadow DOM. 'manual', enables imperative slotting
    * using HTMLSlotElement.assign(). Only applicable when encapsulation is 'shadow'.

--- a/src/declarations/stencil-public-runtime.ts
+++ b/src/declarations/stencil-public-runtime.ts
@@ -81,6 +81,13 @@ export interface ShadowRootOptions {
    * declarative slotting behavior.
    */
   slotAssignment?: 'manual' | 'named';
+  /**
+   * When set to `true`, the shadow root is set to be cloneable. This allows the shadow root and its
+   * contents to be preserved when the host element is deep-cloned (e.g. via `Node.cloneNode(true)`),
+   * which some libraries rely on when cloning DOM subtrees that contain shadow components. Defaults
+   * to `false`. Browsers that do not implement the `clonable` shadow root option ignore it.
+   */
+  clonable?: boolean;
 }
 
 export interface ModeStyles {

--- a/src/mock-doc/node.ts
+++ b/src/mock-doc/node.ts
@@ -277,6 +277,9 @@ export class MockElement extends MockNode {
   attachShadow(_opts: ShadowRootInit) {
     const shadowRoot = this.ownerDocument.createDocumentFragment();
     shadowRoot.delegatesFocus = _opts.delegatesFocus ?? false;
+    // `clonable` is a valid `attachShadow` option per the DOM spec, but is not yet present on the
+    // `ShadowRootInit` lib type, so widen the type locally to read it.
+    shadowRoot.clonable = (_opts as ShadowRootInit & { clonable?: boolean }).clonable ?? false;
     this.shadowRoot = shadowRoot;
     return shadowRoot;
   }

--- a/src/mock-doc/serialize-node.ts
+++ b/src/mock-doc/serialize-node.ts
@@ -148,6 +148,12 @@ function* streamToHtml(
           yield delegatesFocusAttr;
           output.currentLineWidth += delegatesFocusAttr.length;
         }
+
+        if ((node as any).clonable) {
+          const clonableAttr = ' shadowrootclonable';
+          yield clonableAttr;
+          output.currentLineWidth += clonableAttr.length;
+        }
       }
 
       const attrsLength = (node as HTMLElement).attributes.length;
@@ -164,12 +170,14 @@ function* streamToHtml(
           continue;
         }
 
-        // Skip shadowrootmode and shadowrootdelegatesfocus attributes when they've already been
-        // added from the shadow root's properties (to avoid duplication)
+        // Skip shadowrootmode, shadowrootdelegatesfocus, and shadowrootclonable attributes when
+        // they've already been added from the shadow root's properties (to avoid duplication)
         if (
           tag === 'template' &&
           isShadowRoot &&
-          (attrName === 'shadowrootmode' || attrName === 'shadowrootdelegatesfocus')
+          (attrName === 'shadowrootmode' ||
+            attrName === 'shadowrootdelegatesfocus' ||
+            attrName === 'shadowrootclonable')
         ) {
           continue;
         }
@@ -221,8 +229,9 @@ function* streamToHtml(
         }
 
         if (attrValue === '') {
-          // shadowrootdelegatesfocus should always be rendered as a boolean attribute (no value)
-          if (attrName === 'shadowrootdelegatesfocus') {
+          // shadowrootdelegatesfocus and shadowrootclonable should always be rendered as boolean
+          // attributes (no value)
+          if (attrName === 'shadowrootdelegatesfocus' || attrName === 'shadowrootclonable') {
             continue;
           }
           if (opts.removeBooleanAttributeQuotes && BOOLEAN_ATTR.has(attrName)) {
@@ -659,6 +668,7 @@ function getChildNodes(node: Node | MockNode) {
   'scoped',
   'seamless',
   'selected',
+  'shadowrootclonable',
   'shadowrootdelegatesfocus',
   'sortable',
   'truespeed',

--- a/src/mock-doc/test/serialize-node.spec.ts
+++ b/src/mock-doc/test/serialize-node.spec.ts
@@ -185,6 +185,48 @@ describe('serializeNodeToHtml', () => {
     `);
   });
 
+  it('shadow root to template with clonable', () => {
+    const elm = doc.createElement('cmp-a');
+    expect(elm.shadowRoot).toEqual(null);
+
+    const shadowRoot = elm.attachShadow({ mode: 'open', clonable: true } as ShadowRootInit & { clonable?: boolean });
+    expect(shadowRoot.nodeType).toEqual(11);
+    expect(elm.shadowRoot.nodeType).toEqual(11);
+
+    expect(shadowRoot.host).toEqual(elm);
+    expect(elm.outerHTML).toContain('<template shadowrootmode="open" shadowrootclonable');
+  });
+
+  it('shadow root with clonable matches toEqualHtml', () => {
+    const elm = doc.createElement('my-tag');
+    const shadowRoot = elm.attachShadow({ mode: 'open', clonable: true } as ShadowRootInit & { clonable?: boolean });
+
+    const div = doc.createElement('div');
+    div.innerHTML = 'test content';
+    shadowRoot.appendChild(div);
+
+    // Test that the serialized output matches the expected format
+    // This ensures shadowrootclonable appears without ="" when compared
+    expect(elm).toEqualHtml(`
+      <my-tag>
+        <mock:shadow-root shadowrootclonable>
+          <div>test content</div>
+        </mock:shadow-root>
+      </my-tag>
+    `);
+  });
+
+  it('shadow root serializes both delegatesFocus and clonable', () => {
+    const elm = doc.createElement('cmp-a');
+    elm.attachShadow({ mode: 'open', delegatesFocus: true, clonable: true } as ShadowRootInit & {
+      clonable?: boolean;
+    });
+
+    expect(elm.outerHTML).toContain(
+      '<template shadowrootmode="open" shadowrootdelegatesfocus shadowrootclonable',
+    );
+  });
+
   it('style', () => {
     const input = `<style>     \n    text   \n\n</style>`;
     doc.body.innerHTML = input;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -145,6 +145,12 @@ export const enum CMP_FLAGS {
    * e.g. `shadow: { slotAssignment: 'manual' }` is set on the `@Component()` decorator
    */
   shadowSlotAssignmentManual = 1 << 10,
+
+  /**
+   * Determines if `clonable` is enabled for a component that uses the shadow DOM.
+   * e.g. `shadow: { clonable: true }` is set on the `@Component()` decorator
+   */
+  shadowClonable = 1 << 11,
 }
 
 /**

--- a/src/utils/format-component-runtime-meta.ts
+++ b/src/utils/format-component-runtime-meta.ts
@@ -29,6 +29,9 @@ export const formatComponentRuntimeMeta = (
     if (compilerMeta.slotAssignment === 'manual') {
       flags |= CMP_FLAGS.shadowSlotAssignmentManual;
     }
+    if (compilerMeta.shadowClonable) {
+      flags |= CMP_FLAGS.shadowClonable;
+    }
   } else if (compilerMeta.encapsulation === 'scoped') {
     flags |= CMP_FLAGS.scopedCssEncapsulation;
   }

--- a/src/utils/shadow-root.ts
+++ b/src/utils/shadow-root.ts
@@ -13,7 +13,9 @@ let globalStyleSheet: CSSStyleSheet | null | undefined;
 const GLOBAL_STYLE_ID = 'sc-global';
 
 export function createShadowRoot(this: HTMLElement, cmpMeta: d.ComponentRuntimeMeta) {
-  const opts: ShadowRootInit = { mode: 'open' };
+  // `clonable` is a valid `attachShadow` option per the DOM spec, but is not yet present on the
+  // `ShadowRootInit` lib type, so widen the type locally to allow setting it.
+  const opts: ShadowRootInit & { clonable?: boolean } = { mode: 'open' };
 
   if (BUILD.shadowDelegatesFocus) {
     opts.delegatesFocus = !!(cmpMeta.$flags$ & CMP_FLAGS.shadowDelegatesFocus);
@@ -24,6 +26,10 @@ export function createShadowRoot(this: HTMLElement, cmpMeta: d.ComponentRuntimeM
     if (isManual) {
       opts.slotAssignment = 'manual';
     }
+  }
+
+  if (BUILD.shadowClonable) {
+    opts.clonable = !!(cmpMeta.$flags$ & CMP_FLAGS.shadowClonable);
   }
 
   const shadowRoot = this.attachShadow(opts);

--- a/src/utils/test/format-component-runtime-meta.spec.ts
+++ b/src/utils/test/format-component-runtime-meta.spec.ts
@@ -1,0 +1,39 @@
+import { stubComponentCompilerMeta } from '../../compiler/types/tests/ComponentCompilerMeta.stub';
+import { CMP_FLAGS } from '../constants';
+import { formatComponentRuntimeMeta } from '../format-component-runtime-meta';
+
+describe('formatComponentRuntimeMeta', () => {
+  it('sets the shadowClonable flag when clonable is enabled on a shadow component', () => {
+    const compilerMeta = stubComponentCompilerMeta({
+      encapsulation: 'shadow',
+      shadowClonable: true,
+    });
+
+    const [flags] = formatComponentRuntimeMeta(compilerMeta, false) as [number, ...unknown[]];
+
+    expect(flags & CMP_FLAGS.shadowDomEncapsulation).toBeTruthy();
+    expect(flags & CMP_FLAGS.shadowClonable).toBeTruthy();
+  });
+
+  it('does not set the shadowClonable flag when clonable is disabled', () => {
+    const compilerMeta = stubComponentCompilerMeta({
+      encapsulation: 'shadow',
+      shadowClonable: false,
+    });
+
+    const [flags] = formatComponentRuntimeMeta(compilerMeta, false) as [number, ...unknown[]];
+
+    expect(flags & CMP_FLAGS.shadowClonable).toBeFalsy();
+  });
+
+  it('does not set the shadowClonable flag for non-shadow components', () => {
+    const compilerMeta = stubComponentCompilerMeta({
+      encapsulation: 'scoped',
+      shadowClonable: true,
+    });
+
+    const [flags] = formatComponentRuntimeMeta(compilerMeta, false) as [number, ...unknown[]];
+
+    expect(flags & CMP_FLAGS.shadowClonable).toBeFalsy();
+  });
+});

--- a/src/utils/test/shadow-root.spec.ts
+++ b/src/utils/test/shadow-root.spec.ts
@@ -1,0 +1,28 @@
+import type * as d from '../../declarations';
+import { CMP_FLAGS } from '../constants';
+import { createShadowRoot } from '../shadow-root';
+
+describe('createShadowRoot', () => {
+  const callCreateShadowRoot = (flags: number) => {
+    const host = document.createElement('div');
+    const opts: ShadowRootInit[] = [];
+    host.attachShadow = ((init: ShadowRootInit) => {
+      opts.push(init);
+      // jsdom's attachShadow does not accept the extra options we pass, so stub it
+      return document.createElement('div') as unknown as ShadowRoot;
+    }) as HTMLElement['attachShadow'];
+
+    createShadowRoot.call(host, { $flags$: flags } as d.ComponentRuntimeMeta);
+    return opts[0] as ShadowRootInit & { clonable?: boolean };
+  };
+
+  it('passes clonable: true to attachShadow when the shadowClonable flag is set', () => {
+    const opts = callCreateShadowRoot(CMP_FLAGS.shadowDomEncapsulation | CMP_FLAGS.shadowClonable);
+    expect(opts.clonable).toBe(true);
+  });
+
+  it('passes clonable: false to attachShadow when the shadowClonable flag is not set', () => {
+    const opts = callCreateShadowRoot(CMP_FLAGS.shadowDomEncapsulation);
+    expect(opts.clonable).toBe(false);
+  });
+});


### PR DESCRIPTION
Expose the native `clonable` shadow root option so it can be set via the `@Component()` decorator, e.g. `shadow: { clonable: true }`. When enabled, the component's shadow root is attached with `{ clonable: true }`, allowing the shadow root and its contents to be preserved when the host element is deep-cloned (`Node.cloneNode(true)`). Libraries such as AG Grid rely on this when cloning DOM subtrees that contain shadow components; without it the clone is an empty shell.

This follows the existing `delegatesFocus` / `slotAssignment` pipeline end to end:

- add `clonable` to the public `ShadowRootOptions` type
- add the `shadowClonable` flag to `CMP_FLAGS` (1 << 11)
- emit a `clonable` static getter from the decorator, parse it onto component compiler meta (`shadowClonable`), pack it into the runtime flags in `formatComponentRuntimeMeta`, and add the `shadowClonable` build conditional
- set `opts.clonable` in `createShadowRoot` behind the `BUILD.shadowClonable` build flag

Carry `clonable` through the mock-doc / declarative shadow DOM path so the option is not lost across SSR + hydrate, where the shadow root is reused rather than re-attached: `attachShadow` records `clonable` on the mock shadow root and serialization emits the `shadowrootclonable` boolean attribute, mirroring `shadowrootdelegatesfocus`.

`ShadowRootInit` in the current TypeScript DOM lib does not yet include `clonable`, so the option type is widened locally where it is read. Add `clonable` and `shadowrootclonable` to the cspell wordlist.

Tests:
- parse `shadow: { clonable: true }` into component meta, incl. scoped / no encapsulation / alongside delegatesFocus (parse-clonable.spec)
- pack the `shadowClonable` flag into runtime meta (format-component-runtime-meta.spec)
- `createShadowRoot` passes `{ clonable: true }` to `attachShadow` (shadow-root.spec)
- DSD serialization emits `shadowrootclonable`, incl. a toEqualHtml round-trip and a combined delegatesFocus + clonable case (serialize-node.spec)

Fixes #6833

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6833

Stencil has no way to enable the native `clonable` option on a component's shadow root. `shadow` accepts `delegatesFocus` and `slotAssignment`, but not `clonable`, so `createShadowRoot` always calls `attachShadow` without it. As a result, when a host element containing a Stencil shadow component is deep-cloned (`Node.cloneNode(true)`), the shadow root is not preserved and the clone is an empty shell. Libraries such as AG Grid that deep-clone DOM subtrees cannot clone Stencil shadow components. There is no per-component opt-in and no way to carry the option through SSR/hydrate.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

`clonable` can now be set on the shadow options object:

```tsx
@Component({
  tag: 'my-cmp',
  shadow: { clonable: true },
})
export class MyCmp {}