### PR TITLE
fix(compiler): export `setAssetPath` for all outputs everywhere

### DIFF
--- a/V5_PLANNING.md
+++ b/V5_PLANNING.md
@@ -600,6 +600,7 @@ If picked up later: prototype the compiler-owned aggregation step first (the act
 
 ## Known Test Coverage Gaps
 - `validatePublicName` (`compiler/transformers/reserved-public-members.ts`) has no dedicated unit tests - only its event-name counterpart (`compat.suppressEventNameWarnings`, tested in `parse-events.spec.ts`) is covered.
+- `generate-types.ts`'s hand-written `.d.ts` template strings (`generateLoaderTypes`, `generateStandaloneApiTypes`) have no unit tests at all - nothing catches the type declarations drifting out of sync with what the corresponding JS entry actually exports (e.g. the `setAssetPath` gap fixed alongside this note). Not infra-blocked - a real end-to-end `compiler.build()` test (`devMode: false` to trigger types output) confirmed `dist/types/loader.d.ts` is produced and readable in the test FS; a proper test just hasn't been written yet.
 
 ---
 

--- a/packages/core/src/compiler/config/_test_/validate-output-global-style.spec.ts
+++ b/packages/core/src/compiler/config/_test_/validate-output-global-style.spec.ts
@@ -652,5 +652,27 @@ describe('validateGlobalStyleOutputTarget', () => {
       );
       expect(globalStyleWarning).toBeUndefined();
     });
+
+    it('does not emit warning when explicit input is used and a src/global.css file happens to exist on disk', () => {
+      // config.globalStyle is not set by the user, but the auto-detect convention
+      // would otherwise pick up src/global.css and falsely trigger the "both configured" warning
+      config.globalStyle = undefined;
+      (config.sys as d.CompilerSystem).writeFileSync(join(rootDir, 'src', 'global.css'), '');
+      config.outputTargets = [
+        {
+          type: GLOBAL_STYLE,
+          input: './src/theme.css',
+        },
+      ];
+
+      const { config: validatedConfig, diagnostics } = validateConfig(config, mockLoadConfigInit());
+
+      const warnings = diagnostics.filter((d) => d.level === 'warn');
+      const globalStyleWarning = warnings.find(
+        (w) => w.messageText.includes('globalStyle') && w.messageText.includes('global-style'),
+      );
+      expect(globalStyleWarning).toBeUndefined();
+      expect(validatedConfig.globalStyle).toBeUndefined();
+    });
   });
 });

--- a/packages/core/src/compiler/config/validate-config.ts
+++ b/packages/core/src/compiler/config/validate-config.ts
@@ -9,7 +9,7 @@ import {
 } from '@stencil/core';
 
 import { createNodeLogger, createNodeSys } from '../../sys/node';
-import { isBoolean, isString, sortBy, STYLE_EXT } from '../../utils';
+import { isBoolean, isOutputTargetGlobalStyle, isString, sortBy, STYLE_EXT } from '../../utils';
 import { setBooleanConfig } from './config-utils';
 import { DEFAULT_DEV_MODE } from './constants';
 import { validateOutputTargets } from './outputs';
