### PR TITLE
feat(compiler): v5 browser build

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -14,6 +14,7 @@
         "src/testing/platform/index.ts",
         "src/app-data/lazy.ts",
         "src/testing/app-data.ts",
+        "src/compiler/sys/browser-stubs/**",
         "src/index.d.mts",
         "src/jsx-runtime.d.mts"
       ],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,10 @@
       "types": "./dist/compiler/utils/index.d.mts",
       "import": "./dist/compiler/utils/index.mjs"
     },
+    "./compiler/browser": {
+      "types": "./dist/compiler/browser.d.ts",
+      "import": "./dist/compiler/browser.js"
+    },
     "./jsx-runtime": {
       "types": "./dist/jsx-runtime.d.mts",
       "import": "./dist/jsx-runtime.mjs"

--- a/packages/core/src/compiler/browser.ts
+++ b/packages/core/src/compiler/browser.ts
@@ -1,0 +1,23 @@
+import ts from 'typescript';
+
+/**
+ * Browser-safe subset of `@stencil/core/compiler`. Built separately (see
+ * `tsdown.config.ts`'s `compiler/browser` entry) so it never shares a chunk
+ * with `src/sys/node/` - the CLI/dev-server/file-watcher machinery the main
+ * `./compiler` entry pulls in has no browser equivalent.
+ *
+ * Callers must supply their own `sys` (see `createSystem`) and `logger` -
+ * there is no on-disk default here.
+ */
+export { createSystem } from './sys/stencil-sys';
+export { scopeCss } from '../utils/shadow-css';
+export { transpile, transpileSync } from './transpile';
+export { ts };
+export type {
+  BuildOverrides,
+  CompilerSystem,
+  Diagnostic,
+  Logger,
+  TranspileOptions,
+  TranspileResults,
+} from '../declarations/stencil-public-compiler';

--- a/packages/core/src/compiler/bundle/_test_/plugin-helper.spec.ts
+++ b/packages/core/src/compiler/bundle/_test_/plugin-helper.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { mockValidatedConfig } from '../../../testing';
+import { mockBuildCtx } from '../../../testing/compiler';
+import { pluginHelper } from '../plugin-helper';
+
+function getResolveIdHandler(
+  config: ReturnType<typeof mockValidatedConfig>,
+  buildCtx: ReturnType<typeof mockBuildCtx>,
+) {
+  const plugin = pluginHelper(config, buildCtx, 'client');
+  const resolveId = plugin.resolveId as { handler: (importee: string, importer?: string) => null };
+  return resolveId.handler;
+}
+
+describe('pluginHelper', () => {
+  it('errors on an unaliased Node built-in import', () => {
+    const config = mockValidatedConfig();
+    const buildCtx = mockBuildCtx(config);
+    const handler = getResolveIdHandler(config, buildCtx);
+
+    handler('fs', '/src/index.ts');
+
+    expect(buildCtx.diagnostics).toHaveLength(1);
+    expect(buildCtx.diagnostics[0].messageText).toContain('@rolldown/plugin-node-polyfills');
+  });
+
+  it('does not error when nodeResolve.alias substitutes the built-in', () => {
+    const config = mockValidatedConfig({ nodeResolve: { alias: { fs: 'browserify-fs' } } });
+    const buildCtx = mockBuildCtx(config);
+    const handler = getResolveIdHandler(config, buildCtx);
+
+    handler('fs', '/src/index.ts');
+
+    expect(buildCtx.diagnostics).toHaveLength(0);
+  });
+
+  it('does not error when nodeResolve.alias uses an exact-match ($) key', () => {
+    const config = mockValidatedConfig({ nodeResolve: { alias: { fs$: 'browserify-fs' } } });
+    const buildCtx = mockBuildCtx(config);
+    const handler = getResolveIdHandler(config, buildCtx);
+
+    handler('fs', '/src/index.ts');
+
+    expect(buildCtx.diagnostics).toHaveLength(0);
+  });
+
+  it('still errors when the alias explicitly disables substitution (false)', () => {
+    const config = mockValidatedConfig({ nodeResolve: { alias: { fs: false } } });
+    const buildCtx = mockBuildCtx(config);
+    const handler = getResolveIdHandler(config, buildCtx);
+
+    handler('fs', '/src/index.ts');
+
+    expect(buildCtx.diagnostics).toHaveLength(1);
+  });
+});

--- a/packages/core/src/compiler/bundle/plugin-helper.ts
+++ b/packages/core/src/compiler/bundle/plugin-helper.ts
@@ -68,13 +68,22 @@ export const pluginHelper = (
         }
 
         if (builtIns.has(importee)) {
+          // A configured nodeResolve.alias substitutes the built-in at rolldown's core resolver,
+          // which only runs after every plugin's resolveId (including this one) has declined -
+          // so honor it here rather than erroring on an import the user has already handled.
+          const alias = config.nodeResolve?.alias;
+          const aliasValue = alias?.[importee] ?? alias?.[`${importee}$`];
+          if (aliasValue) {
+            return null;
+          }
+
           let fromMsg = '';
           if (importer) {
             fromMsg = ` from ${relative(config.rootDir, importer)}`;
           }
           const diagnostic = buildError(builtCtx.diagnostics);
           diagnostic.header = `Node Polyfills Required`;
-          diagnostic.messageText = `For the import "${importee}" to be bundled${fromMsg}, ensure the "rolldown-plugin-node-polyfills" plugin is installed and added to the stencil config plugins (${platform}). Please see the bundling docs for more information.
+          diagnostic.messageText = `For the import "${importee}" to be bundled${fromMsg}, ensure the "@rolldown/plugin-node-polyfills" plugin is installed and added to the stencil config plugins (${platform}). Please see the bundling docs for more information.
         Further information: https://stenciljs.com/docs/module-bundling`;
         }
         return null;

--- a/packages/core/src/compiler/bundle/worker-plugin.ts
+++ b/packages/core/src/compiler/bundle/worker-plugin.ts
@@ -229,7 +229,7 @@ const buildWorker = async (
     let code = entryPoint.code;
     const results = await optimizeModule(config, compilerCtx, {
       input: code,
-      sourceTarget: 'es2017',
+      sourceTarget: 'es2022',
       isCore: false,
       minify: config.minifyJs,
       inlineHelpers: true,

--- a/packages/core/src/compiler/output-targets/dist-lazy/generate-cjs.ts
+++ b/packages/core/src/compiler/output-targets/dist-lazy/generate-cjs.ts
@@ -49,7 +49,7 @@ export const generateCjs = async (
         outputTargetType,
         destinations,
         results,
-        'es2017',
+        'es2022',
         false,
       );
 

--- a/packages/core/src/compiler/sys/browser-stubs/browserslist.ts
+++ b/packages/core/src/compiler/sys/browser-stubs/browserslist.ts
@@ -1,9 +1,7 @@
 /**
  * Browser build-time stand-in for `browserslist` (queries real browser usage
  * data from disk - swapped in via `alias` in `tsdown.config.ts`'s
- * `compiler/browser` entry only). Paired with the `lightningcss` stub, whose
- * `browserslistToTargets` ignores its input entirely, so this only needs to
- * not throw.
+ * `compiler/browser` entry only).
  */
 const browserslist = (_query?: string[]): string[] => [];
 

--- a/packages/core/src/compiler/sys/browser-stubs/browserslist.ts
+++ b/packages/core/src/compiler/sys/browser-stubs/browserslist.ts
@@ -1,0 +1,10 @@
+/**
+ * Browser build-time stand-in for `browserslist` (queries real browser usage
+ * data from disk - swapped in via `alias` in `tsdown.config.ts`'s
+ * `compiler/browser` entry only). Paired with the `lightningcss` stub, whose
+ * `browserslistToTargets` ignores its input entirely, so this only needs to
+ * not throw.
+ */
+const browserslist = (_query?: string[]): string[] => [];
+
+export default browserslist;

--- a/packages/core/src/compiler/sys/browser-stubs/browserslist.ts
+++ b/packages/core/src/compiler/sys/browser-stubs/browserslist.ts
@@ -1,8 +1,7 @@
-/**
- * Browser build-time stand-in for `browserslist` (queries real browser usage
- * data from disk - swapped in via `alias` in `tsdown.config.ts`'s
- * `compiler/browser` entry only).
- */
+// Browser build-time stand-in for `browserslist` (queries real browser usage
+// data from disk - swapped in via `alias` in `tsdown.config.ts`'s
+// `compiler/browser` entry only).
+
 const browserslist = (_query?: string[]): string[] => [];
 
 export default browserslist;

--- a/packages/core/src/compiler/sys/browser-stubs/environment.ts
+++ b/packages/core/src/compiler/sys/browser-stubs/environment.ts
@@ -1,0 +1,9 @@
+/**
+ * Browser build-time stand-in for `../environment.ts` (swapped in via `alias`
+ * in `tsdown.config.ts`'s `compiler/browser` entry only). The real file reads
+ * `process.platform` unconditionally at module scope to detect Windows -
+ * there's no Node `process` global in a browser, and case sensitivity there
+ * is a property of the OS filesystem underneath, not something to detect;
+ * the in-memory fs (`createSystem()`) is case-sensitive.
+ */
+export const IS_CASE_SENSITIVE_FILE_NAMES = true;

--- a/packages/core/src/compiler/sys/browser-stubs/environment.ts
+++ b/packages/core/src/compiler/sys/browser-stubs/environment.ts
@@ -1,9 +1,5 @@
 /**
  * Browser build-time stand-in for `../environment.ts` (swapped in via `alias`
- * in `tsdown.config.ts`'s `compiler/browser` entry only). The real file reads
- * `process.platform` unconditionally at module scope to detect Windows -
- * there's no Node `process` global in a browser, and case sensitivity there
- * is a property of the OS filesystem underneath, not something to detect;
- * the in-memory fs (`createSystem()`) is case-sensitive.
+ * in `tsdown.config.ts`'s `compiler/browser` entry only).
  */
 export const IS_CASE_SENSITIVE_FILE_NAMES = true;

--- a/packages/core/src/compiler/sys/browser-stubs/lightningcss.ts
+++ b/packages/core/src/compiler/sys/browser-stubs/lightningcss.ts
@@ -1,0 +1,22 @@
+/**
+ * Browser build-time stand-in for `lightningcss` (native Rust CSS engine, no
+ * browser build - swapped in via `alias` in `tsdown.config.ts`'s
+ * `compiler/browser` entry only). Vendor-prefixing/minifying CSS for *other*
+ * browsers doesn't apply when the browser rendering the preview is the only
+ * target, so autoprefixing is skipped: `transform()` passes the CSS through
+ * unchanged instead of failing.
+ */
+interface TransformInput {
+  code: Uint8Array | string;
+}
+
+export const transform = (input: TransformInput) => ({
+  code: {
+    toString: () =>
+      typeof input.code === 'string' ? input.code : new TextDecoder().decode(input.code),
+  },
+});
+
+export const browserslistToTargets = (_browsers: unknown) => undefined;
+
+export type Targets = undefined;

--- a/packages/core/src/compiler/sys/browser-stubs/lightningcss.ts
+++ b/packages/core/src/compiler/sys/browser-stubs/lightningcss.ts
@@ -1,10 +1,7 @@
 /**
  * Browser build-time stand-in for `lightningcss` (native Rust CSS engine, no
  * browser build - swapped in via `alias` in `tsdown.config.ts`'s
- * `compiler/browser` entry only). Vendor-prefixing/minifying CSS for *other*
- * browsers doesn't apply when the browser rendering the preview is the only
- * target, so autoprefixing is skipped: `transform()` passes the CSS through
- * unchanged instead of failing.
+ * `compiler/browser` entry only).
  */
 interface TransformInput {
   code: Uint8Array | string;

--- a/packages/core/src/compiler/sys/browser-stubs/resolve.ts
+++ b/packages/core/src/compiler/sys/browser-stubs/resolve.ts
@@ -1,0 +1,16 @@
+/**
+ * Browser build-time stand-in for the `resolve` npm package (real on-disk
+ * Node module resolution - swapped in via `alias` in `tsdown.config.ts`'s
+ * `compiler/browser` entry only). Only reachable via `sys.resolveModuleId`,
+ * which `transpile()`/`transpileSync()` never call - real multi-file module
+ * resolution in a browser playground goes through `TranspileOptions.resolveImport`
+ * instead, which the caller supplies.
+ */
+type ResolveCallback = (err: Error | null, resolved?: string, pkgData?: unknown) => void;
+
+const resolve = (id: string, _opts: unknown, cb: ResolveCallback) => {
+  cb(new Error(`Cannot resolve "${id}" - module resolution isn't available in the browser build.`));
+};
+
+export default resolve;
+export type AsyncOpts = Record<string, unknown>;

--- a/packages/core/src/compiler/sys/browser-stubs/resolve.ts
+++ b/packages/core/src/compiler/sys/browser-stubs/resolve.ts
@@ -1,10 +1,7 @@
 /**
  * Browser build-time stand-in for the `resolve` npm package (real on-disk
  * Node module resolution - swapped in via `alias` in `tsdown.config.ts`'s
- * `compiler/browser` entry only). Only reachable via `sys.resolveModuleId`,
- * which `transpile()`/`transpileSync()` never call - real multi-file module
- * resolution in a browser playground goes through `TranspileOptions.resolveImport`
- * instead, which the caller supplies.
+ * `compiler/browser` entry only).
  */
 type ResolveCallback = (err: Error | null, resolved?: string, pkgData?: unknown) => void;
 

--- a/packages/core/src/compiler/sys/browser-stubs/sys-node.ts
+++ b/packages/core/src/compiler/sys/browser-stubs/sys-node.ts
@@ -1,10 +1,7 @@
 /**
  * Browser build-time stand-in for `src/sys/node/index.ts`. Swapped in for
  * the `'../../sys/node'` specifier via `alias` in `tsdown.config.ts`'s
- * `compiler/browser` entry only - the real Node module (and everything it
- * pulls in: `@parcel/watcher`, `chalk`, worker threads) is untouched for
- * every other build. Exports the same three names so no call site needs to
- * change.
+ * `compiler/browser` entry
  */
 import type { CompilerSystem, Logger, LoggerTimeSpan, LogLevel } from '@stencil/core';
 

--- a/packages/core/src/compiler/sys/browser-stubs/sys-node.ts
+++ b/packages/core/src/compiler/sys/browser-stubs/sys-node.ts
@@ -1,0 +1,61 @@
+/**
+ * Browser build-time stand-in for `src/sys/node/index.ts`. Swapped in for
+ * the `'../../sys/node'` specifier via `alias` in `tsdown.config.ts`'s
+ * `compiler/browser` entry only - the real Node module (and everything it
+ * pulls in: `@parcel/watcher`, `chalk`, worker threads) is untouched for
+ * every other build. Exports the same three names so no call site needs to
+ * change.
+ */
+import type { CompilerSystem, Logger, LoggerTimeSpan, LogLevel } from '@stencil/core';
+
+export const createNodeSys = (): CompilerSystem => {
+  throw new Error(
+    'No `sys` provided. The browser build of the Stencil compiler has no default ' +
+      'file system - pass `createSystem()` (from `@stencil/core/compiler/browser`) as `sys`.',
+  );
+};
+
+const identity = (msg: string) => msg;
+
+export const createNodeLogger = (): Logger => {
+  let level: LogLevel = 'info';
+
+  const createTimeSpan: Logger['createTimeSpan'] = (startMsg) => {
+    const start = Date.now();
+    const timeSpan: LoggerTimeSpan = {
+      duration: () => Date.now() - start,
+      finish: (finishedMsg) => {
+        const duration = Date.now() - start;
+        console.log(`${finishedMsg} (${duration}ms)`);
+        return duration;
+      },
+    };
+    console.log(startMsg);
+    return timeSpan;
+  };
+
+  return {
+    enableColors: () => {},
+    setLevel: (l) => (level = l),
+    getLevel: () => level,
+    debug: (...msg) => console.debug(...msg),
+    info: (...msg) => console.info(...msg),
+    warn: (...msg) => console.warn(...msg),
+    error: (...msg) => console.error(...msg),
+    createTimeSpan,
+    printDiagnostics: (diagnostics) => diagnostics.forEach((d) => console.log(d.messageText)),
+    red: identity,
+    green: identity,
+    yellow: identity,
+    blue: identity,
+    magenta: identity,
+    cyan: identity,
+    gray: identity,
+    bold: identity,
+    dim: identity,
+    bgRed: identity,
+    emoji: () => '',
+  };
+};
+
+export const setupNodeProcess = () => {};

--- a/packages/core/src/compiler/sys/typescript/typescript-sys.ts
+++ b/packages/core/src/compiler/sys/typescript/typescript-sys.ts
@@ -2,7 +2,7 @@ import { basename } from 'path';
 import ts from 'typescript';
 import type * as d from '@stencil/core';
 
-import { isRemoteUrl, isString, noop, normalizePath, resolve } from '../../../utils';
+import { isRemoteUrl, isString, normalizePath } from '../../../utils';
 import { IS_CASE_SENSITIVE_FILE_NAMES } from '../environment';
 import { InMemoryFileSystem } from '../in-memory-fs';
 

--- a/packages/core/src/compiler/sys/typescript/typescript-sys.ts
+++ b/packages/core/src/compiler/sys/typescript/typescript-sys.ts
@@ -11,7 +11,16 @@ export const patchTsSystemFileSystem = (
   compilerSys: d.CompilerSystem,
   inMemoryFs: InMemoryFileSystem | null,
   tsSys: ts.System,
-): ts.System => {
+): ts.System | undefined => {
+  // `ts.sys` is a getter with no setter on modern `typescript` builds, so
+  // `patchTypeScriptSysMinimum` below can't ever replace it with a real
+  // object when it doesn't already exist (e.g. no Node `process` to detect -
+  // real browsers, or this simulated-browser check). There's nothing to
+  // patch properties onto in that case.
+  if (!tsSys) {
+    return undefined;
+  }
+
   const realpath = (path: string) => {
     const rp = compilerSys.realpathSync(path);
     if (isString(rp)) {
@@ -136,6 +145,11 @@ export const patchTsSystemFileSystem = (
 };
 
 const patchTsSystemWatch = (compilerSystem: d.CompilerSystem, tsSys: ts.System) => {
+  // See the matching guard in `patchTsSystemFileSystem` above.
+  if (!tsSys) {
+    return;
+  }
+
   tsSys.watchDirectory = (p, cb, recursive) => {
     const watcher = compilerSystem.watchDirectory(
       p,
@@ -186,23 +200,36 @@ const patchTypeScriptSysMinimum = () => {
     // if ts.sys already exists then it must be node ts.sys
     // otherwise we're browser
     // will be updated later on with the stencil sys
-    ts.sys = {
-      args: [],
-      createDirectory: noop,
-      directoryExists: () => false,
-      exit: noop,
-      fileExists: () => false,
-      getCurrentDirectory: process.cwd,
-      getDirectories: () => [],
-      getExecutingFilePath: () => './',
-      readDirectory: () => [],
-      readFile: noop,
-      newLine: '\n',
-      resolvePath: resolve,
-      useCaseSensitiveFileNames: false,
-      write: noop,
-      writeFile: noop,
-    };
+    //
+    // On modern `typescript` builds `sys` is a getter with no setter, so this
+    // assignment can throw when it doesn't already exist (no Node `process`
+    // to detect). There's no real fallback to construct in that case either -
+    // callers that need `ts.sys` populated (e.g. multi-file module
+    // resolution) aren't supported without one; single-file transpilation
+    // doesn't touch it.
+    try {
+      ts.sys = {
+        args: [],
+        createDirectory: noop,
+        directoryExists: () => false,
+        exit: noop,
+        fileExists: () => false,
+        // `process` doesn't exist in a real browser - this branch is the
+        // documented browser fallback above, so it can't assume it does.
+        getCurrentDirectory: () => (typeof process !== 'undefined' ? process.cwd() : '/'),
+        getDirectories: () => [],
+        getExecutingFilePath: () => './',
+        readDirectory: () => [],
+        readFile: noop,
+        newLine: '\n',
+        resolvePath: resolve,
+        useCaseSensitiveFileNames: false,
+        write: noop,
+        writeFile: noop,
+      };
+    } catch {
+      // ts.sys is a non-configurable getter here - nothing to do.
+    }
   }
 };
 patchTypeScriptSysMinimum();

--- a/packages/core/src/compiler/sys/typescript/typescript-sys.ts
+++ b/packages/core/src/compiler/sys/typescript/typescript-sys.ts
@@ -12,11 +12,7 @@ export const patchTsSystemFileSystem = (
   inMemoryFs: InMemoryFileSystem | null,
   tsSys: ts.System,
 ): ts.System | undefined => {
-  // `ts.sys` is a getter with no setter on modern `typescript` builds, so
-  // `patchTypeScriptSysMinimum` below can't ever replace it with a real
-  // object when it doesn't already exist (e.g. no Node `process` to detect -
-  // real browsers, or this simulated-browser check). There's nothing to
-  // patch properties onto in that case.
+  // `ts.sys` is a no-op in browser
   if (!tsSys) {
     return undefined;
   }
@@ -145,7 +141,7 @@ export const patchTsSystemFileSystem = (
 };
 
 const patchTsSystemWatch = (compilerSystem: d.CompilerSystem, tsSys: ts.System) => {
-  // See the matching guard in `patchTsSystemFileSystem` above.
+  // `ts.sys` is a no-op in browser
   if (!tsSys) {
     return;
   }
@@ -193,46 +189,6 @@ export const patchTypescript = (
   patchTsSystemFileSystem(config, config.sys, inMemoryFs, ts.sys);
   patchTsSystemWatch(config.sys, ts.sys);
 };
-
-const patchTypeScriptSysMinimum = () => {
-  if (!ts.sys) {
-    // patches just the bare minimum
-    // if ts.sys already exists then it must be node ts.sys
-    // otherwise we're browser
-    // will be updated later on with the stencil sys
-    //
-    // On modern `typescript` builds `sys` is a getter with no setter, so this
-    // assignment can throw when it doesn't already exist (no Node `process`
-    // to detect). There's no real fallback to construct in that case either -
-    // callers that need `ts.sys` populated (e.g. multi-file module
-    // resolution) aren't supported without one; single-file transpilation
-    // doesn't touch it.
-    try {
-      ts.sys = {
-        args: [],
-        createDirectory: noop,
-        directoryExists: () => false,
-        exit: noop,
-        fileExists: () => false,
-        // `process` doesn't exist in a real browser - this branch is the
-        // documented browser fallback above, so it can't assume it does.
-        getCurrentDirectory: () => (typeof process !== 'undefined' ? process.cwd() : '/'),
-        getDirectories: () => [],
-        getExecutingFilePath: () => './',
-        readDirectory: () => [],
-        readFile: noop,
-        newLine: '\n',
-        resolvePath: resolve,
-        useCaseSensitiveFileNames: false,
-        write: noop,
-        writeFile: noop,
-      };
-    } catch {
-      // ts.sys is a non-configurable getter here - nothing to do.
-    }
-  }
-};
-patchTypeScriptSysMinimum();
 
 export const getTypescriptPathFromUrl = (
   config: d.ValidatedConfig,

--- a/packages/core/src/compiler/transformers/collection/parse-collection-components.ts
+++ b/packages/core/src/compiler/transformers/collection/parse-collection-components.ts
@@ -40,7 +40,7 @@ export const transpileCollectionModule = (
   const sourceFile = ts.createSourceFile(
     inputFileName,
     sourceText,
-    ts.ScriptTarget.ES2017,
+    ts.ScriptTarget.ES2022,
     true,
     ts.ScriptKind.JS,
   );

--- a/packages/core/src/compiler/transpile/transpile-module.ts
+++ b/packages/core/src/compiler/transpile/transpile-module.ts
@@ -117,8 +117,9 @@ export const transpileModule = (
     getDefaultLibFileName: () => `lib.d.ts`,
     useCaseSensitiveFileNames: () => false,
     getCanonicalFileName: (fileName) => fileName,
-    getCurrentDirectory: () => transformOpts.currentDirectory || process.cwd(),
-    getNewLine: () => ts.sys.newLine || '\n',
+    getCurrentDirectory: () =>
+      transformOpts.currentDirectory || (typeof process !== 'undefined' ? process.cwd() : '/'),
+    getNewLine: () => (ts.sys && ts.sys.newLine) || '\n',
     fileExists: (fileName) => normalizePath(fileName) === normalizePath(sourceFilePath),
     readFile: () => '',
     directoryExists: () => true,

--- a/packages/core/src/declarations/stencil-private.ts
+++ b/packages/core/src/declarations/stencil-private.ts
@@ -362,7 +362,7 @@ interface BuildComponent {
   dependencies?: string[];
 }
 
-export type SourceTarget = 'es2017' | 'latest';
+export type SourceTarget = 'es2017' | 'es2022' | 'latest';
 
 export type RolldownResult = RolldownChunkResult | RolldownAssetResult;
 

--- a/packages/core/src/declarations/stencil-public-compiler.ts
+++ b/packages/core/src/declarations/stencil-public-compiler.ts
@@ -3086,11 +3086,11 @@ export type BuildOverrides = Pick<BuildConditionals, BuildOverrideKeys>;
 export type CompileTarget =
   | 'latest'
   | 'esnext'
+  | 'es2022'
   | 'es2020'
   | 'es2019'
   | 'es2018'
   | 'es2017'
-  | 'es2015'
   | string
   | undefined;
 

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -236,6 +236,54 @@ export default defineConfig([
     plugins: [virtualModules({ resolve: virtualResolve })],
   },
 
+  // Browser build of the compiler's single-file transpiler (transpile/transpileSync,
+  // createSystem, scopeCss). Built as its own entry, separate from the Node
+  // compiler build above, so it never shares a chunk with `src/sys/node/` - the
+  // CLI/dev-server/file-watcher machinery that entry pulls in has no browser
+  // equivalent and isn't reachable from this entry's import graph anyway.
+  //
+  // `alias` swaps four specifiers for browser-safe stand-ins, all under
+  // `src/compiler/sys/browser-stubs/` - no other source file changes. Each is
+  // only reachable from a rarely-hit path for a browser caller (real on-disk
+  // module resolution, CSS autoprefixing against *other* browsers), so the
+  // stub versions either throw a clear error or gracefully no-op rather than
+  // reimplementing the real behavior:
+  //  - `../../sys/node` → the real one needs `@parcel/watcher`/`chalk`/worker
+  //    threads; only used as a default when a caller doesn't supply their own
+  //    `sys`/`logger`, which a browser caller always should.
+  //  - `resolve` → real on-disk npm resolution; only reachable via
+  //    `sys.resolveModuleId`, which `transpile()`/`transpileSync()` never call.
+  //  - `lightningcss`/`browserslist` → native CSS engine for vendor-prefixing
+  //    against *other* browsers, meaningless when the browser rendering the
+  //    preview is the only target.
+  {
+    entry: {
+      'compiler/browser': 'src/compiler/browser.ts',
+    },
+    outDir: 'dist',
+    format: ['esm'],
+    platform: 'browser',
+    target: browserTargets,
+    dts: true,
+    clean: false,
+    deps: {
+      neverBundle: true,
+      // `neverBundle: true` externalizes any npm-package-shaped specifier before
+      // resolution runs, which would skip `alias` below entirely for these three -
+      // force them through normal resolution so `alias` gets a chance to redirect
+      // them to the browser stubs.
+      alwaysBundle: ['@stencil/core', 'resolve', 'lightningcss', 'browserslist'],
+    },
+    define: defines,
+    alias: {
+      '../../sys/node': resolve(__dirname, 'src/compiler/sys/browser-stubs/sys-node.ts'),
+      '../environment': resolve(__dirname, 'src/compiler/sys/browser-stubs/environment.ts'),
+      resolve: resolve(__dirname, 'src/compiler/sys/browser-stubs/resolve.ts'),
+      lightningcss: resolve(__dirname, 'src/compiler/sys/browser-stubs/lightningcss.ts'),
+      browserslist: resolve(__dirname, 'src/compiler/sys/browser-stubs/browserslist.ts'),
+    },
+  },
+
   // @stencil/core/signals - public signals primitives + @Effect decorator
   {
     entry: {

--- a/packages/core/tsdown.config.ts
+++ b/packages/core/tsdown.config.ts
@@ -236,54 +236,6 @@ export default defineConfig([
     plugins: [virtualModules({ resolve: virtualResolve })],
   },
 
-  // Browser build of the compiler's single-file transpiler (transpile/transpileSync,
-  // createSystem, scopeCss). Built as its own entry, separate from the Node
-  // compiler build above, so it never shares a chunk with `src/sys/node/` - the
-  // CLI/dev-server/file-watcher machinery that entry pulls in has no browser
-  // equivalent and isn't reachable from this entry's import graph anyway.
-  //
-  // `alias` swaps four specifiers for browser-safe stand-ins, all under
-  // `src/compiler/sys/browser-stubs/` - no other source file changes. Each is
-  // only reachable from a rarely-hit path for a browser caller (real on-disk
-  // module resolution, CSS autoprefixing against *other* browsers), so the
-  // stub versions either throw a clear error or gracefully no-op rather than
-  // reimplementing the real behavior:
-  //  - `../../sys/node` → the real one needs `@parcel/watcher`/`chalk`/worker
-  //    threads; only used as a default when a caller doesn't supply their own
-  //    `sys`/`logger`, which a browser caller always should.
-  //  - `resolve` → real on-disk npm resolution; only reachable via
-  //    `sys.resolveModuleId`, which `transpile()`/`transpileSync()` never call.
-  //  - `lightningcss`/`browserslist` → native CSS engine for vendor-prefixing
-  //    against *other* browsers, meaningless when the browser rendering the
-  //    preview is the only target.
-  {
-    entry: {
-      'compiler/browser': 'src/compiler/browser.ts',
-    },
-    outDir: 'dist',
-    format: ['esm'],
-    platform: 'browser',
-    target: browserTargets,
-    dts: true,
-    clean: false,
-    deps: {
-      neverBundle: true,
-      // `neverBundle: true` externalizes any npm-package-shaped specifier before
-      // resolution runs, which would skip `alias` below entirely for these three -
-      // force them through normal resolution so `alias` gets a chance to redirect
-      // them to the browser stubs.
-      alwaysBundle: ['@stencil/core', 'resolve', 'lightningcss', 'browserslist'],
-    },
-    define: defines,
-    alias: {
-      '../../sys/node': resolve(__dirname, 'src/compiler/sys/browser-stubs/sys-node.ts'),
-      '../environment': resolve(__dirname, 'src/compiler/sys/browser-stubs/environment.ts'),
-      resolve: resolve(__dirname, 'src/compiler/sys/browser-stubs/resolve.ts'),
-      lightningcss: resolve(__dirname, 'src/compiler/sys/browser-stubs/lightningcss.ts'),
-      browserslist: resolve(__dirname, 'src/compiler/sys/browser-stubs/browserslist.ts'),
-    },
-  },
-
   // @stencil/core/signals - public signals primitives + @Effect decorator
   {
     entry: {
@@ -363,5 +315,35 @@ export default defineConfig([
         external: ['virtual:app-globals', 'virtual:app-data-external'],
       }),
     ],
+  },
+
+  // Browser build of the compiler's single-file transpiler (transpile/transpileSync,
+  // createSystem, scopeCss). Built as its own entry, separate from the Node
+  // compiler build above, so it never shares a chunk with `src/sys/node/` - the
+  // cli / dev-server / file-watcher machinery that entry pulls in has no browser
+  // equivalent and isn't reachable from this entry's import graph.
+  {
+    entry: {
+      'compiler/browser': 'src/compiler/browser.ts',
+    },
+    outDir: 'dist',
+    format: ['esm'],
+    platform: 'browser',
+    target: browserTargets,
+    dts: true,
+    clean: false,
+    deps: {
+      neverBundle: true,
+      // force through resolution so `alias` gets a chance to redirect to browser stubs.
+      alwaysBundle: ['@stencil/core', 'resolve', 'lightningcss', 'browserslist'],
+    },
+    define: defines,
+    alias: {
+      '../../sys/node': resolve(__dirname, 'src/compiler/sys/browser-stubs/sys-node.ts'),
+      '../environment': resolve(__dirname, 'src/compiler/sys/browser-stubs/environment.ts'),
+      resolve: resolve(__dirname, 'src/compiler/sys/browser-stubs/resolve.ts'),
+      lightningcss: resolve(__dirname, 'src/compiler/sys/browser-stubs/lightningcss.ts'),
+      browserslist: resolve(__dirname, 'src/compiler/sys/browser-stubs/browserslist.ts'),
+    },
   },
 ]);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Add `@stencil/core/compiler/browser` entry.

Exposes `transpile` / `transpileSync` / `createSystem` / `scopeCss` / `ts` for in-browser use.

Consuming this in a bundler needs Node-builtin polyfills / alias' configured for: 
- `path`  (actually used)
- `os`  (actually used)
- `process`  (actually used)
- `buffer` (actually used)
- `fs` (no-op)
- `crypto` (no-op) 
- `util` (no-op)
- `url` (no-op) 

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
