### PR TITLE
fix(compiler): v5 standalone output; each component calls `setAssetPath` and exports it

### DIFF
--- a/packages/core/src/compiler/output-targets/standalone/_test_/standalone.spec.ts
+++ b/packages/core/src/compiler/output-targets/standalone/_test_/standalone.spec.ts
@@ -7,6 +7,7 @@ import { mockBuildCtx, mockCompilerCtx } from '../../../../testing/compiler';
 import { ASSETS, STANDALONE } from '../../../../utils';
 import { BundleOptions } from '../../../bundle/bundle-interface';
 import * as bundleOutputMod from '../../../bundle/bundle-output';
+import { STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID } from '../../../bundle/entry-alias-ids';
 import * as optimizeModuleMod from '../../../optimize/optimize-module';
 import { stubComponentCompilerMeta } from '../../../types/_tests_/ComponentCompilerMeta.stub';
 import { addStandaloneInputs, bundleStandalone } from '../index';
@@ -99,6 +100,40 @@ describe('standalone', () => {
       expect(bundleOpts.loader['\x00core']).toContain('export { setAssetPath };');
     });
 
+    it('is also exported and called from each per-component chunk, not just the aggregate index - the `default` export behavior (tree-shakable subpath imports) never touches the aggregate index at all', () => {
+      const cmpMeta = stubComponentCompilerMeta({
+        assetsDirs: [
+          {
+            absolutePath: '/src/assets',
+            cmpRelativePath: 'assets',
+            originalComponentPath: 'assets',
+          },
+        ],
+      });
+      const config = mockValidatedConfig({
+        outputTargets: [{ type: ASSETS, dir: '/dist/assets' }],
+      });
+      const buildCtx = mockBuildCtx(config);
+      buildCtx.components = [cmpMeta];
+      const bundleOpts: BundleOptions = {
+        id: 'customElements',
+        platform: 'client',
+        inputs: {},
+        loader: {},
+      };
+      const outputTarget: d.OutputTargetStandalone = {
+        type: STANDALONE,
+        dir: '/dist/standalone',
+      };
+      addStandaloneInputs(config, buildCtx, bundleOpts, outputTarget);
+      const perComponentChunk = bundleOpts.loader['\x00StubCmp'];
+      expect(perComponentChunk).toContain(
+        `import { setAssetPath } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';`,
+      );
+      expect(perComponentChunk).toContain('export { setAssetPath };');
+      expect(perComponentChunk).toContain(`setAssetPath(new URL(`);
+    });
+
     it('does not export setAssetPath when no components have assets', () => {
       const cmpMeta = stubComponentCompilerMeta({ assetsDirs: [] });
       const config = mockValidatedConfig();
@@ -117,6 +152,7 @@ describe('standalone', () => {
       };
       addStandaloneInputs(config, buildCtx, bundleOpts, outputTarget);
       expect(bundleOpts.loader['\x00core']).not.toContain('setAssetPath');
+      expect(bundleOpts.loader['\x00StubCmp']).not.toContain('setAssetPath');
     });
   });
 

--- a/packages/core/src/compiler/output-targets/standalone/index.ts
+++ b/packages/core/src/compiler/output-targets/standalone/index.ts
@@ -262,12 +262,38 @@ export const addStandaloneInputs = (
   // function on the `bundle` export behavior option
   const exportNames: string[] = [];
 
+  // Compute relative path from standalone dir to assets dir if components have assets. Computed
+  // up front (rather than after the loop below) because it's also injected into every individual
+  // per-component chunk
+  let relativeAssetPath: string | undefined;
+  const hasComponentsWithAssets = components.some(
+    (cmp) => cmp.assetsDirs != null && cmp.assetsDirs.length > 0,
+  );
+  if (hasComponentsWithAssets) {
+    const assetsTarget = config.outputTargets.find(isOutputTargetAssets);
+    if (assetsTarget?.dir && outputTarget.dir) {
+      // Compute relative path and ensure it ends with '/'
+      const rel = relative(outputTarget.dir, assetsTarget.dir);
+      relativeAssetPath = rel.endsWith('/') ? rel : rel + '/';
+    }
+  }
+
   components.forEach((cmp) => {
     const exp: string[] = [];
     const exportName = dashToPascalCase(cmp.tagName);
     const importName = cmp.componentClassName;
     const importAs = `$Cmp${exportName}`;
     const coreKey = `\0${exportName}`;
+
+    // All per-component chunks are written flat into the same directory as '\0core' (see
+    // `entryFileNames`/`chunkFileNames` in `bundleStandalone`), so the same relative path works
+    // from any of them. Exported too, so a consumer who only ever imports this subpath can still
+    // override the default without also having to import the aggregate index.
+    if (relativeAssetPath) {
+      exp.push(`import { setAssetPath } from '${STENCIL_INTERNAL_STANDALONE_CLIENT_PLATFORM_ID}';`);
+      exp.push(`export { setAssetPath };`);
+      exp.push(`setAssetPath(new URL('${relativeAssetPath}', import.meta.url).href);`);
+    }
 
     if (cmp.isPlain) {
       exp.push(`export { ${importName} as ${exportName} } from '${cmp.sourceFilePath}';`);
@@ -297,20 +323,6 @@ export const addStandaloneInputs = (
     bundleOpts.inputs[cmp.tagName] = coreKey;
     bundleOpts.loader![coreKey] = exp.join('\n');
   });
-
-  // Compute relative path from standalone dir to assets dir if components have assets
-  let relativeAssetPath: string | undefined;
-  const hasComponentsWithAssets = components.some(
-    (cmp) => cmp.assetsDirs != null && cmp.assetsDirs.length > 0,
-  );
-  if (hasComponentsWithAssets) {
-    const assetsTarget = config.outputTargets.find(isOutputTargetAssets);
-    if (assetsTarget?.dir && outputTarget.dir) {
-      // Compute relative path and ensure it ends with '/'
-      const rel = relative(outputTarget.dir, assetsTarget.dir);
-      relativeAssetPath = rel.endsWith('/') ? rel : rel + '/';
-    }
-  }
 
   // Generate the contents of the entry file to be created by the bundler
   bundleOpts.loader!['\0core'] = generateEntryPoint(


### PR DESCRIPTION


<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->



## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
