### PR TITLE
feat(testing): v5 export newSpecPage for easy migration

### DIFF
--- a/cspell-wordlist.txt
+++ b/cspell-wordlist.txt
@@ -185,3 +185,4 @@ extensionless
 rgba
 unhashed
 Unparseable
+compilerstatic

--- a/packages/core/src/compiler/build/_test_/build-stats.spec.ts
+++ b/packages/core/src/compiler/build/_test_/build-stats.spec.ts
@@ -1,4 +1,5 @@
-import { mockBuildCtx, mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { beforeEach, describe, expect, it } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/build/_test_/build-stats.spec.ts
+++ b/packages/core/src/compiler/build/_test_/build-stats.spec.ts
@@ -1,8 +1,8 @@
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { beforeEach, describe, expect, it } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../testing/compiler';
 import { result } from '../../../utils';
 import { generateBuildResults } from '../build-results';
 import { generateBuildStats } from '../build-stats';

--- a/packages/core/src/compiler/build/_test_/write-export-maps.spec.ts
+++ b/packages/core/src/compiler/build/_test_/write-export-maps.spec.ts
@@ -1,6 +1,7 @@
 import { execSync } from 'child_process';
 import * as d from '@stencil/core';
-import { mockBuildCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx } from '@stencil/core/testing/compiler';
 import { beforeEach, describe, expect, it, vi, afterEach, Mock } from 'vitest';
 
 import { stubComponentCompilerMeta } from '../../types/_tests_/ComponentCompilerMeta.stub';

--- a/packages/core/src/compiler/build/_test_/write-export-maps.spec.ts
+++ b/packages/core/src/compiler/build/_test_/write-export-maps.spec.ts
@@ -1,9 +1,9 @@
 import { execSync } from 'child_process';
 import * as d from '@stencil/core';
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx } from '@stencil/core/testing/compiler';
 import { beforeEach, describe, expect, it, vi, afterEach, Mock } from 'vitest';
 
+import { mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx } from '../../../testing/compiler';
 import { stubComponentCompilerMeta } from '../../types/_tests_/ComponentCompilerMeta.stub';
 import { writeExportMaps } from '../write-export-maps';
 

--- a/packages/core/src/compiler/bundle/_test_/app-data-plugin.spec.ts
+++ b/packages/core/src/compiler/bundle/_test_/app-data-plugin.spec.ts
@@ -1,8 +1,8 @@
 import * as d from '@stencil/core';
-import { mockValidatedConfig } from '@stencil/core/testing';
 import MagicString from 'magic-string';
 import { describe, expect, it } from 'vitest';
 
