### PR TITLE
fix(jsx): add ReadonlySignal to prop type union

### DIFF
--- a/V5_PLANNING.md
+++ b/V5_PLANNING.md
@@ -576,6 +576,9 @@ pnpm run dev       # Watch mode
 ## ⚡ Signals - "make default" consideration
 - [ ] Evaluate adoption/feedback
 - [ ] If stable and popular: flip `signalBacking` default to `true`, deprecate old Map path, remove in next major
+- [x] JSX prop types now accept `ReadonlySignal<T>` when `signalBacking` is on (stenciljs/core#6875) - `compiler/types/generate-component-types.ts`
+- [ ] Doc gap (stenciljs/core#6875): the JSX signal bypass only fires when the literal signal reference is the vdom child/attribute value (`h()`/`setAccessor()`'s `isSignalLike()` checks) - `.value` reads in `render()`, including implicit ones (`count % 2`, template literals), are untracked and will not re-render. Documented in `packages/core/src/signals/readme.md`; **stenciljs/site still needs the equivalent public docs update** - not done here, that repo isn't checked out locally.
+- [ ] Considered (not pursued): wrapping `instance.render()` in an `effect()` so any `.value` read during render is tracked, closing the gap above generally. Mechanically works (traced the exact call site in `update-component.ts`), but it's a third reactivity channel alongside the @Prop/@State→scheduleUpdate effects and the vdom bypass, reintroduces Solid-style fine-grained re-render that the bypass was built to avoid paying for, and has real edges (state written during render → signals-core cycle detection, double-scheduling with existing per-prop effects, the SSR async render path). Revisit only as a deliberate feature proposal, not as a fix for #6875.
 
 ---
 

--- a/packages/core/src/compiler/types/_tests_/generate-component-types.spec.ts
+++ b/packages/core/src/compiler/types/_tests_/generate-component-types.spec.ts
@@ -405,4 +405,62 @@ describe('generateComponentTypes', () => {
       expect(result.element).toContain('"_internal"');
     });
   });
+
+  describe('JSX prop types with signalBacking', () => {
+    it('unions JSX prop types with ReadonlySignal<T> when signalBacking is true', () => {
+      const cmpMeta: ComponentCompilerMeta = {
+        ...stubComponentCompilerMeta(),
+        tagName: 'my-counter',
+        properties: [
+          {
+            ...stubComponentCompilerProperty(),
+            name: 'count',
+            type: 'number',
+            complexType: { original: 'number', resolved: 'number', references: {} },
+          },
+          {
+            ...stubComponentCompilerProperty(),
+            name: 'label',
+            type: 'string',
+            complexType: { original: 'string', resolved: 'string', references: {} },
+          },
+        ],
+      };
+
+      const result = generateComponentTypes(cmpMeta, {}, false, true);
+      expect(result.jsx).toContain('"count"?: number | ReadonlySignal<number>;');
+      expect(result.jsx).toContain('"label"?: string | ReadonlySignal<string>;');
+    });
+
+    it('leaves JSX prop types alone when signalBacking is false', () => {
+      const cmpMeta: ComponentCompilerMeta = {
+        ...stubComponentCompilerMeta(),
+        tagName: 'my-counter',
+        properties: [
+          {
+            ...stubComponentCompilerProperty(),
+            name: 'count',
+            type: 'number',
+            complexType: { original: 'number', resolved: 'number', references: {} },
+          },
+        ],
+      };
+
+      const result = generateComponentTypes(cmpMeta, {}, false, false);
+      expect(result.jsx).toContain('"count"?: number;');
+      expect(result.jsx).not.toContain('ReadonlySignal');
+    });
+
+    it('does not union event or form-associated attribute types', () => {
+      const cmpMeta: ComponentCompilerMeta = {
+        ...stubComponentCompilerMeta(),
+        tagName: 'my-input',
+        formAssociated: true,
+      };
+
+      const result = generateComponentTypes(cmpMeta, {}, false, true);
+      expect(result.jsx).toContain('"disabled"?: boolean;');
+      expect(result.jsx).not.toContain('"disabled"?: boolean | ReadonlySignal');
+    });
+  });
 });

