### PR TITLE
fix(runtime): reflected any-typed props

### DIFF
--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -397,8 +397,10 @@ export const proxyComponent = (
           // re-enters this callback, and `parsePropertyValue()` coerces string, number and boolean
           // props so those already agree with their attribute. An `any` prop isn't coerced, so
           // writing the attribute back would destroy the value: `true` becomes `''`, `false`
-          // becomes `null`. An external `setAttribute()` still writes through unless it matches the
-          // reflected form exactly, which we can't tell apart from the runtime's own write.
+          // becomes `null`. `Unknown` props aren't coerced either, but they only reflect when a
+          // serializer is declared, and that path returns above. An external `setAttribute()` still
+          // writes through unless it matches the reflected form exactly, which we can't tell apart
+          // from the runtime's own write.
           if (
             BUILD.reflect &&
             propMemberFlags & MEMBER_FLAGS.ReflectAttr &&

--- a/src/runtime/proxy-component.ts
+++ b/src/runtime/proxy-component.ts
@@ -4,9 +4,20 @@ import { consoleDevWarn, getHostRef, parsePropertyValue, plt } from '@platform';
 import type * as d from '../declarations';
 import { CMP_FLAGS, HOST_FLAGS, MEMBER_FLAGS, WATCH_FLAGS } from '../utils/constants';
 import { getPropertyDescriptor } from '../utils/get-prop-descriptor';
+import { isComplexType } from '../utils/helpers';
 import { normalizeWatchers } from './normalize-watchers';
 import { FORM_ASSOCIATED_CUSTOM_ELEMENT_CALLBACKS, PROXY_FLAGS } from './runtime-constants';
 import { getValue, setValue } from './set-value';
+
+/**
+ * Serialize a prop value the way `setAccessor()` does when it reflects it, so the runtime can
+ * recognize an `attributeChangedCallback` it triggered itself.
+ *
+ * @param propValue the current value of a reflected prop
+ * @returns the string the attribute would hold, or `null` if the attribute would be removed
+ */
+const reflectedAttrValue = (propValue: any): string | null =>
+  propValue == null || propValue === false ? null : propValue === true ? '' : String(propValue);
 
 /**
  * Attach a series of runtime constructs to a compiled Stencil component
@@ -379,7 +390,26 @@ export const proxyComponent = (
           }
 
           const propFlags = members.find(([m]) => m === propName);
-          const isBooleanTarget = propFlags && propFlags[1][0] & MEMBER_FLAGS.Boolean;
+          const propMemberFlags = propFlags ? propFlags[1][0] : 0;
+          const isBooleanTarget = propMemberFlags & MEMBER_FLAGS.Boolean;
+
+          // Guard: skip when a reflected `any` prop is hearing its own reflection. Reflecting
+          // re-enters this callback, and `parsePropertyValue()` coerces string, number and boolean
+          // props so those already agree with their attribute. An `any` prop isn't coerced, so
+          // writing the attribute back would destroy the value: `true` becomes `''`, `false`
+          // becomes `null`. An external `setAttribute()` still writes through unless it matches the
+          // reflected form exactly, which we can't tell apart from the runtime's own write.
+          if (
+            BUILD.reflect &&
+            propMemberFlags & MEMBER_FLAGS.ReflectAttr &&
+            propMemberFlags & MEMBER_FLAGS.Any &&
+            // a complex value is never written to an attribute, so a change while the prop holds
+            // one is always external
+            !isComplexType(this[propName]) &&
+            reflectedAttrValue(this[propName]) === newValue
+          ) {
+            return;
+          }
 
           // Guard: skip when the attribute was removed but the current prop is
           // already undefined. Both mean "not set" for a boolean prop, so the assignment would be

--- a/src/runtime/test/attr.spec.tsx
+++ b/src/runtime/test/attr.spec.tsx
@@ -493,5 +493,174 @@ describe('attribute', () => {
       await waitForChanges();
       expect(root.active).toBe(false);
     });
+
+    it('should keep a reflected any-typed prop set to true, rather than the empty attribute it reflects as', async () => {
+      @Component({ tag: 'cmp-reflect-any-true', shadow: true })
+      class CmpReflectAnyTrue {
+        @Prop({ reflect: true, mutable: true }) value: any;
+
+        render() {
+          return <div>{String(this.value)}</div>;
+        }
+      }
+
+      const { root, waitForChanges } = await newSpecPage({
+        components: [CmpReflectAnyTrue],
+        html: `<cmp-reflect-any-true></cmp-reflect-any-true>`,
+      });
+
+      root.value = true;
+      await waitForChanges();
+
+      expect(root.getAttribute('value')).toBe('');
+      expect(root.value).toBe(true);
+    });
+
+    it('should keep a reflected any-typed prop set to false when markup seeded the attribute', async () => {
+      @Component({ tag: 'cmp-reflect-any-false', shadow: true })
+      class CmpReflectAnyFalse {
+        @Prop({ reflect: true, mutable: true }) value: any;
+
+        render() {
+          return <div>{String(this.value)}</div>;
+        }
+      }
+
+      const { root, waitForChanges } = await newSpecPage({
+        components: [CmpReflectAnyFalse],
+        html: `<cmp-reflect-any-false value="seed"></cmp-reflect-any-false>`,
+      });
+
+      expect(root.value).toBe('seed');
+
+      root.value = false;
+      await waitForChanges();
+
+      // reflecting `false` removes the attribute, which must not null out the prop
+      expect(root.hasAttribute('value')).toBe(false);
+      expect(root.value).toBe(false);
+    });
+
+    it('should keep an object assigned to a reflected any-typed prop', async () => {
+      @Component({ tag: 'cmp-reflect-any-object', shadow: true })
+      class CmpReflectAnyObject {
+        @Prop({ reflect: true, mutable: true }) value: any;
+
+        render() {
+          return <div>{JSON.stringify(this.value)}</div>;
+        }
+      }
+
+      const { root, waitForChanges } = await newSpecPage({
+        components: [CmpReflectAnyObject],
+        html: `<cmp-reflect-any-object></cmp-reflect-any-object>`,
+      });
+
+      const obj = { id: 7 };
+      root.value = obj;
+      await waitForChanges();
+
+      // complex values are never written to an attribute, so there's no round trip to corrupt the prop
+      expect(root.hasAttribute('value')).toBe(false);
+      expect(root.value).toBe(obj);
+    });
+
+    it('should still write an external attribute change through to a reflected any-typed prop', async () => {
+      @Component({ tag: 'cmp-reflect-any-external', shadow: true })
+      class CmpReflectAnyExternal {
+        @Prop({ reflect: true, mutable: true }) value: any;
+
+        render() {
+          return <div>{String(this.value)}</div>;
+        }
+      }
+
+      const { root, waitForChanges } = await newSpecPage({
+        components: [CmpReflectAnyExternal],
+        html: `<cmp-reflect-any-external></cmp-reflect-any-external>`,
+      });
+
+      root.value = true;
+      await waitForChanges();
+      expect(root.value).toBe(true);
+
+      // an external write of something other than the reflected form still wins
+      root.setAttribute('value', 'hello');
+      await waitForChanges();
+      expect(root.value).toBe('hello');
+      expect(root.getAttribute('value')).toBe('hello');
+
+      // and removing it externally still clears the prop
+      root.removeAttribute('value');
+      await waitForChanges();
+      expect(root.value).toBe(null);
+    });
+
+    it('should keep booleans on a reflected any-typed prop that connectedCallback seeded with an id', async () => {
+      // the shape `ion-radio` uses: an `any` prop reflected to the attribute, falling back to a
+      // generated id when the consumer leaves it unset
+      @Component({ tag: 'cmp-reflect-any-seeded', shadow: true })
+      class CmpReflectAnySeeded {
+        @Prop({ reflect: true, mutable: true }) value: any;
+
+        connectedCallback() {
+          if (this.value === undefined) {
+            this.value = 'seeded-id';
+          }
+        }
+
+        render() {
+          return <div>{String(this.value)}</div>;
+        }
+      }
+
+      const { root, waitForChanges } = await newSpecPage({
+        components: [CmpReflectAnySeeded],
+        html: `<cmp-reflect-any-seeded></cmp-reflect-any-seeded>`,
+      });
+
+      expect(root.value).toBe('seeded-id');
+      expect(root.getAttribute('value')).toBe('seeded-id');
+
+      root.value = false;
+      await waitForChanges();
+      expect(root.value).toBe(false);
+
+      root.value = true;
+      await waitForChanges();
+      expect(root.value).toBe(true);
+
+      root.value = 0;
+      await waitForChanges();
+      expect(root.value).toBe(0);
+    });
+
+    it('should apply an external attribute change to a reflected any-typed prop holding a complex value', async () => {
+      @Component({ tag: 'cmp-reflect-any-complex-ext', shadow: true })
+      class CmpReflectAnyComplexExt {
+        @Prop({ reflect: true, mutable: true }) value: any;
+
+        render() {
+          return <div>x</div>;
+        }
+      }
+
+      const { root, waitForChanges } = await newSpecPage({
+        components: [CmpReflectAnyComplexExt],
+        html: `<cmp-reflect-any-complex-ext></cmp-reflect-any-complex-ext>`,
+      });
+
+      root.value = {
+        valueOf: () => 5,
+        toString: () => 'x',
+      };
+      await waitForChanges();
+
+      // a complex value is never reflected, so this change can only be external and must reach the
+      // prop even though it matches the value's string form
+      root.setAttribute('value', 'x');
+      await waitForChanges();
+      expect(root.value).toBe('x');
+    });
   });
 });

--- a/test/wdio/reflect-to-attr/cmp.test.tsx
+++ b/test/wdio/reflect-to-attr/cmp.test.tsx
@@ -56,24 +56,23 @@ describe('reflect-to-attr', function () {
     const cmp = document.querySelector('reflect-to-attr');
 
     // reflecting `true` writes the empty attribute and `false` removes it. Neither may be
-    // assigned back onto the prop, since an `any` prop isn't coerced.
+    // assigned back onto the prop, since an `any` prop isn't coerced. Each wait is on the
+    // reflection itself, so the prop is only read once the round trip has happened.
     cmp.anyVal = true;
-    await browser.pause();
-    expect(cmp.getAttribute('any-val')).toEqual('');
+    await browser.waitUntil(() => cmp.getAttribute('any-val') === '');
     expect(cmp.anyVal).toBe(true);
 
     cmp.anyVal = false;
-    await browser.pause();
-    expect(cmp.getAttribute('any-val')).toEqual(null);
+    await browser.waitUntil(() => !cmp.hasAttribute('any-val'));
     expect(cmp.anyVal).toBe(false);
 
     cmp.anyVal = 0;
-    await browser.pause();
+    await browser.waitUntil(() => cmp.getAttribute('any-val') === '0');
     expect(cmp.anyVal).toBe(0);
 
     // an external attribute write still wins
     cmp.setAttribute('any-val', 'external');
-    await browser.pause();
+    await browser.waitUntil(() => cmp.anyVal === 'external');
     expect(cmp.anyVal).toBe('external');
   });
 

--- a/test/wdio/reflect-to-attr/cmp.test.tsx
+++ b/test/wdio/reflect-to-attr/cmp.test.tsx
@@ -51,6 +51,32 @@ describe('reflect-to-attr', function () {
     expect(cmp.getAttribute('dynamic-nu')).toEqual('123');
   });
 
+  it('should not overwrite a reflected any-typed prop with its own reflected attribute', async () => {
+    await $('reflect-to-attr').waitForExist();
+    const cmp = document.querySelector('reflect-to-attr');
+
+    // reflecting `true` writes the empty attribute and `false` removes it. Neither may be
+    // assigned back onto the prop, since an `any` prop isn't coerced.
+    cmp.anyVal = true;
+    await browser.pause();
+    expect(cmp.getAttribute('any-val')).toEqual('');
+    expect(cmp.anyVal).toBe(true);
+
+    cmp.anyVal = false;
+    await browser.pause();
+    expect(cmp.getAttribute('any-val')).toEqual(null);
+    expect(cmp.anyVal).toBe(false);
+
+    cmp.anyVal = 0;
+    await browser.pause();
+    expect(cmp.anyVal).toBe(0);
+
+    // an external attribute write still wins
+    cmp.setAttribute('any-val', 'external');
+    await browser.pause();
+    expect(cmp.anyVal).toBe('external');
+  });
+
   it('should reflect booleans property', async () => {
     await $('reflect-to-attr').waitForExist();
     const cmp = document.querySelector('reflect-to-attr');

--- a/test/wdio/reflect-to-attr/cmp.tsx
+++ b/test/wdio/reflect-to-attr/cmp.tsx
@@ -17,6 +17,8 @@ export class ReflectToAttr {
   @Prop({ reflect: true, mutable: true }) dynamicStr?: string;
   @Prop({ reflect: true }) dynamicNu?: number;
 
+  @Prop({ reflect: true, mutable: true }) anyVal?: any;
+
   componentDidLoad() {
     this.dynamicStr = 'value';
     this.el.dynamicNu = 123;


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A

Currently, a reflected `any` typed prop is destroyed by its own reflection. The runtime writes the property to the attribute, that write re-enters `attributeChangedCallback`, and the callback assigns the attribute string back onto the property. Setting the prop to `true` leaves it holding `''`, and setting it to `false` leaves it holding `null`.

String, number and boolean props escape this because `parsePropertyValue()` coerces them at assignment, so the property and the attribute already agree. There is already a number-only guard in `attributeChangedCallback` for this same round trip, so the problem is known and handled for one type.


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Now `attributeChangedCallback` returns early when a reflected `any` prop is hearing its own reflection. We detect that by serializing the current prop value the way `setAccessor()` does when it reflects, then comparing it to the incoming attribute. Booleans and numbers survive the round trip, and an external `setAttribute()` still writes through.

Complex values are excluded from the guard because `setAccessor()` never writes them to an attribute at all, so a change while the prop holds one has to have come from outside.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

Six unit tests in `src/runtime/test/attr.spec.tsx` cover the `true` and `false` round trips, an object assignment, external attribute writes and removals, and the `ion-radio` shape where `connectedCallback` seeds the prop with a generated id before the consumer assigns a boolean.

There is also a browser test in `test/wdio/reflect-to-attr`, which needed a new `anyVal` prop on the fixture component since it had no `any` typed prop to reflect.

## Other information

Note: an external `setAttribute()` that happens to write exactly the reflected form is indistinguishable from the runtime's own write, so it gets skipped. Calling `setAttribute('value', '')` from outside on a prop currently holding `true` leaves the prop as `true` rather than `''`. I think that is the better tradeoff, since the alternative is losing the value on every reflection, but it is a behavior change for that narrow case.

This issue specifically caused an issue in Ionic Framework: https://github.com/ionic-team/ionic-framework/issues/31394