### PR TITLE
fix(scope-css): process layer selectors

### DIFF
--- a/src/utils/shadow-css.ts
+++ b/src/utils/shadow-css.ts
@@ -471,6 +471,13 @@ const scopeSelector = (selector: string, scopeSelectorText: string, hostSelector
     .join(', ');
 };
 
+const isScopableAtRule = (selector: string) =>
+  selector.startsWith('@media') ||
+  selector.startsWith('@supports') ||
+  selector.startsWith('@page') ||
+  selector.startsWith('@document') ||
+  selector.startsWith('@layer');
+
 const scopeSelectors = (
   cssText: string,
   scopeSelectorText: string,
@@ -483,12 +490,7 @@ const scopeSelectors = (
     let content = rule.content;
     if (rule.selector[0] !== '@') {
       selector = scopeSelector(rule.selector, scopeSelectorText, hostSelector, slotSelector);
-    } else if (
-      rule.selector.startsWith('@media') ||
-      rule.selector.startsWith('@supports') ||
-      rule.selector.startsWith('@page') ||
-      rule.selector.startsWith('@document')
-    ) {
+    } else if (isScopableAtRule(rule.selector)) {
       content = scopeSelectors(rule.content, scopeSelectorText, hostSelector, slotSelector, commentOriginalSelector);
     }
 
@@ -619,20 +621,18 @@ export const scopeCss = (cssText: string, scopeId: string, commentOriginalSelect
       return rule;
     };
 
-    cssText = processRules(cssText, (rule) => {
-      if (rule.selector[0] !== '@') {
-        return processCommentedSelector(rule);
-      } else if (
-        rule.selector.startsWith('@media') ||
-        rule.selector.startsWith('@supports') ||
-        rule.selector.startsWith('@page') ||
-        rule.selector.startsWith('@document')
-      ) {
-        rule.content = processRules(rule.content, processCommentedSelector);
+    const commentSelectors = (input: string): string =>
+      processRules(input, (rule) => {
+        if (rule.selector[0] !== '@') {
+          return processCommentedSelector(rule);
+        }
+        if (isScopableAtRule(rule.selector)) {
+          rule.content = commentSelectors(rule.content);
+        }
         return rule;
-      }
-      return rule;
-    });
+      });
+
+    cssText = commentSelectors(cssText);
   }
 
   const scoped = scopeCssText(cssText, scopeId, hostScopeId, slotScopeId, commentOriginalSelector);

--- a/src/utils/test/scope-css.spec.ts
+++ b/src/utils/test/scope-css.spec.ts
@@ -107,6 +107,18 @@ describe('scopeCSS', function () {
     expect(s(css, 'a')).toEqual(expected);
   });
 
+  it('should handle layer rules', () => {
+    const css = '@layer defaults {section {display: block;}}';
+    const expected = '@layer defaults {section.a {display:block;}}';
+    expect(s(css, 'a')).toEqual(expected);
+  });
+
+  it('should preserve original selectors in nested grouping rules', () => {
+    const css = '@layer defaults {@media (min-width: 640px) {:host {display: block;}}}';
+    const expected = '@layer defaults {@media (min-width:640px) {/*!@:host*/.a-h {display:block;}}}';
+    expect(s(css, 'a', true)).toEqual(expected);
+  });
+
   // Check that the browser supports un-prefixed CSS animation
   it('should handle keyframes rules', () => {
     const css = '@keyframes foo {0% {transform:translate(-50%) scaleX(0);}}';


### PR DESCRIPTION
## What is the current behavior?

`scopeCss` does not traverse `@layer` blocks. Selectors for elements inside a layer are therefore left unscoped.

This also affects shadow components rendered with `serializeShadowRoot: 'scoped'`. Their server generated CSS omits the original selector annotation inside `@layer`. During client hydration, `convertScopedToShadow` cannot restore selectors such as `:host`, so the shadow stylesheet retains a scoped class that cannot match the host and its styles stop applying.

GitHub Issue Number: #6857

## What is the new behavior?

`scopeCss` now processes `@layer` alongside its other supported grouping rules. The same predicate is used when scoping selectors and preserving original selector annotations. Annotation also recurses through nested supported grouping rules, so combinations such as `@layer` containing `@media` restore correctly during client hydration.

## Documentation

N/A

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Testing

- Added focused unit coverage for layer scoping and nested original selector annotations.
- Ran the focused `scope-css` test suite, repository lint, and production build.
- Reproduced the failure with Stencil 4.44.2 and verified the locally packed fix in Chrome 152 using the standalone reproduction.

## Other information

Minimal reproduction: https://github.com/wessmeister/stencil-scoped-layer-repro