--- a/packages/core/src/compiler/types/generate-component-types.ts
+++ b/packages/core/src/compiler/types/generate-component-types.ts
@@ -43,7 +43,7 @@ const FORM_ASSOCIATED_ATTRIBUTES: d.TypeInfo = [
  * @param cmp the metadata for the component that a type definition string is generated for
  * @param typeImportData locally/imported/globally used type names, which may be used to prevent naming collisions
  * @param areTypesInternal `true` if types being generated are for a project's internal purposes, `false` otherwise
- * @param signalBacking `true` if the component is using signal backing for its props; includes the signals map on the element interface
+ * @param signalBacking `true` if the component is using signal backing for its props; includes the signals map on the element interface and unions JSX prop types with `ReadonlySignal<T>`
  * @returns the generated types string alongside additional metadata
  */
 export const generateComponentTypes = (
@@ -81,8 +81,18 @@ export const generateComponentTypes = (
     ? FORM_ASSOCIATED_ATTRIBUTES.filter((attr) => !propNames.has(attr.name))
     : [];
 
+  // In signal-backed builds, the runtime accepts a `ReadonlySignal<T>` anywhere a JSX prop
+  // expects `T` (see `isSignalLike` in `set-accessor.ts`) - DOM updates then bypass the vdom
+  // diff entirely. Union it into the JSX prop types so that pattern type-checks.
+  const jsxPropAttributes = signalBacking
+    ? propAttributes.map((attr) => ({
+        ...attr,
+        type: `${attr.type} | ReadonlySignal<${attr.type}>`,
+      }))
+    : propAttributes;
+
   const jsxAttributes = attributesToMultiLineString(
-    [...propAttributes, ...eventAttributes, ...formAssociatedAttrs],
+    [...jsxPropAttributes, ...eventAttributes, ...formAssociatedAttrs],
     true,
     areTypesInternal,
   );

--- a/packages/core/src/runtime/_test_/signal-vdom.spec.tsx
+++ b/packages/core/src/runtime/_test_/signal-vdom.spec.tsx
@@ -1,5 +1,5 @@
 import { signal } from '@preact/signals-core';
-import { Component, h, State } from '@stencil/core';
+import { Component, h, Prop, State } from '@stencil/core';
 import { expect, describe, it } from '@stencil/vitest';
 
 import { newSpecPage } from '../../testing';
@@ -47,6 +47,95 @@ describe('vdom signal bypass - text children', () => {
     expect(root.querySelector('span').textContent).toBe('42');
     // Component render() was NOT called again
     expect(renderCount).toBe(0);
+  });
+
+  it('wires up live tracking when a position switches from a plain value to a signal on a later render', async () => {
+    const count = signal(1);
+
+    @Component({ tag: 'cmp-a' })
+    class CmpA {
+      @Prop() useSignal = false;
+      render() {
+        return <span>{this.useSignal ? count : 'static'}</span>;
+      }
+    }
+
+    const { root, waitForChanges } = await newSpecPage({
+      ...VDOM,
+      components: [CmpA],
+      html: `<cmp-a></cmp-a>`,
+    });
+    expect(root.querySelector('span').textContent).toBe('static');
+
+    (root as any).useSignal = true;
+    await waitForChanges();
+    expect(root.querySelector('span').textContent).toBe('1');
+
+    // the text node already existed before the signal showed up - this is the
+    // case createElm's wiring alone can't handle, patch() must pick it up too
+    count.value = 42;
+    expect(root.querySelector('span').textContent).toBe('42');
+  });
+
+  it('re-subscribes when a signal-backed position switches to a different signal', async () => {
+    const first = signal('first');
+    const second = signal('second');
+
+    @Component({ tag: 'cmp-a' })
+    class CmpA {
+      @Prop() useSecond = false;
+      render() {
+        return <span>{this.useSecond ? second : first}</span>;
+      }
+    }
+
+    const { root, waitForChanges } = await newSpecPage({
+      ...VDOM,
+      components: [CmpA],
+      html: `<cmp-a></cmp-a>`,
+    });
+    expect(root.querySelector('span').textContent).toBe('first');
+
+    (root as any).useSecond = true;
+    await waitForChanges();
+    expect(root.querySelector('span').textContent).toBe('second');
+
+    // the old subscription (to `first`) must have been torn down - changing it
+    // should no longer affect this node
+    first.value = 'changed-first';
+    expect(root.querySelector('span').textContent).toBe('second');
+
+    // the new subscription (to `second`) must be live
+    second.value = 'changed-second';
+    expect(root.querySelector('span').textContent).toBe('changed-second');
+  });
+
+  it('tears down the subscription when a signal-backed position reverts to a plain value', async () => {
+    const count = signal(1);
+
+    @Component({ tag: 'cmp-a' })
+    class CmpA {
+      @Prop() useSignal = true;
+      render() {
+        return <span>{this.useSignal ? count : 'static'}</span>;
+      }
+    }
+
+    const { root, waitForChanges } = await newSpecPage({
+      ...VDOM,
+      components: [CmpA],
+      html: `<cmp-a></cmp-a>`,
+    });
+    expect(root.querySelector('span').textContent).toBe('1');
+
+    (root as any).useSignal = false;
+    await waitForChanges();
+    expect(root.querySelector('span').textContent).toBe('static');
+
+    // the old subscription must be disposed - changing the signal now should
+    // not reach back into this (now unrelated) text node
+    count.value = 99;
+    expect(root.querySelector('span').textContent).toBe('static');
   });
 
   it('handles multiple signal text children independently', async () => {

--- a/packages/core/src/runtime/vdom/vdom-render.ts
+++ b/packages/core/src/runtime/vdom/vdom-render.ts
@@ -28,6 +28,7 @@ import {
 import { h, isHost, newVNode as createVNode } from './h';
 import { disposeAllSignalAttrs } from './set-accessor';
 import { updateElement } from './update-element';
+import type { SignalLike } from '../signals';
 
 let scopeId: string;
 let contentRef: d.RenderNode | undefined;
@@ -51,14 +52,36 @@ const signalNodeDisposers = new WeakMap<Node, () => void>();
 const disposeSignalVNode = (vnode: d.VNode) => {
   const elm = vnode.$elm$;
   if (elm) {
-    const dispose = signalNodeDisposers.get(elm);
-    if (dispose) {
-      dispose();
-      signalNodeDisposers.delete(elm);
-    }
+    disposeTextSignal(elm);
     disposeAllSignalAttrs(elm);
   }
   vnode.$children$?.forEach(disposeSignalVNode);
+};
+
+/**
+ * Tear down a text node's signal subscription, if it has one.
+ * @param textNode the text node to unsubscribe
+ */
+const disposeTextSignal = (textNode: Node) => {
+  const dispose = signalNodeDisposers.get(textNode);
+  if (dispose) {
+    dispose();
+    signalNodeDisposers.delete(textNode);
+  }
+};
+
+/**
+ * Subscribe a text node to a signal, keeping its `data` in sync on every change.
+ * @param textNode the text node to keep in sync
+ * @param textSig the signal to subscribe to
+ */
+const wireTextSignal = (textNode: Node, textSig: SignalLike) => {
+  signalNodeDisposers.set(
+    textNode,
+    effect(() => {
+      (textNode as unknown as Text).data = String(textSig.value);
+    }),
+  );
 };
 
 /**
@@ -109,14 +132,7 @@ const createElm = (oldParentVNode: d.VNode, newParentVNode: d.VNode, childIndex:
     // create text node
     elm = newVNode.$elm$ = win.document.createTextNode(newVNode.$text$) as any;
     if (BUILD.vdomSignals && newVNode.$signal$) {
-      const textSig = newVNode.$signal$;
-      const textNode = elm;
-      signalNodeDisposers.set(
-        textNode,
-        effect(() => {
-          (textNode as unknown as Text).data = String(textSig.value);
-        }),
-      );
+      wireTextSignal(elm, newVNode.$signal$);
     }
   } else if (BUILD.slotRelocation && newVNode.$flags$ & VNODE_FLAGS.isSlotReference) {
     // create a slot reference node
@@ -827,10 +843,29 @@ export const patch = (oldVNode: d.VNode, newVNode: d.VNode, isInitialRender = fa
   } else if (BUILD.vdomText && BUILD.slotRelocation && (defaultHolder = elm['s-cr'] as any)) {
     // this element has slotted content
     defaultHolder.parentNode.textContent = text;
-  } else if (BUILD.vdomText && oldVNode.$text$ !== text) {
-    // update the text content for the text only vnode
-    // and also only if the text is different than before
-    elm.data = text;
+  } else if (BUILD.vdomText) {
+    if (BUILD.vdomSignals && newVNode.$signal$) {
+      if (newVNode.$signal$ !== oldVNode.$signal$) {
+        // the signal reference is new (this position wasn't signal-backed before, or it
+        // held a different signal) - tear down any previous subscription and wire a fresh
+        // one. `createElm` only wires this up for brand-new text nodes, so a position that
+        // switches from a plain value (or a different signal) to this signal on a later
+        // render would otherwise silently stop updating.
+        disposeTextSignal(elm);
+        wireTextSignal(elm, newVNode.$signal$);
+      }
+      // same signal as last render - its own effect already keeps `elm.data` in sync
+    } else {
+      if (BUILD.vdomSignals && oldVNode.$signal$) {
+        // was signal-backed, no longer is - tear down the subscription
+        disposeTextSignal(elm);
+      }
+      if (oldVNode.$text$ !== text) {
+        // update the text content for the text only vnode
+        // and also only if the text is different than before
+        elm.data = text;
+      }
+    }
   }
 };
 

--- a/packages/core/src/signals/readme.md
+++ b/packages/core/src/signals/readme.md
@@ -18,3 +18,41 @@ With `extras.signalBacking: true` in `stencil.config.ts`, `@Prop` and `@State` m
 ## Relationship to `runtime/signals.ts`
 
 This directory is the public surface; `../runtime/signals.ts` has the internal implementation that wires `@Prop`/`@State` proxying to actual signal instances.
+
+## The JSX bypass only fires at the literal vdom slot
+
+Placing a signal directly as a vdom child or attribute value skips `render()`/vdom-diffing entirely for that node - the runtime detects the signal via `isSignalLike()` at exactly two call sites (`h()` for children/`class`, `setAccessor()` for attributes/props) and subscribes an `effect()` that patches just that DOM node. Writes still go through `.value` as usual:
+
+```ts
+import { count } from './count'; // exported signal(0)
+
+@Component({ tag: 'my-counter' })
+export class MyCounter {
+  private increment = () => {
+    count.value = count.value + 1;
+  };
+
+  render() {
+    return <button onClick={this.increment}>{count}</button>;
+  }
+}
+```
+
+`{count}` - the bare signal - is what makes the bypass fire. `{count.value}` would render the current count once and then never update; the button's text would freeze after the first click, since Stencil would have no way of knowing `render()` needs to run again.
+
+For anything that needs a signal's value to affect *how* `render()` runs (branches, derived lists, computed strings), route it through `@State`:
+
+```ts
+@State() private isEven = false;
+
+@Effect()
+private syncIsEven() {
+  this.isEven = count.value % 2 === 0;
+}
+
+render() {
+  return this.isEven ? <a-thing /> : <empty-state />;
+}
+```
+
+`@State`/`@Prop` changes always trigger a normal, tracked re-render - `@Effect()` is the supported bridge between an external signal and Stencil's own re-render trigger.


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: https://github.com/stenciljs/core/issues/6875


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Adds docs around signal usage in jsx
- Adds `ReadonlySignal` to the LocalJSX prop union when `signalBacking: true`
- Fixed a bug where an incoming prop could mutate (plain text to signal and vice-versa) and lose reactivity in the patch process

Closes https://github.com/stenciljs/core/issues/6875

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