@@ -104,6 +104,13 @@ export const validateConfig = (
   // Derive sys early — needed for namespace derivation from package.json before the config object is fully formed.
   const sys = config.sys ?? bootstrapConfig.sys ?? createNodeSys({ logger });
 
+  // An explicit `global-style` output target with `input` means the user has taken
+  // control of global styles that way; skip the `globalStyle` auto-detect below so it
+  // doesn't set `config.globalStyle` and trigger a misleading "both configured" warning.
+  const hasExplicitGlobalStyleWithInput = (config.outputTargets || []).some(
+    (o) => isOutputTargetGlobalStyle(o) && isString(o.input),
+  );
+
   // Auto-detect global style / script if not explicitly configured.
   // Checks src/global.{css,scss,sass} and src/global.{ts,js} respectively.
   if (
@@ -119,7 +126,7 @@ export const validateConfig = (
           : join(preRootDir, config.srcDir)
         : join(preRootDir, 'src');
 
-    if (!isString(config.globalStyle)) {
+    if (!isString(config.globalStyle) && !hasExplicitGlobalStyleWithInput) {
       for (const ext of STYLE_EXT) {
         const candidate = join(srcDir, `global.${ext}`);
         if (sys.accessSync(candidate)) {

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-loader-bundle.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-loader-bundle.spec.ts
@@ -66,4 +66,76 @@ describe('outputTarget, loader-bundle', () => {
 
     expectFilesDoNotExist(compiler.fs, [join(root, 'www'), join(root, 'build')]);
   });
+
+  describe('loader.d.ts setAssetPath', () => {
+    // The shared `compiler`/`root` from the outer `beforeEach` don't request a `types`
+    // output target, so each test here builds its own compiler with one added.
+    const buildWithTypesOutput = async (): Promise<{ compiler: d.Compiler; root: string }> => {
+      const result = await createTestCompiler({
+        config: {
+          outputTargets: [
+            { type: 'loader-bundle', skipInDev: false } as d.OutputTargetLoaderBundle,
+            { type: 'types' } as d.OutputTargetTypes,
+          ],
+        },
+      });
+      return { compiler: result.compiler, root: result.config.rootDir };
+    };
+
+    it('is exported when a component declares assetsDirs, so a consuming bundler can override it', async () => {
+      const { compiler: assetsCompiler, root: assetsRoot } = await buildWithTypesOutput();
+      try {
+        await assetsCompiler.fs.writeFiles({
+          [join(assetsRoot, 'package.json')]: JSON.stringify({
+            type: 'module',
+            module: 'dist/loader-bundle/index.js',
+          }),
+          [join(assetsRoot, 'src', 'index.html')]: `<cmp-a></cmp-a>`,
+          [join(assetsRoot, 'src', 'cmp-a.tsx')]: `
+            @Component({
+              tag: 'cmp-a',
+              assetsDirs: ['assets'],
+            }) export class CmpA {}`,
+          [join(assetsRoot, 'src', 'assets', 'logo.svg')]: `<svg></svg>`,
+        });
+        await assetsCompiler.fs.commit();
+
+        const r = await assetsCompiler.build();
+        expect(r.diagnostics).toHaveLength(0);
+
+        const loaderDts = await assetsCompiler.fs.readFile(
+          join(assetsRoot, 'dist', 'types', 'loader.d.ts'),
+        );
+        expect(loaderDts).toContain('export declare function setAssetPath(path: string): string;');
+      } finally {
+        await assetsCompiler.destroy();
+      }
+    });
+
+    it('is omitted when no component declares assets', async () => {
+      const { compiler: noAssetsCompiler, root: noAssetsRoot } = await buildWithTypesOutput();
+      try {
+        await noAssetsCompiler.fs.writeFiles({
+          [join(noAssetsRoot, 'package.json')]: JSON.stringify({
+            type: 'module',
+            module: 'dist/loader-bundle/index.js',
+          }),
+          [join(noAssetsRoot, 'src', 'index.html')]: `<cmp-a></cmp-a>`,
+          [join(noAssetsRoot, 'src', 'cmp-a.tsx')]: `
+            @Component({ tag: 'cmp-a' }) export class CmpA {}`,
+        });
+        await noAssetsCompiler.fs.commit();
+
+        const r = await noAssetsCompiler.build();
+        expect(r.diagnostics).toHaveLength(0);
+
+        const loaderDts = await noAssetsCompiler.fs.readFile(
+          join(noAssetsRoot, 'dist', 'types', 'loader.d.ts'),
+        );
+        expect(loaderDts).not.toContain('setAssetPath');
+      } finally {
+        await noAssetsCompiler.destroy();
+      }
+    });
+  });
 });

--- a/packages/core/src/compiler/output-targets/_test_/output-targets-standalone.spec.ts
+++ b/packages/core/src/compiler/output-targets/_test_/output-targets-standalone.spec.ts
@@ -5,7 +5,7 @@ import type * as d from '@stencil/core';
 
 import { mockCompilerSystem, mockModule, mockValidatedConfig } from '../../../testing';
 import { mockBuildCtx, mockCompilerCtx } from '../../../testing/compiler';
-import { STANDALONE } from '../../../utils';
+import { ASSETS, STANDALONE } from '../../../utils';
 import {
   STENCIL_APP_GLOBALS_ID,
   STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID,
@@ -390,6 +390,33 @@ export const defineCustomElements = (opts) => {
         addStandaloneInputs(config, buildCtx, bundleOptions, outputTarget);
 
         expect(bundleOptions.inputs['my-custom-loader']).toBe('\0loader');
+      });
+
+      it('exports setAssetPath from the loader module so it is usable via a bundler, not just a CDN <script> tag', () => {
+        const component = stubComponentCompilerMeta({
+          assetsDirs: [
+            {
+              absolutePath: '/src/assets',
+              cmpRelativePath: 'assets',
+              originalComponentPath: 'assets',
+            },
+          ],
+        });
+        buildCtx.components = [component];
+
+        config.outputTargets.push({ type: ASSETS, dir: '/dist/assets' });
+        const outputTarget = config.outputTargets[0] as OutputTargetStandalone;
+        outputTarget.dir = '/dist/standalone';
+        outputTarget.autoLoader = { fileName: 'loader', autoStart: true };
+
+        const bundleOptions = getBundleOptions(config, buildCtx, compilerCtx, outputTarget);
+        addStandaloneInputs(config, buildCtx, bundleOptions, outputTarget);
+
+        const loaderContent = bundleOptions.loader['\0loader'];
+        expect(loaderContent).toContain(
+          `import { setAssetPath } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';`,
+        );
+        expect(loaderContent).toContain('export { setAssetPath };');
       });
 
       it('should not add loader when autoLoader is not set', () => {

--- a/packages/core/src/compiler/output-targets/dist-lazy/_test_/lazy-output.spec.ts
+++ b/packages/core/src/compiler/output-targets/dist-lazy/_test_/lazy-output.spec.ts
@@ -60,6 +60,38 @@ describe('outputLazy', () => {
       const entry = getLoaderEntry(vi.mocked(bundleOutput).mock.calls[0], LAZY_EXTERNAL_ENTRY_ID);
       expect(entry).not.toContain('(async () =>');
     });
+
+    it('exports setAssetPath when components have assetsDirs, so a consuming bundler can override the default', async () => {
+      const { config, compilerCtx, buildCtx } = setup([
+        { type: DIST_LAZY, esmDir: '/dist/esm' },
+        { type: ASSETS, dir: '/dist/assets' },
+      ]);
+      buildCtx.components = [
+        stubComponentCompilerMeta({
+          assetsDirs: [
+            {
+              absolutePath: '/src/assets',
+              cmpRelativePath: 'assets',
+              originalComponentPath: 'assets',
+            },
+          ],
+        }),
+      ];
+      await outputLazy(config, compilerCtx, buildCtx);
+
+      const entry = getLoaderEntry(vi.mocked(bundleOutput).mock.calls[0], LAZY_EXTERNAL_ENTRY_ID);
+      expect(entry).toContain(
+        `export { setNonce, setRegistry, setTagTransformer, setAssetPath } from '${STENCIL_CORE_ID}';`,
+      );
+    });
+
+    it('does not export setAssetPath when no components have assets', async () => {
+      const { config, compilerCtx, buildCtx } = setup([{ type: DIST_LAZY, esmDir: '/dist/esm' }]);
+      await outputLazy(config, compilerCtx, buildCtx);
+
+      const entry = getLoaderEntry(vi.mocked(bundleOutput).mock.calls[0], LAZY_EXTERNAL_ENTRY_ID);
+      expect(entry).not.toContain('setAssetPath');
+    });
   });
 
   describe('browser entry', () => {
@@ -119,6 +151,13 @@ describe('outputLazy', () => {
         expect(entry).toContain(`import { setAssetPath } from '${STENCIL_CORE_ID}';`);
         expect(entry).toContain(`setAssetPath(new URL(`);
         expect(entry).toContain(`import.meta.url)).href);`);
+        // exported just like setTagTransformer: a static import fully evaluates this
+        // module - including the default setAssetPath call, which runs before the
+        // IIFE's first `await` - before the importing script's own code runs, so a
+        // consumer can override it via `import {setAssetPath} from '.../index.esm.js'`
+        expect(entry).toContain(
+          `export { setNonce, setRegistry, setTagTransformer, setAssetPath } from '${STENCIL_CORE_ID}';`,
+        );
       });
 
       it('calls setAssetPath before globalScripts and bootstrapLazy', async () => {

--- a/packages/core/src/compiler/output-targets/dist-lazy/lazy-output.ts
+++ b/packages/core/src/compiler/output-targets/dist-lazy/lazy-output.ts
@@ -266,7 +266,19 @@ function createEntryModule(cmps: d.ComponentCompilerMeta[]): d.EntryModule {
 
 const getLazyEntry = (isBrowser: boolean, assetPath?: string, externalRuntime = false): string => {
   const s = new MagicString(``);
-  s.append(`export { setNonce, setRegistry, setTagTransformer } from '${STENCIL_CORE_ID}';\n`);
+  const platformExports = ['setNonce', 'setRegistry', 'setTagTransformer'];
+  // Exported (when there's a path to override) on both builds, same as setTagTransformer.
+  // External build: defineCustomElements() is only invoked whenever the consumer calls it,
+  // well after import, so there's no race at all. Browser build: a static import fully
+  // evaluates this module - including the default setAssetPath call, which runs before the
+  // IIFE's first `await` below - before the importing script's own top-level code runs;
+  // bootstrapLazy() only resumes after that `await`, i.e. at least one microtask later. Either
+  // way, a consumer's own `import { setAssetPath } from '.../index.esm.js'; setAssetPath(...);`
+  // reliably lands before it's needed - exactly like the documented setTagTransformer usage.
+  if (assetPath) {
+    platformExports.push('setAssetPath');
+  }
+  s.append(`export { ${platformExports.join(', ')} } from '${STENCIL_CORE_ID}';\n`);
   s.append(`import { bootstrapLazy } from '${STENCIL_CORE_ID}';\n`);
 
   if (isBrowser) {

--- a/packages/core/src/compiler/output-targets/dist-lazy/lazy-output.ts
+++ b/packages/core/src/compiler/output-targets/dist-lazy/lazy-output.ts
@@ -267,14 +267,7 @@ function createEntryModule(cmps: d.ComponentCompilerMeta[]): d.EntryModule {
 const getLazyEntry = (isBrowser: boolean, assetPath?: string, externalRuntime = false): string => {
   const s = new MagicString(``);
   const platformExports = ['setNonce', 'setRegistry', 'setTagTransformer'];
-  // Exported (when there's a path to override) on both builds, same as setTagTransformer.
-  // External build: defineCustomElements() is only invoked whenever the consumer calls it,
-  // well after import, so there's no race at all. Browser build: a static import fully
-  // evaluates this module - including the default setAssetPath call, which runs before the
-  // IIFE's first `await` below - before the importing script's own top-level code runs;
-  // bootstrapLazy() only resumes after that `await`, i.e. at least one microtask later. Either
-  // way, a consumer's own `import { setAssetPath } from '.../index.esm.js'; setAssetPath(...);`
-  // reliably lands before it's needed - exactly like the documented setTagTransformer usage.
+  // Exported (when there's a path to override) on both builds
   if (assetPath) {
     platformExports.push('setAssetPath');
   }

--- a/packages/core/src/compiler/output-targets/standalone/_test_/standalone.spec.ts
+++ b/packages/core/src/compiler/output-targets/standalone/_test_/standalone.spec.ts
@@ -4,7 +4,7 @@ import type * as d from '@stencil/core';
 
 import { mockValidatedConfig } from '../../../../testing';
 import { mockBuildCtx, mockCompilerCtx } from '../../../../testing/compiler';
-import { STANDALONE } from '../../../../utils';
+import { ASSETS, STANDALONE } from '../../../../utils';
 import { BundleOptions } from '../../../bundle/bundle-interface';
 import * as bundleOutputMod from '../../../bundle/bundle-output';
 import * as optimizeModuleMod from '../../../optimize/optimize-module';
@@ -66,6 +66,58 @@ describe('standalone', () => {
     expect(bundleOpts.loader['\x00core']).toContain(
       `export { MyTag, defineCustomElement as defineCustomElementMyTag } from '\x00MyTag';\n`,
     );
+  });
+
+  describe('asset path', () => {
+    it('exports setAssetPath so a consuming bundler can override the default when components have assets', () => {
+      const cmpMeta = stubComponentCompilerMeta({
+        assetsDirs: [
+          {
+            absolutePath: '/src/assets',
+            cmpRelativePath: 'assets',
+            originalComponentPath: 'assets',
+          },
+        ],
+      });
+      const config = mockValidatedConfig({
+        outputTargets: [{ type: ASSETS, dir: '/dist/assets' }],
+      });
+      const buildCtx = mockBuildCtx(config);
+      buildCtx.components = [cmpMeta];
+      const bundleOpts: BundleOptions = {
+        id: 'customElements',
+        platform: 'client',
+        inputs: {},
+        loader: {},
+      };
+      const outputTarget: d.OutputTargetStandalone = {
+        type: STANDALONE,
+        dir: '/dist/standalone',
+        customElementsExportBehavior: 'single-export-module',
+      };
+      addStandaloneInputs(config, buildCtx, bundleOpts, outputTarget);
+      expect(bundleOpts.loader['\x00core']).toContain('export { setAssetPath };');
+    });
+
+    it('does not export setAssetPath when no components have assets', () => {
+      const cmpMeta = stubComponentCompilerMeta({ assetsDirs: [] });
+      const config = mockValidatedConfig();
+      const buildCtx = mockBuildCtx(config);
+      buildCtx.components = [cmpMeta];
+      const bundleOpts: BundleOptions = {
+        id: 'customElements',
+        platform: 'client',
+        inputs: {},
+        loader: {},
+      };
+      const outputTarget: d.OutputTargetStandalone = {
+        type: STANDALONE,
+        dir: '/dist/standalone',
+        customElementsExportBehavior: 'single-export-module',
+      };
+      addStandaloneInputs(config, buildCtx, bundleOpts, outputTarget);
+      expect(bundleOpts.loader['\x00core']).not.toContain('setAssetPath');
+    });
   });
 
   describe('minification', () => {

--- a/packages/core/src/compiler/output-targets/standalone/generate-loader-module.ts
+++ b/packages/core/src/compiler/output-targets/standalone/generate-loader-module.ts
@@ -31,12 +31,6 @@ export const generateLoaderModule = (
     )
     .join('\n');
 
-  // setAssetPath is re-exported so a consumer can override the default relative path, the
-  // same way setTagTransformer already works: `start()` (if autoStart) only kicks off async
-  // work (dynamic per-tag imports, then component upgrade/render, where assets actually get
-  // resolved), so a static `import { setAssetPath } from '.../loader.js'; setAssetPath(...);`
-  // reliably lands before any of that - whether the importer is a bundler or a raw
-  // <script type="module"> tag.
   const assetPathImport = relativeAssetPath
     ? `import { setAssetPath } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';\nexport { setAssetPath };\n`
     : '';

--- a/packages/core/src/compiler/output-targets/standalone/generate-loader-module.ts
+++ b/packages/core/src/compiler/output-targets/standalone/generate-loader-module.ts
@@ -31,8 +31,14 @@ export const generateLoaderModule = (
     )
     .join('\n');
 
+  // setAssetPath is re-exported so a consumer can override the default relative path, the
+  // same way setTagTransformer already works: `start()` (if autoStart) only kicks off async
+  // work (dynamic per-tag imports, then component upgrade/render, where assets actually get
+  // resolved), so a static `import { setAssetPath } from '.../loader.js'; setAssetPath(...);`
+  // reliably lands before any of that - whether the importer is a bundler or a raw
+  // <script type="module"> tag.
   const assetPathImport = relativeAssetPath
-    ? `import { setAssetPath } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';\n`
+    ? `import { setAssetPath } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';\nexport { setAssetPath };\n`
     : '';
   const assetPathInit = relativeAssetPath
     ? `setAssetPath(new URL('${relativeAssetPath}', String(import.meta.url)).href);\n`

--- a/packages/core/src/compiler/output-targets/standalone/index.ts
+++ b/packages/core/src/compiler/output-targets/standalone/index.ts
@@ -363,11 +363,13 @@ export const generateEntryPoint = (
     `export * from '${USER_INDEX_ENTRY_ID}';`,
   );
 
-  // Auto-configure asset path if components use assets
+  // Auto-configure asset path if components use assets. Also export setAssetPath so a
+  // consuming bundler can override the default if it relocates the assets elsewhere.
   if (relativeAssetPath) {
     imports.push(
       `import { setAssetPath } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';`,
     );
+    exports.push(`export { setAssetPath };`);
     // Use import.meta.url for runtime resolution that works regardless of where bundle is hosted
     body.push(`setAssetPath(new URL('${relativeAssetPath}', import.meta.url).href);`);
   }

--- a/packages/core/src/compiler/output-targets/standalone/standalone-types.ts
+++ b/packages/core/src/compiler/output-targets/standalone/standalone-types.ts
@@ -159,7 +159,12 @@ const generateStandaloneTypesOutput = async (
         ? outputTarget.autoLoader.fileName || 'loader'
         : 'loader';
     const loaderDtsPath = join(outputTarget.dir!, `${loaderFileName}.d.ts`);
-    const loaderDtsCode = generateLoaderType();
+    // matches the hasComponentsWithAssets check in addStandaloneInputs, which decides
+    // whether setAssetPath is actually exported from the generated loader module
+    const hasAssets = buildCtx.components.some(
+      (cmp) => cmp.assetsDirs != null && cmp.assetsDirs.length > 0,
+    );
+    const loaderDtsCode = generateLoaderType(hasAssets);
     await compilerCtx.fs.writeFile(loaderDtsPath, loaderDtsCode, {
       outputTargetType: outputTarget.type,
     });
@@ -168,9 +173,10 @@ const generateStandaloneTypesOutput = async (
 
 /**
  * Generate a type declaration file for the auto-loader module
+ * @param hasAssets whether any component declares assets, matching whether setAssetPath is actually exported
  * @returns the contents of the type declaration file for the loader
  */
-const generateLoaderType = (): string => {
+const generateLoaderType = (hasAssets: boolean): string => {
   return [
     `/**`,
     ` * Start the auto-loader, scanning the DOM and watching for changes.`,
@@ -185,6 +191,19 @@ const generateLoaderType = (): string => {
     ` */`,
     `export declare function stop(): void;`,
     ``,
+    ...(hasAssets
+      ? [
+          `/**`,
+          ` * Used to manually set the base path where component assets can be found. The`,
+          ` * default is relative to this module's own location, which may not hold once a`,
+          ` * consuming bundler relocates it - call this before start() to override.`,
+          ` * @param path the asset path to set`,
+          ` * @returns the set path`,
+          ` */`,
+          `export declare function setAssetPath(path: string): string;`,
+          ``,
+        ]
+      : []),
   ].join('\n');
 };
 

--- a/packages/core/src/compiler/types/generate-types.ts
+++ b/packages/core/src/compiler/types/generate-types.ts
@@ -76,8 +76,7 @@ const generateTypesOutput = async (
   }
 
   // setAssetPath is only exported from the generated bundles when at least one
-  // component declares assets - mirrors the runtime codegen in lazy-output.ts
-  // and standalone/index.ts, so the types stay in sync with what's actually exported.
+  // component declares assets
   const hasAssets = buildCtx.components.some(
     (cmp) => cmp.assetsDirs != null && cmp.assetsDirs.length > 0,
   );

--- a/packages/core/src/compiler/types/generate-types.ts
+++ b/packages/core/src/compiler/types/generate-types.ts
@@ -75,16 +75,23 @@ const generateTypesOutput = async (
     await generateStandaloneTypes(config, compilerCtx, buildCtx, typesDir);
   }
 
+  // setAssetPath is only exported from the generated bundles when at least one
+  // component declares assets - mirrors the runtime codegen in lazy-output.ts
+  // and standalone/index.ts, so the types stay in sync with what's actually exported.
+  const hasAssets = buildCtx.components.some(
+    (cmp) => cmp.assetsDirs != null && cmp.assetsDirs.length > 0,
+  );
+
   // Generate loader.d.ts if loader-bundle output target exists
   const hasLoaderBundle = config.outputTargets.some(isOutputTargetLoaderBundle);
   if (hasLoaderBundle) {
-    await generateLoaderTypes(compilerCtx, typesDir);
+    await generateLoaderTypes(compilerCtx, typesDir, hasAssets);
   }
 
   // Generate standalone.d.ts if standalone output target exists
   const hasStandalone = config.outputTargets.some(isOutputTargetStandalone);
   if (hasStandalone) {
-    await generateStandaloneApiTypes(compilerCtx, typesDir);
+    await generateStandaloneApiTypes(compilerCtx, typesDir, hasAssets);
   }
 };
 
@@ -94,8 +101,13 @@ const generateTypesOutput = async (
  *
  * @param compilerCtx the current compiler context
  * @param typesDir the directory to write the loader.d.ts file to
+ * @param hasAssets whether any component declares assets, matching whether setAssetPath is actually exported
  */
-const generateLoaderTypes = async (compilerCtx: d.CompilerCtx, typesDir: string): Promise<void> => {
+const generateLoaderTypes = async (
+  compilerCtx: d.CompilerCtx,
+  typesDir: string,
+  hasAssets: boolean,
+): Promise<void> => {
   const loaderDtsContent = `export * from './components';
 export interface CustomElementsDefineOptions {
   exclude?: string[];
@@ -131,7 +143,21 @@ export type TagTransformer = (tag: string) => string;
  * Useful for namespacing (e.g. \`my-button\` → \`acme-button\`) in multi-library pages.
  */
 export declare function setTagTransformer(transformer: TagTransformer): void;
-`;
+${
+  hasAssets
+    ? `
+/**
+ * Used to manually set the base path where component assets can be found. The
+ * default is relative to this module's own location, which may not hold once a
+ * bundler relocates it, or once its CDN URL diverges from the assets' own -
+ * import and call this before the module's default has been used to override it.
+ * @param path the asset path to set
+ * @returns the set path
+ */
+export declare function setAssetPath(path: string): string;
+`
+    : ''
+}`;
 
   const loaderDtsPath = join(typesDir, 'loader.d.ts');
   await compilerCtx.fs.writeFile(loaderDtsPath, loaderDtsContent);
@@ -143,10 +169,12 @@ export declare function setTagTransformer(transformer: TagTransformer): void;
  *
  * @param compilerCtx the current compiler context
  * @param typesDir the directory to write the standalone.d.ts file to
+ * @param hasAssets whether any component declares assets, matching whether setAssetPath is actually exported
  */
 const generateStandaloneApiTypes = async (
   compilerCtx: d.CompilerCtx,
   typesDir: string,
+  hasAssets: boolean,
 ): Promise<void> => {
   const standaloneDtsContent = `/**
  * Used to specify a nonce value that corresponds with an application's CSP.
@@ -180,7 +208,20 @@ export interface SetPlatformOptions {
   rel?: (el: EventTarget, eventName: string, listener: EventListenerOrEventListenerObject, options: boolean | AddEventListenerOptions) => void;
 }
 export declare const setPlatformOptions: (opts: SetPlatformOptions) => void;
-`;
+${
+  hasAssets
+    ? `
+/**
+ * Used to manually set the base path where component assets can be found. The
+ * default is relative to this module's own location, which may not hold once a
+ * consuming bundler relocates it - call this before any component module is imported to override.
+ * @param path the asset path to set
+ * @returns the set path
+ */
+export declare const setAssetPath: (path: string) => string;
+`
+    : ''
+}`;
 
   const standaloneDtsPath = join(typesDir, 'standalone.d.ts');
   await compilerCtx.fs.writeFile(standaloneDtsPath, standaloneDtsContent);

--- a/test/special-config/assets-global-style/package.json
+++ b/test/special-config/assets-global-style/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.1",
   "private": true,
   "description": "Tests explicit assets and global-style output target configurations",
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "module": "dist/loader-bundle/index.js",
   "types": "dist/types/loader.d.ts",


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