+import { mockValidatedConfig } from '../../../testing';
 import { appendBuildConditionals } from '../app-data-plugin';
 
 function setup() {

--- a/packages/core/src/compiler/bundle/_test_/core-resolve-plugin.spec.ts
+++ b/packages/core/src/compiler/bundle/_test_/core-resolve-plugin.spec.ts
@@ -1,4 +1,5 @@
-import { mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/bundle/_test_/core-resolve-plugin.spec.ts
+++ b/packages/core/src/compiler/bundle/_test_/core-resolve-plugin.spec.ts
@@ -1,9 +1,9 @@
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it } from 'vitest';
 import type * as d from '@stencil/core';
 
 import { createSystem } from '../../../compiler/sys/stencil-sys';
+import { mockValidatedConfig } from '../../../testing';
+import { mockCompilerCtx } from '../../../testing/compiler';
 import {
   coreResolvePlugin,
   getHydratedFlagHead,

--- a/packages/core/src/compiler/bundle/_test_/ext-transforms-plugin.spec.ts
+++ b/packages/core/src/compiler/bundle/_test_/ext-transforms-plugin.spec.ts
@@ -1,7 +1,7 @@
-import { mockModule, mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, vi } from 'vitest';
 
+import { mockModule, mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../testing/compiler';
 import { normalizePath } from '../../../utils';
 import * as importPathLib from '../../transformers/stencil-import-path';
 import { stubComponentCompilerMeta } from '../../types/_tests_/ComponentCompilerMeta.stub';

--- a/packages/core/src/compiler/bundle/_test_/ext-transforms-plugin.spec.ts
+++ b/packages/core/src/compiler/bundle/_test_/ext-transforms-plugin.spec.ts
@@ -1,9 +1,5 @@
-import {
-  mockBuildCtx,
-  mockCompilerCtx,
-  mockModule,
-  mockValidatedConfig,
-} from '@stencil/core/testing';
+import { mockModule, mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, vi } from 'vitest';
 
 import { normalizePath } from '../../../utils';

--- a/packages/core/src/compiler/config/_test_/validate-package-json.spec.ts
+++ b/packages/core/src/compiler/config/_test_/validate-package-json.spec.ts
@@ -1,4 +1,5 @@
-import { mockBuildCtx, mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/config/_test_/validate-package-json.spec.ts
+++ b/packages/core/src/compiler/config/_test_/validate-package-json.spec.ts
@@ -1,8 +1,8 @@
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../testing/compiler';
 import { validateBuildPackageJson } from '../validate-package-json';
 
 describe('validateBuildPackageJson', () => {

--- a/packages/core/src/compiler/docs/_test_/agent-skill.spec.ts
+++ b/packages/core/src/compiler/docs/_test_/agent-skill.spec.ts
@@ -1,4 +1,5 @@
-import { mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, MockInstance, beforeEach, afterEach, vi } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/docs/_test_/agent-skill.spec.ts
+++ b/packages/core/src/compiler/docs/_test_/agent-skill.spec.ts
@@ -1,8 +1,8 @@
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, MockInstance, beforeEach, afterEach, vi } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockValidatedConfig } from '../../../testing';
+import { mockCompilerCtx } from '../../../testing/compiler';
 import { generateAgentSkillDocs } from '../agent-skill';
 
 /**

--- a/packages/core/src/compiler/docs/_test_/custom-elements-manifest.spec.ts
+++ b/packages/core/src/compiler/docs/_test_/custom-elements-manifest.spec.ts
@@ -1,4 +1,5 @@
-import { mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, MockInstance, beforeEach, afterEach, vi } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/docs/_test_/custom-elements-manifest.spec.ts
+++ b/packages/core/src/compiler/docs/_test_/custom-elements-manifest.spec.ts
@@ -1,8 +1,8 @@
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, MockInstance, beforeEach, afterEach, vi } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockValidatedConfig } from '../../../testing';
+import { mockCompilerCtx } from '../../../testing/compiler';
 import { generateCustomElementsManifestDocs } from '../cem';
 
 describe('custom-elements-manifest', () => {

--- a/packages/core/src/compiler/docs/_test_/generate-doc-data.spec.ts
+++ b/packages/core/src/compiler/docs/_test_/generate-doc-data.spec.ts
@@ -1,9 +1,5 @@
-import {
-  mockBuildCtx,
-  mockCompilerCtx,
-  mockModule,
-  mockValidatedConfig,
-} from '@stencil/core/testing';
+import { mockModule, mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/docs/_test_/generate-doc-data.spec.ts
+++ b/packages/core/src/compiler/docs/_test_/generate-doc-data.spec.ts
@@ -1,8 +1,8 @@
-import { mockModule, mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockModule, mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../testing/compiler';
 import { DEFAULT_STYLE_MODE, getComponentsFromModules } from '../../../utils';
 import { stubComponentCompilerMeta } from '../../types/_tests_/ComponentCompilerMeta.stub';
 import { AUTO_GENERATE_COMMENT } from '../constants';

--- a/packages/core/src/compiler/html/_test_/remove-unused-styles.spec.ts
+++ b/packages/core/src/compiler/html/_test_/remove-unused-styles.spec.ts
@@ -1,7 +1,7 @@
-import { mockDocument } from '@stencil/core/testing';
 import { describe, expect, it, beforeEach } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockDocument } from '../../../testing';
 import { removeUnusedStyles } from '../remove-unused-styles';
 
 describe('removeUnusedStyles', () => {

--- a/packages/core/src/compiler/output-targets/_test_/build-conditionals.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/build-conditionals.spec.ts
@@ -1,7 +1,7 @@
-import { mockConfig, mockLoadConfigInit } from '@stencil/core/testing';
 import { describe, expect, it, beforeEach } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockConfig, mockLoadConfigInit } from '../../../testing';
 import { validateConfig } from '../../config/validate-config';
 import { getLazyBuildConditionals } from '../dist-lazy/lazy-build-conditionals';
 import { getSsrBuildConditionals } from '../ssr/ssr-build-conditionals';

--- a/packages/core/src/compiler/output-targets/_test_/output-assets.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-assets.spec.ts
@@ -1,13 +1,8 @@
 import { describe, expect, it, beforeEach, vi, afterEach } from 'vitest';
 import type * as d from '@stencil/core';
 
-import {
-  mockBuildCtx,
-  mockCompilerCtx,
-  mockCompilerSystem,
-  mockComponentMeta,
-  mockValidatedConfig,
-} from '../../../testing';
+import { mockCompilerSystem, mockComponentMeta, mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../testing/compiler';
 import { ASSETS, WWW, join } from '../../../utils';
 import { outputAssets } from '../output-assets';
 

--- a/packages/core/src/compiler/output-targets/_test_/output-global-style.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-global-style.spec.ts
@@ -1,12 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as d from '@stencil/core';
 
-import {
-  mockBuildCtx,
-  mockCompilerCtx,
-  mockCompilerSystem,
-  mockValidatedConfig,
-} from '../../../testing';
+import { mockCompilerSystem, mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../testing/compiler';
 import { GLOBAL_STYLE, LOADER_BUNDLE, WWW, join } from '../../../utils';
 import * as globalStylesModule from '../../style/global-styles';
 import { outputGlobalStyle } from '../output-global-style';

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-collection.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-collection.spec.ts
@@ -1,9 +1,5 @@
-import {
-  mockBuildCtx,
-  mockCompilerCtx,
-  mockModule,
-  mockValidatedConfig,
-} from '@stencil/core/testing';
+import { mockModule, mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach, MockInstance, vi, afterEach } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-collection.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-collection.spec.ts
@@ -1,8 +1,8 @@
-import { mockModule, mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach, MockInstance, vi, afterEach } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockModule, mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../testing/compiler';
 import * as test from '../../transformers/map-imports-to-path-aliases';
 import { outputCollection } from '../collection';
 

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-loader-bundle.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-loader-bundle.spec.ts
@@ -1,4 +1,4 @@
-import { createTestCompiler } from '@stencil/core/testing';
+import { createTestCompiler } from '@stencil/core/testing/compiler';
 import { describe, it, beforeEach, afterEach, expect } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-loader-bundle.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-loader-bundle.spec.ts
@@ -1,7 +1,7 @@
-import { createTestCompiler } from '@stencil/core/testing/compiler';
 import { describe, it, beforeEach, afterEach, expect } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { createTestCompiler } from '../../../testing/compiler';
 import { expectFilesDoNotExist, expectFilesExist } from '../../../testing/testing-utils';
 import { join } from '../../../utils';
 

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-ssr-wasm.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-ssr-wasm.spec.ts
@@ -1,8 +1,8 @@
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../testing/compiler';
 import { join, SSR_WASM } from '../../../utils';
 import * as optimizeModuleMod from '../../optimize/optimize-module';
 import { writeSsrWasmOutput } from '../ssr-wasm/generate-ssr-wasm';

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-ssr-wasm.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-ssr-wasm.spec.ts
@@ -1,4 +1,5 @@
-import { mockBuildCtx, mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-ssr.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-ssr.spec.ts
@@ -1,9 +1,9 @@
 import path from 'path';
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach, vi, MockInstance, afterEach } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../testing/compiler';
 import { SSR } from '../../../utils';
 import { validateSsr } from '../../config/outputs/validate-ssr';
 import * as optimizeModuleMod from '../../optimize/optimize-module';

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-ssr.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-ssr.spec.ts
@@ -1,5 +1,6 @@
 import path from 'path';
-import { mockBuildCtx, mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach, vi, MockInstance, afterEach } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-standalone.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-standalone.spec.ts
@@ -1,10 +1,10 @@
 import path from 'path';
 import { OutputTargetStandalone } from '@stencil/core';
-import { mockCompilerSystem, mockModule, mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockCompilerSystem, mockModule, mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../testing/compiler';
 import { STANDALONE } from '../../../utils';
 import {
   STENCIL_APP_GLOBALS_ID,

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-standalone.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-standalone.spec.ts
@@ -1,12 +1,7 @@
 import path from 'path';
 import { OutputTargetStandalone } from '@stencil/core';
-import {
-  mockBuildCtx,
-  mockCompilerCtx,
-  mockCompilerSystem,
-  mockModule,
-  mockValidatedConfig,
-} from '@stencil/core/testing';
+import { mockCompilerSystem, mockModule, mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-www-dist.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-www-dist.spec.ts
@@ -1,4 +1,4 @@
-import { createTestCompiler } from '@stencil/core/testing';
+import { createTestCompiler } from '@stencil/core/testing/compiler';
 import { describe, it, beforeEach, afterEach, expect } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-www-dist.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-www-dist.spec.ts
@@ -1,7 +1,7 @@
-import { createTestCompiler } from '@stencil/core/testing/compiler';
 import { describe, it, beforeEach, afterEach, expect } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { createTestCompiler } from '../../../testing/compiler';
 import { expectFilesDoNotExist, expectFilesExist } from '../../../testing/testing-utils';
 import { join } from '../../../utils';
 

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-www.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-www.spec.ts
@@ -1,4 +1,4 @@
-import { createTestCompiler } from '@stencil/core/testing';
+import { createTestCompiler } from '@stencil/core/testing/compiler';
 import { describe, it, beforeEach, afterEach, expect } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-www.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-www.spec.ts
@@ -1,7 +1,7 @@
-import { createTestCompiler } from '@stencil/core/testing/compiler';
 import { describe, it, beforeEach, afterEach, expect } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { createTestCompiler } from '../../../testing/compiler';
 import { expectFilesDoNotExist, expectFilesExist } from '../../../testing/testing-utils';
 import { join } from '../../../utils';
 

--- a/packages/core/src/compiler/output-targets/_test_/stanalone-types.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/stanalone-types.spec.ts
@@ -1,9 +1,9 @@
 import path from 'path';
-import { mockCompilerSystem, mockModule, mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach, MockInstance, vi, afterEach } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockCompilerSystem, mockModule, mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../testing/compiler';
 import { STANDALONE, normalizePath } from '../../../utils';
 import { stubComponentCompilerMeta } from '../../types/_tests_/ComponentCompilerMeta.stub';
 import * as outputCustomElementsMod from '../standalone';

--- a/packages/core/src/compiler/output-targets/_test_/stanalone-types.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/stanalone-types.spec.ts
@@ -1,11 +1,6 @@
 import path from 'path';
-import {
-  mockBuildCtx,
-  mockCompilerCtx,
-  mockCompilerSystem,
-  mockModule,
-  mockValidatedConfig,
-} from '@stencil/core/testing';
+import { mockCompilerSystem, mockModule, mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach, MockInstance, vi, afterEach } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/output-targets/dist-lazy/_test_/generate-esm-browser.spec.ts
+++ b/packages/core/src/compiler/output-targets/dist-lazy/_test_/generate-esm-browser.spec.ts
@@ -1,4 +1,5 @@
-import { mockBuildCtx, mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/output-targets/dist-lazy/_test_/generate-esm-browser.spec.ts
+++ b/packages/core/src/compiler/output-targets/dist-lazy/_test_/generate-esm-browser.spec.ts
@@ -1,8 +1,8 @@
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockValidatedConfig } from '../../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../../testing/compiler';
 import { DIST_LAZY, join } from '../../../../utils';
 import * as optimizeModuleMod from '../../../optimize/optimize-module';
 import { generateEsmBrowser } from '../generate-esm-browser';

--- a/packages/core/src/compiler/output-targets/dist-lazy/_test_/lazy-output.spec.ts
+++ b/packages/core/src/compiler/output-targets/dist-lazy/_test_/lazy-output.spec.ts
@@ -1,4 +1,5 @@
-import { mockBuildCtx, mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/output-targets/dist-lazy/_test_/lazy-output.spec.ts
+++ b/packages/core/src/compiler/output-targets/dist-lazy/_test_/lazy-output.spec.ts
@@ -1,8 +1,8 @@
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockValidatedConfig } from '../../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../../testing/compiler';
 import { DIST_LAZY, ASSETS } from '../../../../utils';
 import {
   STENCIL_APP_GLOBALS_ID,

--- a/packages/core/src/compiler/output-targets/standalone/_test_/standalone.spec.ts
+++ b/packages/core/src/compiler/output-targets/standalone/_test_/standalone.spec.ts
@@ -1,5 +1,6 @@
 import path from 'path';
-import { mockBuildCtx, mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach, vi, MockInstance, afterEach } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/output-targets/standalone/_test_/standalone.spec.ts
+++ b/packages/core/src/compiler/output-targets/standalone/_test_/standalone.spec.ts
@@ -1,9 +1,9 @@
 import path from 'path';
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach, vi, MockInstance, afterEach } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockValidatedConfig } from '../../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../../testing/compiler';
 import { STANDALONE } from '../../../../utils';
 import { BundleOptions } from '../../../bundle/bundle-interface';
 import * as bundleOutputMod from '../../../bundle/bundle-output';

--- a/packages/core/src/compiler/plugin/_test_/plugin.spec.ts
+++ b/packages/core/src/compiler/plugin/_test_/plugin.spec.ts
@@ -1,11 +1,11 @@
+import { describe, it, beforeAll, beforeEach, afterEach, expect } from 'vitest';
+import type * as d from '@stencil/core';
+
 import {
   createTestCompiler,
   prepareTestCompiler,
   type PreparedTestCompiler,
-} from '@stencil/core/testing/compiler';
-import { describe, it, beforeAll, beforeEach, afterEach, expect } from 'vitest';
-import type * as d from '@stencil/core';
-
+} from '../../../testing/compiler';
 import { join } from '../../../utils';
 
 describe('plugin', () => {

--- a/packages/core/src/compiler/plugin/_test_/plugin.spec.ts
+++ b/packages/core/src/compiler/plugin/_test_/plugin.spec.ts
@@ -2,7 +2,7 @@ import {
   createTestCompiler,
   prepareTestCompiler,
   type PreparedTestCompiler,
-} from '@stencil/core/testing';
+} from '@stencil/core/testing/compiler';
 import { describe, it, beforeAll, beforeEach, afterEach, expect } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/prerender/_test_/prerendered-write-path.spec.ts
+++ b/packages/core/src/compiler/prerender/_test_/prerendered-write-path.spec.ts
@@ -1,7 +1,7 @@
-import { mockValidatedConfig } from '@stencil/core/testing';
 import { describe, expect, it, beforeEach } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockValidatedConfig } from '../../../testing';
 import { join, resolve } from '../../../utils';
 import { validateWww } from '../../config/outputs/validate-www';
 import { getWriteFilePathFromUrlPath } from '../prerendered-write-path';

--- a/packages/core/src/compiler/service-worker/_test_/service-worker-util.spec.ts
+++ b/packages/core/src/compiler/service-worker/_test_/service-worker-util.spec.ts
@@ -1,7 +1,7 @@
-import { mockConfig, mockLoadConfigInit } from '@stencil/core/testing';
 import { describe, expect, it } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockConfig, mockLoadConfigInit } from '../../../testing';
 import { isOutputTargetWww } from '../../../utils';
 import { validateConfig } from '../../config/validate-config';
 import { generateServiceWorkerUrl } from '../service-worker-util';

--- a/packages/core/src/compiler/service-worker/_test_/service-worker.spec.ts
+++ b/packages/core/src/compiler/service-worker/_test_/service-worker.spec.ts
@@ -1,4 +1,4 @@
-import { createTestCompiler } from '@stencil/core/testing';
+import { createTestCompiler } from '@stencil/core/testing/compiler';
 import { expect, describe, it } from '@stencil/vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/service-worker/_test_/service-worker.spec.ts
+++ b/packages/core/src/compiler/service-worker/_test_/service-worker.spec.ts
@@ -1,7 +1,7 @@
-import { createTestCompiler } from '@stencil/core/testing/compiler';
 import { expect, describe, it } from '@stencil/vitest';
 import type * as d from '@stencil/core';
 
+import { createTestCompiler } from '../../../testing/compiler';
 import { join } from '../../../utils';
 
 describe('service worker', () => {

--- a/packages/core/src/compiler/style/_test_/build-conditionals.spec.ts
+++ b/packages/core/src/compiler/style/_test_/build-conditionals.spec.ts
@@ -1,11 +1,11 @@
+import { describe, expect, it, beforeAll, beforeEach, afterEach } from 'vitest';
+import type * as d from '@stencil/core';
+
 import {
   createTestCompiler,
   prepareTestCompiler,
   type PreparedTestCompiler,
-} from '@stencil/core/testing/compiler';
-import { describe, expect, it, beforeAll, beforeEach, afterEach } from 'vitest';
-import type * as d from '@stencil/core';
-
+} from '../../../testing/compiler';
 import { join } from '../../../utils';
 import { getLazyBuildConditionals } from '../../output-targets/dist-lazy/lazy-build-conditionals';
 

--- a/packages/core/src/compiler/style/_test_/build-conditionals.spec.ts
+++ b/packages/core/src/compiler/style/_test_/build-conditionals.spec.ts
@@ -2,7 +2,7 @@ import {
   createTestCompiler,
   prepareTestCompiler,
   type PreparedTestCompiler,
-} from '@stencil/core/testing';
+} from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeAll, beforeEach, afterEach } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/style/_test_/component-global-styles.spec.ts
+++ b/packages/core/src/compiler/style/_test_/component-global-styles.spec.ts
@@ -1,8 +1,8 @@
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../testing/compiler';
 import {
   collectAndBuildComponentGlobalStyles,
   generateHydrateCss,

--- a/packages/core/src/compiler/style/_test_/component-global-styles.spec.ts
+++ b/packages/core/src/compiler/style/_test_/component-global-styles.spec.ts
@@ -1,4 +1,5 @@
-import { mockBuildCtx, mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/style/_test_/css-imports.spec.ts
+++ b/packages/core/src/compiler/style/_test_/css-imports.spec.ts
@@ -1,5 +1,6 @@
 import path from 'path';
-import { mockBuildCtx, mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach, MockInstance, vi, afterEach } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/style/_test_/css-imports.spec.ts
+++ b/packages/core/src/compiler/style/_test_/css-imports.spec.ts
@@ -1,9 +1,9 @@
 import path from 'path';
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach, MockInstance, vi, afterEach } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../testing/compiler';
 import { buildError, normalizePath } from '../../../utils';
 import {
   getCssImports,

--- a/packages/core/src/compiler/style/_test_/optimize-css.spec.ts
+++ b/packages/core/src/compiler/style/_test_/optimize-css.spec.ts
@@ -1,10 +1,10 @@
 import os from 'os';
 import path from 'path';
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockValidatedConfig } from '../../../testing';
+import { mockCompilerCtx } from '../../../testing/compiler';
 import { optimizeCss } from '../optimize-css';
 
 describe('optimizeCss', () => {

--- a/packages/core/src/compiler/style/_test_/optimize-css.spec.ts
+++ b/packages/core/src/compiler/style/_test_/optimize-css.spec.ts
@@ -1,6 +1,7 @@
 import os from 'os';
 import path from 'path';
-import { mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/style/_test_/style-rebuild.spec.ts
+++ b/packages/core/src/compiler/style/_test_/style-rebuild.spec.ts
@@ -1,8 +1,8 @@
 import path from 'path';
-import { mockCompilerSystem, mockLoadConfigInit } from '@stencil/core/testing';
 import { describe, it, beforeEach } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockCompilerSystem, mockLoadConfigInit } from '../../../testing';
 import { createCompiler } from '../../compiler';
 import { validateConfig } from '../../config/validate-config';
 

--- a/packages/core/src/compiler/style/_test_/style.spec.ts
+++ b/packages/core/src/compiler/style/_test_/style.spec.ts
@@ -1,11 +1,11 @@
+import { describe, it, beforeAll, beforeEach, afterEach, expect } from 'vitest';
+import type * as d from '@stencil/core';
+
 import {
   createTestCompiler,
   prepareTestCompiler,
   type PreparedTestCompiler,
-} from '@stencil/core/testing/compiler';
-import { describe, it, beforeAll, beforeEach, afterEach, expect } from 'vitest';
-import type * as d from '@stencil/core';
-
+} from '../../../testing/compiler';
 import { join } from '../../../utils';
 
 describe('component-styles', () => {

--- a/packages/core/src/compiler/style/_test_/style.spec.ts
+++ b/packages/core/src/compiler/style/_test_/style.spec.ts
@@ -2,7 +2,7 @@ import {
   createTestCompiler,
   prepareTestCompiler,
   type PreparedTestCompiler,
-} from '@stencil/core/testing';
+} from '@stencil/core/testing/compiler';
 import { describe, it, beforeAll, beforeEach, afterEach, expect } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/sys/typescript/_test_/typescript-sys.spec.ts
+++ b/packages/core/src/compiler/sys/typescript/_test_/typescript-sys.spec.ts
@@ -1,7 +1,7 @@
-import { mockValidatedConfig } from '@stencil/core/testing';
 import { describe, expect, it } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockValidatedConfig } from '../../../../testing';
 import { createSystem } from '../../stencil-sys';
 import { getTypescriptPathFromUrl } from '../typescript-sys';
 

--- a/packages/core/src/compiler/transformers/_test_/add-define-custom-element-function.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/add-define-custom-element-function.spec.ts
@@ -1,5 +1,6 @@
 import * as d from '@stencil/core';
-import { mockCompilerCtx, mockModule } from '@stencil/core/testing';
+import { mockModule } from '@stencil/core/testing';
+import { mockCompilerCtx } from '@stencil/core/testing/compiler';
 import * as ts from 'typescript';
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import type { MockInstance } from 'vitest';

--- a/packages/core/src/compiler/transformers/_test_/add-define-custom-element-function.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/add-define-custom-element-function.spec.ts
@@ -1,10 +1,10 @@
 import * as d from '@stencil/core';
-import { mockModule } from '@stencil/core/testing';
-import { mockCompilerCtx } from '@stencil/core/testing/compiler';
 import * as ts from 'typescript';
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import type { MockInstance } from 'vitest';
 
+import { mockModule } from '../../../testing';
+import { mockCompilerCtx } from '../../../testing/compiler';
 import { stubComponentCompilerMeta } from '../../types/_tests_/ComponentCompilerMeta.stub';
 import { addDefineCustomElementFunctions } from '../component-native/add-define-custom-element-function';
 import * as TransformUtils from '../transform-utils';

--- a/packages/core/src/compiler/transformers/_test_/add-static-style.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/add-static-style.spec.ts
@@ -1,4 +1,4 @@
-import { mockBuildCtx } from '@stencil/core/testing';
+import { mockBuildCtx } from '@stencil/core/testing/compiler';
 import ts from 'typescript';
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import type * as d from '@stencil/core';

--- a/packages/core/src/compiler/transformers/_test_/add-static-style.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/add-static-style.spec.ts
@@ -1,8 +1,8 @@
-import { mockBuildCtx } from '@stencil/core/testing/compiler';
 import ts from 'typescript';
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockBuildCtx } from '../../../testing/compiler';
 import {
   addStaticStyleGetterWithinClass,
   addStaticStylePropertyToClass,

--- a/packages/core/src/compiler/transformers/_test_/add-tag-transform.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/add-tag-transform.spec.ts
@@ -1,4 +1,4 @@
-import { mockBuildCtx } from '@stencil/core/testing';
+import { mockBuildCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach } from 'vitest';
 
 import { addTagTransform } from '../add-tag-transform';

--- a/packages/core/src/compiler/transformers/_test_/add-tag-transform.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/add-tag-transform.spec.ts
@@ -1,6 +1,6 @@
-import { mockBuildCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, beforeEach } from 'vitest';
 
+import { mockBuildCtx } from '../../../testing/compiler';
 import { addTagTransform } from '../add-tag-transform';
 import { transpileModule } from './transpile';
 import { formatCode } from './utils';

--- a/packages/core/src/compiler/transformers/_test_/detect-modern-prop-decls.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/detect-modern-prop-decls.spec.ts
@@ -1,7 +1,7 @@
-import { mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { ScriptTarget } from 'typescript';
 import { describe, expect, it } from 'vitest';
 
+import { mockCompilerCtx } from '../../../testing/compiler';
 import { transpileModule } from './transpile';
 
 describe('ts config', () => {

--- a/packages/core/src/compiler/transformers/_test_/detect-modern-prop-decls.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/detect-modern-prop-decls.spec.ts
@@ -1,4 +1,4 @@
-import { mockCompilerCtx } from '@stencil/core/testing';
+import { mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { ScriptTarget } from 'typescript';
 import { describe, expect, it } from 'vitest';
 

--- a/packages/core/src/compiler/transformers/_test_/functional-component-deps.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/functional-component-deps.spec.ts
@@ -1,7 +1,7 @@
-import { mockModule } from '@stencil/core/testing';
 import { describe, expect, it } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockModule } from '../../../testing';
 import { getBuildFeatures, updateComponentBuildConditionals } from '../../app-core/app-data';
 import { stubComponentCompilerMeta } from '../../types/_tests_/ComponentCompilerMeta.stub';
 import { transpileModule } from './transpile';

--- a/packages/core/src/compiler/transformers/_test_/lazy-component.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/lazy-component.spec.ts
@@ -1,4 +1,4 @@
-import { mockBuildCtx } from '@stencil/core/testing';
+import { mockBuildCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/transformers/_test_/lazy-component.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/lazy-component.spec.ts
@@ -1,7 +1,7 @@
-import { mockBuildCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockBuildCtx } from '../../../testing/compiler';
 import { lazyComponentTransform } from '../component-lazy/transform-lazy-component';
 import { transpileModule } from './transpile';
 import { c, formatCode } from './utils';

--- a/packages/core/src/compiler/transformers/_test_/map-imports-to-path-aliases.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/map-imports-to-path-aliases.spec.ts
@@ -1,8 +1,8 @@
-import { mockValidatedConfig } from '@stencil/core/testing';
 import { describe, expect, it, beforeEach, vi, afterEach } from 'vitest';
 import type { OutputTargetCollection } from '@stencil/core';
 
 import { ValidatedConfig } from '../../../compiler';
+import { mockValidatedConfig } from '../../../testing';
 import { mapImportsToPathAliases } from '../map-imports-to-path-aliases';
 import { transpileModule } from './transpile';
 

--- a/packages/core/src/compiler/transformers/_test_/native-component.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/native-component.spec.ts
@@ -1,8 +1,8 @@
 import * as d from '@stencil/core';
-import { mockBuildCtx } from '@stencil/core/testing/compiler';
 import * as ts from 'typescript';
 import { describe, expect, it, beforeEach } from 'vitest';
 
+import { mockBuildCtx } from '../../../testing/compiler';
 import { nativeComponentTransform } from '../component-native/tranform-to-native-component';
 import { transpileModule } from './transpile';
 import { c, formatCode } from './utils';

--- a/packages/core/src/compiler/transformers/_test_/native-component.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/native-component.spec.ts
@@ -1,5 +1,5 @@
 import * as d from '@stencil/core';
-import { mockBuildCtx } from '@stencil/core/testing';
+import { mockBuildCtx } from '@stencil/core/testing/compiler';
 import * as ts from 'typescript';
 import { describe, expect, it, beforeEach } from 'vitest';
 

--- a/packages/core/src/compiler/transformers/_test_/parse-props.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/parse-props.spec.ts
@@ -1,10 +1,10 @@
 import { createRequire } from 'module';
 import { dirname, join as pathJoin, relative, resolve } from 'path';
-import { mockCompilerSystem, mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx } from '@stencil/core/testing/compiler';
 import * as ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
+import { mockCompilerSystem, mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx } from '../../../testing/compiler';
 import { normalizePath } from '../../../utils';
 import { createCompiler } from '../../compiler';
 import { validateTsConfig } from '../../sys/typescript/typescript-config';

--- a/packages/core/src/compiler/transformers/_test_/parse-props.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/parse-props.spec.ts
@@ -1,6 +1,7 @@
 import { createRequire } from 'module';
 import { dirname, join as pathJoin, relative, resolve } from 'path';
-import { mockBuildCtx, mockCompilerSystem, mockValidatedConfig } from '@stencil/core/testing';
+import { mockCompilerSystem, mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx } from '@stencil/core/testing/compiler';
 import * as ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 

--- a/packages/core/src/compiler/transformers/_test_/proxy-custom-element-function.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/proxy-custom-element-function.spec.ts
@@ -1,5 +1,6 @@
 import * as d from '@stencil/core';
-import { mockCompilerCtx, mockModule } from '@stencil/core/testing';
+import { mockModule } from '@stencil/core/testing';
+import { mockCompilerCtx } from '@stencil/core/testing/compiler';
 import * as ts from 'typescript';
 import { describe, expect, it, beforeEach, afterEach, MockInstance, vi } from 'vitest';
 

--- a/packages/core/src/compiler/transformers/_test_/proxy-custom-element-function.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/proxy-custom-element-function.spec.ts
@@ -1,9 +1,9 @@
 import * as d from '@stencil/core';
-import { mockModule } from '@stencil/core/testing';
-import { mockCompilerCtx } from '@stencil/core/testing/compiler';
 import * as ts from 'typescript';
 import { describe, expect, it, beforeEach, afterEach, MockInstance, vi } from 'vitest';
 
+import { mockModule } from '../../../testing';
+import { mockCompilerCtx } from '../../../testing/compiler';
 import { stubComponentCompilerMeta } from '../../types/_tests_/ComponentCompilerMeta.stub';
 import * as AddComponentMetaProxy from '../add-component-meta-proxy';
 import { proxyCustomElement } from '../component-native/proxy-custom-element-function';

--- a/packages/core/src/compiler/transformers/_test_/rewrite-aliased-paths.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/rewrite-aliased-paths.spec.ts
@@ -1,10 +1,10 @@
 import path from 'path';
 import { CompilerCtx } from '@stencil/core';
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockCompilerCtx } from '@stencil/core/testing/compiler';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
+import { mockValidatedConfig } from '../../../testing';
+import { mockCompilerCtx } from '../../../testing/compiler';
 import { normalizePath } from '../../../utils';
 import { patchTypescript } from '../../sys/typescript/typescript-sys';
 import {

--- a/packages/core/src/compiler/transformers/_test_/rewrite-aliased-paths.spec.ts
+++ b/packages/core/src/compiler/transformers/_test_/rewrite-aliased-paths.spec.ts
@@ -1,6 +1,7 @@
 import path from 'path';
 import { CompilerCtx } from '@stencil/core';
-import { mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockCompilerCtx } from '@stencil/core/testing/compiler';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 

--- a/packages/core/src/compiler/transformers/_test_/transpile.ts
+++ b/packages/core/src/compiler/transformers/_test_/transpile.ts
@@ -1,8 +1,8 @@
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import ts from 'typescript';
 import type * as d from '@stencil/core';
 
+import { mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../testing/compiler';
 import { performAutomaticKeyInsertion } from '../automatic-key-insertion';
 import { convertDecoratorsToStatic } from '../decorators-to-static/convert-decorators';
 import { updateModule } from '../static-to-meta/parse-static';

--- a/packages/core/src/compiler/transformers/_test_/transpile.ts
+++ b/packages/core/src/compiler/transformers/_test_/transpile.ts
@@ -1,4 +1,5 @@
-import { mockBuildCtx, mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import ts from 'typescript';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/transformers/static-to-meta/class-extension/_test_/compiler-ctx-merge.spec.ts
+++ b/packages/core/src/compiler/transformers/static-to-meta/class-extension/_test_/compiler-ctx-merge.spec.ts
@@ -1,10 +1,10 @@
-import { mockModule, mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 import type * as d from '@stencil/core';
 
 import { mergeExtendedClassMeta } from '..';
+import { mockModule, mockValidatedConfig } from '../../../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../../../testing/compiler';
 import { isStaticGetter } from '../../../transform-utils';
 
 describe('mergeExtendedClassMeta', () => {

--- a/packages/core/src/compiler/transformers/static-to-meta/class-extension/_test_/compiler-ctx-merge.spec.ts
+++ b/packages/core/src/compiler/transformers/static-to-meta/class-extension/_test_/compiler-ctx-merge.spec.ts
@@ -1,9 +1,5 @@
-import {
-  mockBuildCtx,
-  mockCompilerCtx,
-  mockModule,
-  mockValidatedConfig,
-} from '@stencil/core/testing';
+import { mockModule, mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 import type * as d from '@stencil/core';

--- a/packages/core/src/compiler/transformers/static-to-meta/class-extension/_test_/resolve-import-merge.spec.ts
+++ b/packages/core/src/compiler/transformers/static-to-meta/class-extension/_test_/resolve-import-merge.spec.ts
@@ -1,9 +1,9 @@
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx } from '@stencil/core/testing/compiler';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
 import { extractInheritedMeta, mergeExtendedClassMetaWithResolveImport } from '..';
+import { mockValidatedConfig } from '../../../../../testing';
+import { mockBuildCtx } from '../../../../../testing/compiler';
 import { isStaticGetter } from '../../../transform-utils';
 
 // Helper: run with a .tsx filename (decorator syntax path)

--- a/packages/core/src/compiler/transformers/static-to-meta/class-extension/_test_/resolve-import-merge.spec.ts
+++ b/packages/core/src/compiler/transformers/static-to-meta/class-extension/_test_/resolve-import-merge.spec.ts
@@ -1,4 +1,5 @@
-import { mockBuildCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx } from '@stencil/core/testing/compiler';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 

--- a/packages/core/src/compiler/transpile/_test_/run-program-rebuild-diagnostics.spec.ts
+++ b/packages/core/src/compiler/transpile/_test_/run-program-rebuild-diagnostics.spec.ts
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { mockBuildCtx, mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import ts from 'typescript';
 import { afterEach, describe, expect, it } from 'vitest';
 

--- a/packages/core/src/compiler/transpile/_test_/run-program-rebuild-diagnostics.spec.ts
+++ b/packages/core/src/compiler/transpile/_test_/run-program-rebuild-diagnostics.spec.ts
@@ -1,11 +1,11 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import ts from 'typescript';
 import { afterEach, describe, expect, it } from 'vitest';
 
+import { mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../testing/compiler';
 import { runTsProgram } from '../run-program';
 
 /**

--- a/packages/core/src/compiler/transpile/_test_/run-program.spec.ts
+++ b/packages/core/src/compiler/transpile/_test_/run-program.spec.ts
@@ -1,6 +1,6 @@
-import { mockValidatedConfig } from '@stencil/core/testing';
 import { describe, expect, it } from 'vitest';
 
+import { mockValidatedConfig } from '../../../testing';
 import { getRelativeDts } from '../run-program';
 
 describe('run-program.ts', () => {

--- a/packages/core/src/compiler/transpile/_test_/ts-config.spec.ts
+++ b/packages/core/src/compiler/transpile/_test_/ts-config.spec.ts
@@ -1,7 +1,7 @@
-import { mockValidatedConfig } from '@stencil/core/testing';
 import ts from 'typescript';
 import { describe, expect, it } from 'vitest';
 
+import { mockValidatedConfig } from '../../../testing';
 import { getTsOptionsToExtend } from '../ts-config';
 
 describe('ts-config.ts', () => {

--- a/packages/core/src/compiler/types/_tests_/generate-app-types.spec.ts
+++ b/packages/core/src/compiler/types/_tests_/generate-app-types.spec.ts
@@ -1,5 +1,6 @@
 import path from 'path';
-import { mockBuildCtx, mockCompilerCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, afterEach, beforeEach, vi } from 'vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/compiler/types/_tests_/generate-app-types.spec.ts
+++ b/packages/core/src/compiler/types/_tests_/generate-app-types.spec.ts
@@ -1,9 +1,9 @@
 import path from 'path';
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx, mockCompilerCtx } from '@stencil/core/testing/compiler';
 import { describe, expect, it, afterEach, beforeEach, vi } from 'vitest';
 import type * as d from '@stencil/core';
 
+import { mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx, mockCompilerCtx } from '../../../testing/compiler';
 import { patchTypescript } from '../../sys/typescript/typescript-sys';
 import { generateAppTypes } from '../generate-app-types';
 import { stubComponentCompilerEvent } from './ComponentCompilerEvent.stub';

--- a/packages/core/src/declarations/stencil-public-compiler.ts
+++ b/packages/core/src/declarations/stencil-public-compiler.ts
@@ -2923,9 +2923,11 @@ export interface CompilerRequestResponse {
 export interface TranspileOptions {
   /**
    * A component can be defined as a custom element by using `customelement`, or the
-   * component class can be exported by using `module`. Default is `customelement`.
+   * component class can be exported by using `module`. Set to `null` to leave the
+   * class's own export as-is (used with `componentMetadata: 'compilerstatic'` for
+   * unit-testing preprocessors). Default is `customelement`.
    */
-  componentExport?: 'customelement' | 'module' | string | undefined;
+  componentExport?: 'customelement' | 'module' | string | null | undefined;
   /**
    * Sets how and if component metadata should be assigned on the compiled
    * component output. The `compilerstatic` value will set the metadata to
@@ -2960,8 +2962,11 @@ export interface TranspileOptions {
   /**
    * How component styles should be associated to the component. The `static`
    * setting will assign the styles as a static getter on the component class.
+   * Set to `null` to skip the assignment entirely (and leave any `styleUrl`
+   * import unresolved) - useful for unit-testing preprocessors that don't
+   * need real stylesheets.
    */
-  style?: 'static' | string | undefined;
+  style?: 'static' | string | null | undefined;
   /**
    * How style data should be added for imports. For example, the `queryparams` value
    * adds the component's tagname and encapsulation info as querystring parameter

--- a/packages/core/src/runtime/_test_/attr-deserialize.spec.tsx
+++ b/packages/core/src/runtime/_test_/attr-deserialize.spec.tsx
@@ -1,7 +1,7 @@
 import { AttrDeserialize, Component, Element, Prop, State } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it, vi } from '@stencil/vitest';
 
+import { newSpecPage } from '../../testing';
 import { withSilentWarn } from '../../testing/testing-utils';
 
 describe('attribute deserialization', () => {

--- a/packages/core/src/runtime/_test_/attr-prop-prefix.spec.tsx
+++ b/packages/core/src/runtime/_test_/attr-prop-prefix.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Prop } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 // Augment JSX to allow attr:* and prop:* prefixed attributes
 declare module '@stencil/core' {

--- a/packages/core/src/runtime/_test_/attr.spec.tsx
+++ b/packages/core/src/runtime/_test_/attr.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, h, Host, Prop } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('attribute', () => {
   it('multi-word attribute', async () => {

--- a/packages/core/src/runtime/_test_/before-each.spec.tsx
+++ b/packages/core/src/runtime/_test_/before-each.spec.tsx
@@ -1,6 +1,6 @@
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it, beforeEach } from '@stencil/vitest';
 
+import { newSpecPage } from '../../testing';
 import { CmpA } from './fixtures/cmp-a';
 
 describe('newSpecPage, spec testing', () => {

--- a/packages/core/src/runtime/_test_/client-hydrate-to-vdom.spec.tsx
+++ b/packages/core/src/runtime/_test_/client-hydrate-to-vdom.spec.tsx
@@ -1,8 +1,8 @@
 import { Component, h, Host } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
 import type * as d from '@stencil/core';
 
+import { newSpecPage } from '../../testing';
 import { initializeClientHydrate } from '../client-hydrate';
 
 describe('initializeClientHydrate', () => {

--- a/packages/core/src/runtime/_test_/component-error-handling.spec.tsx
+++ b/packages/core/src/runtime/_test_/component-error-handling.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, ComponentInterface, h, Prop, setErrorHandler } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it, vi } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('component error handling', () => {
   it('calls a handler with an error and element during every lifecycle hook and render', async () => {

--- a/packages/core/src/runtime/_test_/dom-extras.spec.tsx
+++ b/packages/core/src/runtime/_test_/dom-extras.spec.tsx
@@ -1,7 +1,7 @@
 import { Component, h, Host } from '@stencil/core';
-import { newSpecPage, SpecPage } from '@stencil/core/testing';
 import { expect, describe, it, beforeEach } from '@stencil/vitest';
 
+import { newSpecPage, SpecPage } from '../../testing';
 import { applyLightDomPatches, patchSlottedNode } from '../dom-extras';
 
 describe('dom-extras - patches for non-shadow dom methods and accessors', () => {

--- a/packages/core/src/runtime/_test_/element.spec.tsx
+++ b/packages/core/src/runtime/_test_/element.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, Element, Method } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('element', () => {
   it('allows the class to be set', async () => {

--- a/packages/core/src/runtime/_test_/event.spec.tsx
+++ b/packages/core/src/runtime/_test_/event.spec.tsx
@@ -9,8 +9,9 @@ import {
   resolveVar,
   State,
 } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('event', () => {
   it('event normal ionChange event', async () => {

--- a/packages/core/src/runtime/_test_/extends-basic.spec.tsx
+++ b/packages/core/src/runtime/_test_/extends-basic.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Prop, Watch } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('extends', () => {
   it('should call inherited watch methods when props change', async () => {

--- a/packages/core/src/runtime/_test_/globals.spec.tsx
+++ b/packages/core/src/runtime/_test_/globals.spec.tsx
@@ -1,6 +1,7 @@
 import { Build, Component, Env } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it, beforeEach } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('globals', () => {
   @Component({

--- a/packages/core/src/runtime/_test_/host.spec.tsx
+++ b/packages/core/src/runtime/_test_/host.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Host, Prop, State } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('hostData', () => {
   it('render hostData() attributes', async () => {

--- a/packages/core/src/runtime/_test_/hydrate-no-encapsulation.spec.tsx
+++ b/packages/core/src/runtime/_test_/hydrate-no-encapsulation.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Host } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('hydrate no encapsulation', () => {
   it('no script annotations', async () => {

--- a/packages/core/src/runtime/_test_/hydrate-prop.spec.tsx
+++ b/packages/core/src/runtime/_test_/hydrate-prop.spec.tsx
@@ -1,7 +1,7 @@
 import { Component, h, Prop } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
 
+import { newSpecPage } from '../../testing';
 import { MEMBER_FLAGS } from '../../utils';
 
 describe('hydrate prop types', () => {

--- a/packages/core/src/runtime/_test_/hydrate-scoped.spec.tsx
+++ b/packages/core/src/runtime/_test_/hydrate-scoped.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Host } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('hydrate scoped', () => {
   it('converts shadow and slots to light dom via serializeShadowRoot', async () => {

--- a/packages/core/src/runtime/_test_/hydrate-shadow-child.spec.tsx
+++ b/packages/core/src/runtime/_test_/hydrate-shadow-child.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Host } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('hydrate, shadow child', () => {
   it('no slot', async () => {

--- a/packages/core/src/runtime/_test_/hydrate-shadow-in-shadow.spec.tsx
+++ b/packages/core/src/runtime/_test_/hydrate-shadow-in-shadow.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Host } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('hydrate, shadow in shadow', () => {
   it('nested cmp-b w/ shadow/slot, root level text', async () => {

--- a/packages/core/src/runtime/_test_/hydrate-shadow-parent.spec.tsx
+++ b/packages/core/src/runtime/_test_/hydrate-shadow-parent.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Host } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('hydrate, shadow parent', () => {
   it('slot depth 1, text w/out vdom', async () => {

--- a/packages/core/src/runtime/_test_/hydrate-shadow.spec.tsx
+++ b/packages/core/src/runtime/_test_/hydrate-shadow.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, h } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('hydrate, shadow', () => {
   it('light dom parent, nested shadow slot', async () => {

--- a/packages/core/src/runtime/_test_/hydrate-slot-fallback.spec.tsx
+++ b/packages/core/src/runtime/_test_/hydrate-slot-fallback.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, h } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('hydrate, slot fallback', () => {
   it('shows slot fallback content in a `scoped: true` parent', async () => {

--- a/packages/core/src/runtime/_test_/hydrate-slotted-content-order.spec.tsx
+++ b/packages/core/src/runtime/_test_/hydrate-slotted-content-order.spec.tsx
@@ -1,7 +1,7 @@
 import { Component, h } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
 
+import { newSpecPage } from '../../testing';
 import { applyLightDomPatches } from '../dom-extras';
 
 describe("hydrated components' slotted node order", () => {

--- a/packages/core/src/runtime/_test_/hydrate-style-element.spec.tsx
+++ b/packages/core/src/runtime/_test_/hydrate-style-element.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, h } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('hydrate style element', () => {
   it('style element text', async () => {

--- a/packages/core/src/runtime/_test_/initialize-component.spec.tsx
+++ b/packages/core/src/runtime/_test_/initialize-component.spec.tsx
@@ -1,8 +1,8 @@
 import { Component } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
 import { getHostRef } from 'virtual:platform';
 
+import { newSpecPage } from '../../testing';
 import { HOST_FLAGS } from '../../utils';
 
 describe('initialize component', () => {

--- a/packages/core/src/runtime/_test_/jsx.spec.tsx
+++ b/packages/core/src/runtime/_test_/jsx.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, Fragment, h, Host, Prop, State } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('jsx', () => {
   it('Fragment', async () => {

--- a/packages/core/src/runtime/_test_/lazy-load-retry.spec.tsx
+++ b/packages/core/src/runtime/_test_/lazy-load-retry.spec.tsx
@@ -9,15 +9,9 @@ import {
   vi,
   type MockInstance,
 } from '@stencil/vitest';
-import {
-  flushAll,
-  flushLoadModule,
-  getHostRef,
-  registerInstance,
-  registerModule,
-  resetPlatform,
-  win,
-} from 'virtual:platform';
+import { getHostRef, registerInstance, win } from 'virtual:platform';
+// @ts-expect-error - flushAll, flushLoadModule, registerModule, resetPlatform are only exported from the test bundle
+import { flushAll, flushLoadModule, registerModule, resetPlatform } from 'virtual:platform';
 import type { LazyBundlesRuntimeData } from '@stencil/core/compiler';
 
 import { HOST_FLAGS } from '../../utils';

--- a/packages/core/src/runtime/_test_/lifecycle-async.spec.tsx
+++ b/packages/core/src/runtime/_test_/lifecycle-async.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, Prop, Watch } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it, vi } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('lifecycle async', () => {
   it('wait for componentWillLoad', async () => {

--- a/packages/core/src/runtime/_test_/lifecycle-sync.spec.tsx
+++ b/packages/core/src/runtime/_test_/lifecycle-sync.spec.tsx
@@ -1,7 +1,8 @@
 import { Component, Element, forceUpdate, h, Host, Method, Prop, Watch } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
 import type { ComponentShouldUpdateChanges } from '@stencil/core';
+
+import { newSpecPage } from '../../testing';
 
 describe('lifecycle sync', () => {
   it('should fire connected/disconnected when removed', async () => {

--- a/packages/core/src/runtime/_test_/listen.spec.tsx
+++ b/packages/core/src/runtime/_test_/listen.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, Event, EventEmitter, Listen, resolveVar, State } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it, vi } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('listen', () => {
   it('listen to click on host, from elm.click()', async () => {

--- a/packages/core/src/runtime/_test_/method.spec.tsx
+++ b/packages/core/src/runtime/_test_/method.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, Method, State } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('method', () => {
   it('call method', async () => {

--- a/packages/core/src/runtime/_test_/mixin.spec.tsx
+++ b/packages/core/src/runtime/_test_/mixin.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, Event, EventEmitter, h, MixedInCtor, Mixin, Prop, State } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('mixin', () => {
   it('can call a constructor with args', async () => {

--- a/packages/core/src/runtime/_test_/nested-slot-forwarding.spec.tsx
+++ b/packages/core/src/runtime/_test_/nested-slot-forwarding.spec.tsx
@@ -1,7 +1,7 @@
 import { Component, h } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { it, describe, expect } from 'vitest';
 
+import { newSpecPage } from '../../testing';
 import { applyLightDomPatches } from '../dom-extras';
 
 describe('nested named slot forwarding', () => {

--- a/packages/core/src/runtime/_test_/nested-slot-forwarding.spec.tsx
+++ b/packages/core/src/runtime/_test_/nested-slot-forwarding.spec.tsx
@@ -182,7 +182,7 @@ describe('nested named slot forwarding', () => {
       html: `<cmp-b><span slot="named">initial</span></cmp-b>`,
     });
 
-    const span = page.doc.querySelector('span[slot="named"]');
+    const span = page.doc.querySelector<HTMLElement>('span[slot="named"]');
     expect(span.hidden).toBe(true);
   });
 

--- a/packages/core/src/runtime/_test_/prop-serialize.spec.tsx
+++ b/packages/core/src/runtime/_test_/prop-serialize.spec.tsx
@@ -1,7 +1,7 @@
 import { Component, Element, h, Prop, PropSerialize, State } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it, vi } from '@stencil/vitest';
 
+import { newSpecPage } from '../../testing';
 import { withSilentWarn } from '../../testing/testing-utils';
 
 describe('attribute serialization', () => {

--- a/packages/core/src/runtime/_test_/prop-warnings.spec.tsx
+++ b/packages/core/src/runtime/_test_/prop-warnings.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Method, Prop } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it, vi, afterEach, afterAll } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 @Component({
   tag: 'shared-cmp',

--- a/packages/core/src/runtime/_test_/prop.spec.tsx
+++ b/packages/core/src/runtime/_test_/prop.spec.tsx
@@ -1,7 +1,8 @@
 import { AttrDeserialize, Component, h, Prop } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
 import type { ComponentShouldUpdateChanges } from '@stencil/core';
+
+import { newSpecPage } from '../../testing';
 
 function Clamp(lowerBound: number, upperBound: number): any {
   const clamp = (value: number) => Math.max(lowerBound, Math.min(value, upperBound));

--- a/packages/core/src/runtime/_test_/queue.spec.tsx
+++ b/packages/core/src/runtime/_test_/queue.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, Method, readTask, writeTask } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('queue', () => {
   it('should execute tasks in the right order', async () => {

--- a/packages/core/src/runtime/_test_/reactive-controller.spec.tsx
+++ b/packages/core/src/runtime/_test_/reactive-controller.spec.tsx
@@ -7,8 +7,9 @@ import {
   ReactiveControllerHost,
   State,
 } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('reactive-controller', () => {
   it('calls hostConnected on an added controller when the component connects', async () => {

--- a/packages/core/src/runtime/_test_/reactive-controller.spec.tsx
+++ b/packages/core/src/runtime/_test_/reactive-controller.spec.tsx
@@ -79,6 +79,7 @@ describe('reactive-controller', () => {
         this.host = host;
         host.addController(this);
       }
+      hostDidUpdate() {}
       tick() {
         this.host.requestUpdate();
       }

--- a/packages/core/src/runtime/_test_/regression-json-string-non-parsing.spec.tsx
+++ b/packages/core/src/runtime/_test_/regression-json-string-non-parsing.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Prop } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 /**
  * Regression tests for:

--- a/packages/core/src/runtime/_test_/render-text.spec.tsx
+++ b/packages/core/src/runtime/_test_/render-text.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, Prop } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('render-text', () => {
   @Component({ tag: 'cmp-a' })

--- a/packages/core/src/runtime/_test_/render-vdom.spec.tsx
+++ b/packages/core/src/runtime/_test_/render-vdom.spec.tsx
@@ -9,9 +9,9 @@ import {
   setErrorHandler,
   State,
 } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
 
+import { newSpecPage } from '../../testing';
 import { withSilentWarn } from '../../testing/testing-utils';
 
 describe('render-vdom', () => {

--- a/packages/core/src/runtime/_test_/scoped.spec.tsx
+++ b/packages/core/src/runtime/_test_/scoped.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Host, Prop, State } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('scoped', () => {
   it('should add scoped classes', async () => {

--- a/packages/core/src/runtime/_test_/shadow.spec.tsx
+++ b/packages/core/src/runtime/_test_/shadow.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, h } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 @Component({
   tag: 'cmp-a',

--- a/packages/core/src/runtime/_test_/signal-backing.spec.tsx
+++ b/packages/core/src/runtime/_test_/signal-backing.spec.tsx
@@ -1,8 +1,8 @@
 import { Component, h, Method, Prop, State, Watch } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it, vi } from '@stencil/vitest';
 
 import { Effect, computed, getSignal, STENCIL_SIGNALS_SYMBOL } from '../../signals';
+import { newSpecPage } from '../../testing';
 
 /** Shared option applied to every test - the only thing that makes these tests distinct. */
 const SIG = { buildFlags: { signalBacking: true, vdomSignals: true } } as const;

--- a/packages/core/src/runtime/_test_/signal-vdom.spec.tsx
+++ b/packages/core/src/runtime/_test_/signal-vdom.spec.tsx
@@ -1,7 +1,8 @@
 import { signal } from '@preact/signals-core';
 import { Component, h, State } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 const VDOM = {
   buildFlags: { vdomSignals: true, vdomText: true, vdomAttribute: true, vdomClass: true },

--- a/packages/core/src/runtime/_test_/state.spec.tsx
+++ b/packages/core/src/runtime/_test_/state.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, Method, State } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 function Clamp(lowerBound: number, upperBound: number): any {
   const clamp = (value: number) => Math.max(lowerBound, Math.min(value, upperBound));

--- a/packages/core/src/runtime/_test_/style.spec.tsx
+++ b/packages/core/src/runtime/_test_/style.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, getMode, setMode } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('style', () => {
   it('get style string', async () => {

--- a/packages/core/src/runtime/_test_/svg-element.spec.tsx
+++ b/packages/core/src/runtime/_test_/svg-element.spec.tsx
@@ -2,8 +2,9 @@
 
 import { Component, h } from '@stencil/core';
 import { Prop } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it, beforeEach } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('SVG element', () => {
   it('should render #text nodes', async () => {

--- a/packages/core/src/runtime/_test_/update-component.spec.tsx
+++ b/packages/core/src/runtime/_test_/update-component.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Prop, State } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it, vi } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('update-component', () => {
   describe('scheduleUpdate - re-entrancy guard', () => {

--- a/packages/core/src/runtime/_test_/vdom-relocation.spec.tsx
+++ b/packages/core/src/runtime/_test_/vdom-relocation.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, h, Listen, State } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../testing';
 
 describe('vdom-relocation', () => {
   it('vdom-relocation', async () => {

--- a/packages/core/src/runtime/_test_/watch.spec.tsx
+++ b/packages/core/src/runtime/_test_/watch.spec.tsx
@@ -1,7 +1,7 @@
 import { Component, Method, Prop, State, Watch } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it, vi } from '@stencil/vitest';
 
+import { newSpecPage } from '../../testing';
 import { withSilentWarn } from '../../testing/testing-utils';
 
 describe('watch', () => {

--- a/packages/core/src/runtime/vdom/_test_/patch.spec.ts
+++ b/packages/core/src/runtime/vdom/_test_/patch.spec.ts
@@ -1,7 +1,7 @@
-import { shuffleArray } from '@stencil/core/testing';
 import { expect, describe, it, beforeEach } from '@stencil/vitest';
 import type * as d from '@stencil/core';
 
+import { shuffleArray } from '../../../testing';
 import { SVG_NS } from '../../../utils';
 import { h, newVNode } from '../h';
 import { toVNode } from '../util';

--- a/packages/core/src/runtime/vdom/_test_/scoped-slot.spec.tsx
+++ b/packages/core/src/runtime/vdom/_test_/scoped-slot.spec.tsx
@@ -1,6 +1,7 @@
 import { Component, forceUpdate, h, Prop } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it } from '@stencil/vitest';
+
+import { newSpecPage } from '../../../testing';
 
 describe('scoped slot', () => {
   it('should relocate nested default slot nodes', async () => {

--- a/packages/core/src/runtime/vdom/_test_/vdom-annotations.spec.tsx
+++ b/packages/core/src/runtime/vdom/_test_/vdom-annotations.spec.tsx
@@ -1,7 +1,7 @@
 import { Component, h } from '@stencil/core';
-import { newSpecPage } from '@stencil/core/testing';
 import { expect, describe, it, beforeEach } from '@stencil/vitest';
 
+import { newSpecPage } from '../../../testing';
 import { insertVdomAnnotations } from '../vdom-annotations';
 
 describe('vdom-annotations', () => {

--- a/packages/core/src/testing/compiler.ts
+++ b/packages/core/src/testing/compiler.ts
@@ -1,0 +1,17 @@
+/**
+ * Compiler-backed testing utilities. Split out from `@stencil/core/testing` because these
+ * pull in the full Stencil compiler (and, transitively, `typescript`) - unlike `newSpecPage`,
+ * which is compiler-free.
+ *
+ * Internal only - not a published subpath (no `./testing/compiler` entry in package.json
+ * `exports`). Resolved within this monorepo via the `tsconfig.json` "paths" entry and
+ * `vitest.config.ts` alias. Component authors writing spec tests want `@stencil/core/testing`.
+ */
+export { mockBuildCtx, mockCompilerCtx } from './mocks';
+export {
+  createTestCompiler,
+  prepareTestCompiler,
+  type CreateTestCompilerOptions,
+  type PreparedTestCompiler,
+  type TestCompilerResult,
+} from './create-test-compiler';

--- a/packages/core/src/testing/compiler.ts
+++ b/packages/core/src/testing/compiler.ts
@@ -4,14 +4,12 @@
  * which is compiler-free.
  *
  * Internal only - not a published subpath (no `./testing/compiler` entry in package.json
- * `exports`). Resolved within this monorepo via the `tsconfig.json` "paths" entry and
- * `vitest.config.ts` alias. Component authors writing spec tests want `@stencil/core/testing`.
+ * `exports`). Import via a relative path from `_test_` files. Component authors writing
+ * spec tests want `@stencil/core/testing`.
  */
 export { mockBuildCtx, mockCompilerCtx } from './mocks';
 export {
   createTestCompiler,
   prepareTestCompiler,
-  type CreateTestCompilerOptions,
   type PreparedTestCompiler,
-  type TestCompilerResult,
 } from './create-test-compiler';

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -1,6 +1,4 @@
 export {
-  mockBuildCtx,
-  mockCompilerCtx,
   mockCompilerSystem,
   mockComponentMeta,
   mockConfig,
@@ -11,13 +9,6 @@ export {
   mockValidatedConfig,
   mockWindow,
 } from './mocks';
-export {
-  createTestCompiler,
-  prepareTestCompiler,
-  type CreateTestCompilerOptions,
-  type PreparedTestCompiler,
-  type TestCompilerResult,
-} from './create-test-compiler';
 export { newSpecPage } from './spec-page';
 export { setupConsoleMocker, shuffleArray } from './testing-utils';
 export { createTestingSystem } from './testing-sys';

--- a/packages/core/src/utils/_test_/util.spec.ts
+++ b/packages/core/src/utils/_test_/util.spec.ts
@@ -1,4 +1,5 @@
-import { mockBuildCtx, mockValidatedConfig } from '@stencil/core/testing';
+import { mockValidatedConfig } from '@stencil/core/testing';
+import { mockBuildCtx } from '@stencil/core/testing/compiler';
 import { expect, describe, it, beforeEach } from '@stencil/vitest';
 import type * as d from '@stencil/core';
 

--- a/packages/core/src/utils/_test_/util.spec.ts
+++ b/packages/core/src/utils/_test_/util.spec.ts
@@ -1,8 +1,8 @@
-import { mockValidatedConfig } from '@stencil/core/testing';
-import { mockBuildCtx } from '@stencil/core/testing/compiler';
 import { expect, describe, it, beforeEach } from '@stencil/vitest';
 import type * as d from '@stencil/core';
 
+import { mockValidatedConfig } from '../../testing';
+import { mockBuildCtx } from '../../testing/compiler';
 import * as util from '../index';
 import { getTextDocs } from '../util';
 import { stubDiagnostic } from './fixtures/Diagnostic.stub';

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -36,6 +36,7 @@
       "virtual:platform": ["./src/client/index.ts"],
       "@stencil/core/runtime/server/ssr-factory": ["./src/server/runner/ssr-factory.ts"],
       "@stencil/core/testing": ["./src/testing/index.ts"],
+      "@stencil/core/testing/compiler": ["./src/testing/compiler.ts"],
       "@stencil/core": ["./src/declarations/index.ts"]
     }
   },

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -35,8 +35,6 @@
       "virtual:app-globals": ["./src/app-globals/index.ts"],
       "virtual:platform": ["./src/client/index.ts"],
       "@stencil/core/runtime/server/ssr-factory": ["./src/server/runner/ssr-factory.ts"],
-      "@stencil/core/testing": ["./src/testing/index.ts"],
-      "@stencil/core/testing/compiler": ["./src/testing/compiler.ts"],
       "@stencil/core": ["./src/declarations/index.ts"]
     }
   },

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -39,6 +39,6 @@
       "@stencil/core": ["./src/declarations/index.ts"]
     }
   },
-  "include": ["src/**/*.ts", "tsdown.config.ts", "build/**/*.ts"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "tsdown.config.ts", "build/**/*.ts"],
   "exclude": ["dist"]
 }

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -56,7 +56,6 @@ export default defineConfig([
       'jsx-runtime': 'src/jsx-runtime.ts',
       'compiler/index': 'src/compiler/index.ts',
       'compiler/utils/index': 'src/utils/compiler-exports.ts',
-      'testing/index': 'src/testing/index.ts',
       'sys/node/index': 'src/sys/node/index.ts',
       'sys/node/worker': 'src/sys/node/worker.ts',
       'mock-doc': 'src/mock-doc.ts',
@@ -78,6 +77,36 @@ export default defineConfig([
       // Copy curated public types (paths resolve via declarations entry below)
       { from: 'src/index.d.mts', to: 'dist' },
       { from: 'src/jsx-runtime.d.mts', to: 'dist' },
+    ],
+  },
+
+  // Testing (@stencil/core/testing - newSpecPage, mocks, etc.)
+  // Separate build step: needs its own virtual:app-data/virtual:platform
+  // mappings (testing BUILD conditionals + mock-doc platform), which would
+  // otherwise be shared/clobbered by the main Node build above.
+  {
+    entry: {
+      'testing/index': 'src/testing/index.ts',
+    },
+    outDir: 'dist',
+    format: ['esm'],
+    platform: 'node',
+    target: nodeTarget,
+    dts: true,
+    clean: false,
+    deps: {
+      neverBundle: true,
+      alwaysBundle: ['@stencil/core'],
+    },
+    define: defines,
+    plugins: [
+      virtualModules({
+        resolve: {
+          'virtual:app-data': resolve(__dirname, 'src/testing/app-data.ts'),
+          'virtual:app-globals': resolve(__dirname, 'src/app-globals/index.ts'),
+          'virtual:platform': resolve(__dirname, 'src/testing/platform/index.ts'),
+        },
+      }),
     ],
   },
 

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
       'virtual:app-globals': resolve(__dirname, 'src/app-globals/index.ts'),
       'virtual:platform': resolve(__dirname, 'src/testing/platform/index.ts'),
       // Ensure transpiled components resolve to source (same plt instance)
+      '@stencil/core/testing/compiler': resolve(__dirname, 'src/testing/compiler.ts'),
       '@stencil/core/testing': resolve(__dirname, 'src/testing/index.ts'),
       '@stencil/core': resolve(__dirname, 'src/index.ts'),
     },

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -17,8 +17,9 @@ export default defineConfig({
       'virtual:app-data': resolve(__dirname, 'src/testing/app-data.ts'),
       'virtual:app-globals': resolve(__dirname, 'src/app-globals/index.ts'),
       'virtual:platform': resolve(__dirname, 'src/testing/platform/index.ts'),
-      // Ensure transpiled components resolve to source (same plt instance)
-      '@stencil/core/testing/compiler': resolve(__dirname, 'src/testing/compiler.ts'),
+      // Ensure transpiled components resolve to source (same plt instance).
+      // this alias only serves the `import { h } from '@stencil/core/testing'`
+      // that stencilVitestPlugin embeds
       '@stencil/core/testing': resolve(__dirname, 'src/testing/index.ts'),
       '@stencil/core': resolve(__dirname, 'src/index.ts'),
     },

--- a/packages/unplugin/src/_test_/transform.spec.ts
+++ b/packages/unplugin/src/_test_/transform.spec.ts
@@ -119,4 +119,51 @@ describe('transformStencil', () => {
       expect(result!.code).toContain('connectedCallback');
     });
   });
+
+  describe('mode: spec-page', () => {
+    it('emits COMPILER_META instead of a self-registering custom element', () => {
+      const result = transformStencil(COMPONENT, '/src/my-button.tsx', { mode: 'spec-page' });
+      expect(result).not.toBeNull();
+      expect(result!.code).toContain('COMPILER_META');
+      expect(result!.code).not.toContain('defineCustomElement');
+      expect(result!.code).not.toContain('bootstrapLazy');
+    });
+
+    it('imports from @stencil/core/testing rather than the standalone client', () => {
+      const result = transformStencil(COMPONENT, '/src/my-button.tsx', { mode: 'spec-page' });
+      expect(result!.code).toContain('@stencil/core/testing');
+    });
+
+    it('does not double-export the class (compilerstatic keeps the source export)', () => {
+      const result = transformStencil(COMPONENT, '/src/my-button.tsx', { mode: 'spec-page' });
+      expect(result!.code).toMatch(/export const MyButton/);
+      expect(result!.code).not.toContain('export{MyButton}');
+    });
+
+    it('injects no HMR snippet even when dev=true', () => {
+      const result = transformStencil(
+        COMPONENT,
+        '/src/my-button.tsx',
+        { mode: 'spec-page' },
+        true,
+        'vite',
+      );
+      expect(result!.code).not.toContain('import.meta.hot');
+      expect(result!.code).not.toContain('__stencil_module__');
+    });
+
+    it('does not emit an unresolved styleUrl import (no CSS loader needed for spec-page tests)', () => {
+      const cmpWithStyle = `
+        import { Component, h } from '@stencil/core';
+        @Component({ tag: 'styled-cmp', styleUrl: 'styled-cmp.css', encapsulation: { type: 'shadow' } })
+        export class StyledCmp { render() { return <div />; } }
+      `;
+      const result = transformStencil(cmpWithStyle, '/src/styled-cmp.tsx', { mode: 'spec-page' });
+      expect(result).not.toBeNull();
+      // the file path is still recorded in COMPILER_META.styles[].externalStyles
+      // (harmless metadata) but nothing should `import` it
+      expect(result!.code).not.toMatch(/from ["'].*styled-cmp\.css/);
+      expect(result!.code).toContain('externalStyles');
+    });
+  });
 });

--- a/packages/unplugin/src/index.ts
+++ b/packages/unplugin/src/index.ts
@@ -2,9 +2,20 @@ export { unpluginStencil, getStencilCEM, STENCIL_DOCS_ID } from './plugin.js';
 export type { StencilPluginOptions } from './options.js';
 
 import { unpluginStencil } from './plugin.js';
+import type { StencilPluginOptions } from './options.js';
 
 export const stencilVite = unpluginStencil.vite;
 export const stencilRollup = unpluginStencil.rollup;
 export const stencilWebpack = unpluginStencil.webpack;
 export const stencilEsbuild = unpluginStencil.esbuild;
 export const stencilRspack = unpluginStencil.rspack;
+
+/**
+ * Vite plugin that transpiles components for use with `newSpecPage()` from
+ * `@stencil/core/testing`, instead of the self-registering custom-element
+ * output the other exports produce. Use in `vitest.config.ts`.
+ * @param options - plugin options; `mode` is fixed to `'spec-page'` and cannot be overridden
+ * @returns a Vite plugin
+ */
+export const stencilSpecPage = (options: Omit<StencilPluginOptions, 'mode'> = {}) =>
+  unpluginStencil.vite({ ...options, mode: 'spec-page' });

--- a/packages/unplugin/src/options.ts
+++ b/packages/unplugin/src/options.ts
@@ -15,13 +15,30 @@ export type StencilConfigSubset = Pick<StencilConfig, 'signalBacking'> & {
 export interface StencilPluginOptions {
   /**
    * Additional options forwarded to `transpileSync` for every `.tsx`/`.ts` file.
-   * `file`, `resolveImport`, `styleImportData`, and `componentExport` are
-   * managed by the plugin and should not be set here.
+   * `file`, `resolveImport`, `styleImportData`, `componentExport`, `componentMetadata`,
+   * and `coreImportPath` are managed by the plugin and should not be set here.
    */
   transpileOptions?: Omit<
     TranspileOptions,
-    'file' | 'resolveImport' | 'styleImportData' | 'componentExport'
+    | 'file'
+    | 'resolveImport'
+    | 'styleImportData'
+    | 'componentExport'
+    | 'componentMetadata'
+    | 'coreImportPath'
   >;
+
+  /**
+   * `'build'` (default) transpiles components into self-registering custom
+   * elements for a real bundler/DOM - the output used by `stencilVite`,
+   * `stencilRollup`, etc.
+   *
+   * `'spec-page'` transpiles components for use with `newSpecPage()` from
+   * `@stencil/core/testing`: no self-registration, static `COMPILER_META`
+   * for the mock-doc registry instead. Use `stencilSpecPage` rather than
+   * setting this directly.
+   */
+  mode?: 'build' | 'spec-page';
 
   /**
    * Glob patterns (relative to the project root) for files to include.

--- a/packages/unplugin/src/transform.ts
+++ b/packages/unplugin/src/transform.ts
@@ -147,18 +147,28 @@ export function transformStencil(
   // Cheap regex guard — avoids paying transpileSync cost for plain TS files.
   if (!/(@Component|@Prop|@State|@Event|@Method|@Watch|@Listen)\s*[(\s]/.test(code)) return null;
 
+  const specPage = options.mode === 'spec-page';
   const jsxOpts = resolveJsxOpts(code, process.cwd());
   const result = transpileSync(code, {
     ...jsxOpts,
     ...options.transpileOptions,
     file: id,
-    componentExport: 'customelement',
+    ...(specPage
+      ? {
+          componentExport: null,
+          componentMetadata: 'compilerstatic' as const,
+          coreImportPath: '@stencil/core/testing',
+          // No CSS loader is wired for spec-page mode - `newSpecPage()` tests are
+          // behavioral and don't need real stylesheets. `null` skips the style assignment entirely.
+          style: null,
+        }
+      : { componentExport: 'customelement' as const }),
     styleImportData: 'queryparams',
     resolveImport: makeResolver(onBaseClass),
     buildOverrides: {
       ...configOverrides,
       ...options.transpileOptions?.buildOverrides,
-      ...(dev ? { hotModuleReplacement: true, isDev: true } : {}),
+      ...(dev && !specPage ? { hotModuleReplacement: true, isDev: true } : {}),
     },
   });
 
@@ -184,13 +194,16 @@ export function transformStencil(
   const tagName = result.data[0].tagName;
   const className = result.data[0].componentClassName;
 
-  // customelement mode strips the export keyword, so re-export the class
-  // ourselves — consumers import it by name, and
-  // hmrStandalone needs it in the re-imported module in dev mode
-  const namedExport = `\nexport{${className}};`;
-  const out = dev
-    ? result.code + namedExport + buildHmrSnippet(tagName, className, framework)
-    : result.code + namedExport;
+  let out = result.code;
+  if (!specPage) {
+    // customelement mode strips the export keyword, so re-export the class
+    // ourselves — consumers import it by name, and
+    // hmrStandalone needs it in the re-imported module in dev mode
+    const namedExport = `\nexport{${className}};`;
+    out = dev
+      ? result.code + namedExport + buildHmrSnippet(tagName, className, framework)
+      : result.code + namedExport;
+  }
 
   const docsComponent = cmpMetaToDocsComponent(result.data[0], id);
 

--- a/packages/unplugin/test/spec-page.spec.ts
+++ b/packages/unplugin/test/spec-page.spec.ts
@@ -1,0 +1,27 @@
+import { newSpecPage } from '@stencil/core/testing';
+import { describe, expect, it } from 'vitest';
+
+import { MyButton } from './fixtures/my-button';
+import { MyCard } from './fixtures/my-card';
+
+describe('stencilSpecPage + newSpecPage integration', () => {
+  it('renders a plain component and reacts to prop changes', async () => {
+    const page = await newSpecPage({
+      components: [MyButton],
+      html: `<my-button label="Save"></my-button>`,
+    });
+    expect(page.root!.shadowRoot!.textContent).toBe('Save');
+
+    page.root!.label = 'Cancel';
+    await page.waitForChanges();
+    expect(page.root!.shadowRoot!.textContent).toBe('Cancel');
+  });
+
+  it('renders a component with styleUrl without crashing (CSS content itself is out of scope)', async () => {
+    const page = await newSpecPage({
+      components: [MyCard],
+      html: `<my-card heading="Hello"></my-card>`,
+    });
+    expect(page.root!.shadowRoot!.textContent).toBe('Hello');
+  });
+});

--- a/packages/unplugin/vitest.config.ts
+++ b/packages/unplugin/vitest.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig } from 'vitest/config';
 
+import { stencilSpecPage } from './src/index.js';
+
 export default defineConfig({
+  plugins: [stencilSpecPage()],
   test: {
-    include: ['src/**/*.spec.ts', 'test/build.spec.ts', 'test/docs.spec.ts'],
+    include: [
+      'src/**/*.spec.ts',
+      'test/build.spec.ts',
+      'test/docs.spec.ts',
+      'test/spec-page.spec.ts',
+    ],
   },
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Users must do more work than strictly necessary to migrate their spec tests to v5. 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Expose / export the internally used `newSpecPage`
- Expose a very small `stencilSpecPage` helper from `@stencil/unplugin`. Use this as a plugin within `vitest.config.ts` ; tests can easily be migrated from jest > vitest 

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
