### PR TITLE
fix(runtime): reflected boolean attributes

### DIFF
--- a/src/runtime/test/attr.spec.tsx
+++ b/src/runtime/test/attr.spec.tsx
@@ -363,6 +363,26 @@ describe('attribute', () => {
       `);
     });
 
+    it('should remove a reflected boolean attribute when set to false, even if pre-existing markup wrote it as a literal string', async () => {
+      // https://github.com/stenciljs/core/issues/6828
+      @Component({ tag: 'cmp-reflect-bool-literal' })
+      class CmpReflectBoolLiteral {
+        @Prop({ reflect: true, mutable: true }) flag = false;
+      }
+
+      const { root, waitForChanges } = await newSpecPage({
+        components: [CmpReflectBoolLiteral],
+        html: `<cmp-reflect-bool-literal flag="true"></cmp-reflect-bool-literal>`,
+      });
+
+      expect(root.flag).toBe(true);
+
+      root.flag = false;
+      await waitForChanges();
+
+      expect(root.hasAttribute('flag')).toBe(false);
+    });
+
     it('should reflect properties as attributes with strict build', async () => {
       @Component({ tag: 'cmp-a', shadow: true })
       class CmpA {

--- a/src/runtime/vdom/set-accessor.ts
+++ b/src/runtime/vdom/set-accessor.ts
@@ -225,7 +225,11 @@ export const setAccessor = (
       }
     }
     if (newValue == null || newValue === false) {
-      if (newValue !== false || elm.getAttribute(memberName) === '') {
+      if (
+        newValue !== false ||
+        elm.getAttribute(memberName) === '' ||
+        (flags & VNODE_FLAGS.isHost && !isEnumeratedAttribute(memberName))
+      ) {
         if (BUILD.vdomXlink && xlink) {
           elm.removeAttributeNS(XLINK_NS, memberName);
         } else {
@@ -246,6 +250,17 @@ export const setAccessor = (
     }
   }
 };
+
+/**
+ * Attribute names that are enumerated (tri-state true/false/unset) rather than
+ * plain boolean-presence attributes. An explicit `"false"` string on one of
+ * these is semantically different from the attribute being absent, so a
+ * reflected `false` value must not clear a pre-existing literal value.
+ */
+const ENUMERATED_ATTRIBUTES = /*@__PURE__*/ new Set(['draggable', 'contenteditable', 'spellcheck']);
+
+const isEnumeratedAttribute = (attrName: string): boolean =>
+  ENUMERATED_ATTRIBUTES.has(attrName) || attrName.startsWith('aria-');
 
 const parseClassListRegex = /\s/;
 /**

--- a/src/runtime/vdom/test/set-accessor.spec.ts
+++ b/src/runtime/vdom/test/set-accessor.spec.ts
@@ -1,5 +1,6 @@
 import { BUILD } from '@app-data';
 
+import { VNODE_FLAGS } from '../../runtime-constants';
 import { parseClassList, setAccessor } from '../set-accessor';
 
 describe('setAccessor for custom elements', () => {
@@ -268,6 +269,56 @@ describe('setAccessor for custom elements', () => {
     expect(elm.myprop).toBeUndefined();
 
     expect(elm).toEqualAttributes({});
+  });
+
+  it('should remove a reflected boolean attribute even if it holds a stale literal string', () => {
+    // e.g. static/SSR markup wrote `flag="true"` before the component upgraded;
+    // `flags` carries VNODE_FLAGS.isHost because this is how `@Prop({ reflect: true })`
+    // values are written back onto the host element
+    elm.setAttribute('flag', 'true');
+
+    setAccessor(elm, 'flag', true, false, false, VNODE_FLAGS.isHost);
+
+    expect(elm.hasAttribute('flag')).toBe(false);
+  });
+
+  it('should still remove a reflected boolean attribute that holds the canonical empty string', () => {
+    elm.setAttribute('flag', '');
+
+    setAccessor(elm, 'flag', true, false, false, VNODE_FLAGS.isHost);
+
+    expect(elm.hasAttribute('flag')).toBe(false);
+  });
+
+  it('should never remove enumerated attributes outright when reflected as false', () => {
+    // enumerated (tri-state) attributes must stay present - `draggable` is a native
+    // IDL property, so its value gets updated to "false" via the property setter
+    // (still present, not removed); the others aren't touched at all here and so
+    // keep their original literal value
+    for (const [attrName, expectedValue] of [
+      ['draggable', 'false'],
+      ['contenteditable', 'true'],
+      ['spellcheck', 'true'],
+      ['aria-hidden', 'true'],
+    ]) {
+      const enumElm = document.createElement('my-tag');
+      enumElm.setAttribute(attrName, 'true');
+
+      setAccessor(enumElm, attrName, true, false, false, VNODE_FLAGS.isHost);
+
+      expect(enumElm.hasAttribute(attrName)).toBe(true);
+      expect(enumElm.getAttribute(attrName)).toBe(expectedValue);
+    }
+  });
+
+  it('should preserve a stale literal "true" for non-host (non-reflected) writes, matching prior behavior', () => {
+    // no VNODE_FLAGS.isHost set here - e.g. an author writing `<div flag={false}>`
+    // by hand in JSX on some element that isn't the component's own host
+    elm.setAttribute('flag', 'true');
+
+    setAccessor(elm, 'flag', true, false, false, 0);
+
+    expect(elm.getAttribute('flag')).toBe('true');
   });
 
   it('should add aria role attribute', () => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: https://github.com/stenciljs/core/issues/6828

Reflected boolean attributes' stale value never removed

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

New optional test in attr removal gate - "if host *and* not an official enumerated attribute ('draggable', 'contenteditable', 'spellcheck', 'attr-*')"

Fixes https://github.com/stenciljs/core/issues/6828

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
