### PR TITLE
fix(ssr): abort stuck component and in-flight fetch() on hydrate timeout

### DIFF
--- a/src/compiler/output-targets/dist-hydrate-script/hydrate-factory-closure.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/hydrate-factory-closure.ts
@@ -103,8 +103,30 @@ export function hydrateFactory($stencilWindow, $stencilHydrateOpts, $stencilHydr
 
   var fetch, FetchError, Headers, Request, Response;
 
+  // Aborted when the render times out or errors, so in-flight fetch() calls
+  // made by component code stop holding the render's window/results alive
+  // instead of running to completion against a torn-down window. See #6864.
+  var $stencilAbortController = new AbortController();
+
+  function $stencilFetchSignal(callerSignal) {
+    if (!callerSignal) {
+      return $stencilAbortController.signal;
+    }
+    if (callerSignal.aborted || $stencilAbortController.signal.aborted) {
+      return callerSignal.aborted ? callerSignal : $stencilAbortController.signal;
+    }
+    var merged = new AbortController();
+    var onAbort = function () { merged.abort(); };
+    callerSignal.addEventListener('abort', onAbort, { once: true });
+    $stencilAbortController.signal.addEventListener('abort', onAbort, { once: true });
+    return merged.signal;
+  }
+
   if (typeof $stencilWindow.fetch === 'function') {
-    fetch = $stencilWindow.fetch;
+    var $stencilRawFetch = $stencilWindow.fetch;
+    fetch = $stencilWindow.fetch = function(input, init) {
+      return $stencilRawFetch(input, Object.assign({}, init, { signal: $stencilFetchSignal(init && init.signal) }));
+    };
   } else {
     fetch = $stencilWindow.fetch = function() { throw new Error('fetch() is not implemented'); };
   }
@@ -141,7 +163,7 @@ export function hydrateFactory($stencilWindow, $stencilHydrateOpts, $stencilHydr
 
 export const HYDRATE_FACTORY_OUTRO = `
     /*hydrateAppClosure end*/
-    hydrateApp(window, $stencilHydrateOpts, $stencilHydrateResults, $stencilAfterHydrate, $stencilHydrateResolve);
+    hydrateApp(window, $stencilHydrateOpts, $stencilHydrateResults, $stencilAfterHydrate, $stencilHydrateResolve, $stencilAbortController);
   }
 
   hydrateAppClosure($stencilWindow);

--- a/src/compiler/output-targets/dist-hydrate-script/hydrate-factory-closure.ts
+++ b/src/compiler/output-targets/dist-hydrate-script/hydrate-factory-closure.ts
@@ -12,6 +12,10 @@ export const MODE_RESOLUTION_CHAIN_DECLARATION = `modeResolutionChain = [];`;
 export const HYDRATE_FACTORY_INTRO = `
 // const ${MODE_RESOLUTION_CHAIN_DECLARATION}
 
+// captured here, at true module scope, before hydrateFactory shadows the
+// AbortController identifier for component code below.
+var $stencilNativeAbortController = AbortController;
+
 export function hydrateFactory($stencilWindow, $stencilHydrateOpts, $stencilHydrateResults, $stencilAfterHydrate, $stencilHydrateResolve) {
   var globalThis = $stencilWindow;
   var self = $stencilWindow;
@@ -106,7 +110,23 @@ export function hydrateFactory($stencilWindow, $stencilHydrateOpts, $stencilHydr
   // Aborted when the render times out or errors, so in-flight fetch() calls
   // made by component code stop holding the render's window/results alive
   // instead of running to completion against a torn-down window. See #6864.
-  var $stencilAbortController = new AbortController();
+  var $stencilAbortController = new $stencilNativeAbortController();
+
+  // Any AbortController a component creates itself is transparently wired to
+  // cascade-abort when the render times out too, so component code using the
+  // standard AbortController convention for its own cancellable work (axios,
+  // aws-sdk v3, the mongodb driver, etc.) gets cancelled automatically. 
+  var AbortController = function () {
+    var controller = new $stencilNativeAbortController();
+    $stencilAbortController.signal.addEventListener(
+      'abort',
+      function () {
+        controller.abort();
+      },
+      { once: true },
+    );
+    return controller;
+  };
 
   function $stencilFetchSignal(callerSignal) {
     if (!callerSignal) {
@@ -115,7 +135,7 @@ export function hydrateFactory($stencilWindow, $stencilHydrateOpts, $stencilHydr
     if (callerSignal.aborted || $stencilAbortController.signal.aborted) {
       return callerSignal.aborted ? callerSignal : $stencilAbortController.signal;
     }
-    var merged = new AbortController();
+    var merged = new $stencilNativeAbortController();
     var onAbort = function () { merged.abort(); };
     callerSignal.addEventListener('abort', onAbort, { once: true });
     $stencilAbortController.signal.addEventListener('abort', onAbort, { once: true });

--- a/src/hydrate/platform/hydrate-app.ts
+++ b/src/hydrate/platform/hydrate-app.ts
@@ -17,6 +17,7 @@ export function hydrateApp(
     resolve: (results: d.HydrateResults) => void,
   ) => void,
   resolve: (results: d.HydrateResults) => void,
+  abortController: AbortController,
 ) {
   const connectedElements = new Set<any>();
   const createdElements = new Set<HTMLElement>();
@@ -28,6 +29,18 @@ export function hydrateApp(
 
   let tmrId: any;
   let ranCompleted = false;
+  // Resolves once the render is finalizing (error or timeout), so components
+  // still mid-`await` can stop waiting instead of resuming against a window
+  // that's about to be torn down, and so their own in-flight `fetch()` calls
+  // (wrapped in the hydrate factory closure) get aborted rather than running
+  // to completion against it. See #6864.
+  const abortedPromise = new Promise<void>((res) => {
+    if (abortController.signal.aborted) {
+      res();
+    } else {
+      abortController.signal.addEventListener('abort', () => res(), { once: true });
+    }
+  });
 
   function hydratedComplete() {
     globalThis.clearTimeout(tmrId);
@@ -55,6 +68,10 @@ export function hydrateApp(
 
   function hydratedError(err: any) {
     renderCatchError(opts, results, err);
+    // let any component still awaiting `componentOnReady()` bail out, and
+    // abort any of their in-flight `fetch()` calls, instead of resuming
+    // after `hydratedComplete` tears the window down.
+    abortController.abort();
     hydratedComplete();
   }
 
@@ -140,7 +157,7 @@ export function hydrateApp(
 
           // add it to our Set so we know it's already being connected
           connectedElements.add(elm);
-          return hydrateComponent.call(elm, win, results, elm.nodeName, elm, waitingElements);
+          return hydrateComponent.call(elm, win, results, elm.nodeName, elm, waitingElements, abortedPromise);
         }
       }
 
@@ -189,6 +206,7 @@ async function hydrateComponent(
   tagName: string,
   elm: d.HostElement,
   waitingElements: Set<HTMLElement>,
+  aborted: Promise<void>,
 ) {
   tagName = tagName.toLowerCase();
   const Cstr = loadModule(
@@ -212,19 +230,25 @@ async function hydrateComponent(
 
       try {
         connectedCallback(elm);
-        await elm.componentOnReady();
 
-        results.hydratedCount++;
+        // race `componentOnReady` against the render finishing: if the
+        // render times out first, stop waiting rather than resuming this
+        // continuation once the window has been destroyed (see #6864).
+        const wasAborted = await Promise.race([elm.componentOnReady().then(() => false), aborted.then(() => true)]);
 
-        const ref = getHostRef(elm);
-        const modeName = !ref?.$modeName$ ? '$' : ref?.$modeName$;
-        if (!results.components.some((c) => c.tag === tagName && c.mode === modeName)) {
-          results.components.push({
-            tag: tagName,
-            mode: modeName,
-            count: 0,
-            depth: -1,
-          });
+        if (!wasAborted) {
+          results.hydratedCount++;
+
+          const ref = getHostRef(elm);
+          const modeName = !ref?.$modeName$ ? '$' : ref?.$modeName$;
+          if (!results.components.some((c) => c.tag === tagName && c.mode === modeName)) {
+            results.components.push({
+              tag: tagName,
+              mode: modeName,
+              count: 0,
+              depth: -1,
+            });
+          }
         }
       } catch (e) {
         win.console.error(e);

--- a/src/mock-doc/window.ts
+++ b/src/mock-doc/window.ts
@@ -878,12 +878,16 @@ function resetWindow(win: MockWindow) {
       } catch (e) {}
     }
 
-    // ensure we don't hold onto nodeFetch values
-    (win as any).fetch = null;
-    (win as any).Headers = null;
-    (win as any).Request = null;
-    (win as any).Response = null;
-    (win as any).FetchError = null;
+    // ensure we don't hold onto nodeFetch values; fail loudly instead of a
+    // bare null-deref if anything still touches the window after this point
+    const windowDestroyed = () => {
+      throw new Error('MockWindow was already destroyed');
+    };
+    (win as any).fetch = windowDestroyed;
+    (win as any).Headers = windowDestroyed;
+    (win as any).Request = windowDestroyed;
+    (win as any).Response = windowDestroyed;
+    (win as any).FetchError = windowDestroyed;
   }
 }
 

--- a/test/end-to-end/custom-elements-manifest.json
+++ b/test/end-to-end/custom-elements-manifest.json
@@ -2281,6 +2281,55 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/hydrate-timeout/slow-fetch-cmp.tsx",
+      "declarations": [
+        {
+          "kind": "class",
+          "customElement": true,
+          "tagName": "slow-fetch-cmp",
+          "name": "SlowFetchCmp",
+          "description": "Used by hydrate-timeout.e2e.ts to reproduce stenciljs/core#6864: a\ncomponent whose `componentWillLoad` is still awaiting `fetch()` when the\nrender's `opts.timeout` fires.",
+          "attributes": [
+            {
+              "name": "url",
+              "type": {
+                "text": "string"
+              },
+              "fieldName": "url"
+            }
+          ],
+          "members": [
+            {
+              "kind": "field",
+              "name": "url",
+              "type": {
+                "text": "string"
+              },
+              "readonly": true,
+              "attribute": "url"
+            }
+          ]
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "SlowFetchCmp",
+          "declaration": {
+            "name": "SlowFetchCmp"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "slow-fetch-cmp",
+          "declaration": {
+            "name": "SlowFetchCmp"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/declarative-shadow-dom/ssr-shadow-cmp.tsx",
       "declarations": [
         {

--- a/test/end-to-end/custom-elements-manifest.json
+++ b/test/end-to-end/custom-elements-manifest.json
@@ -1611,7 +1611,7 @@
           "customElement": true,
           "tagName": "own-controller-cmp",
           "name": "OwnControllerCmp",
-          "description": "Used by hydrate-timeout.e2e.ts to verify the AbortController shim: a\ncomponent that creates its own AbortController has that controller cascade-aborted \nautomatically when the render times out\n\nThe outcome is reported via `global` (not observable through\nrenderToString's result) so the test can assert on it."
+          "description": "Used by hydrate-timeout.e2e.ts to verify the AbortController shim: a\ncomponent that creates its own AbortController has that controller cascade-aborted\nautomatically when the render times out\n\nThe outcome is reported via `global` (not observable through\nrenderToString's result) so the test can assert on it."
         }
       ],
       "exports": [

--- a/test/end-to-end/custom-elements-manifest.json
+++ b/test/end-to-end/custom-elements-manifest.json
@@ -1604,6 +1604,35 @@
     },
     {
       "kind": "javascript-module",
+      "path": "src/hydrate-timeout/own-controller-cmp.tsx",
+      "declarations": [
+        {
+          "kind": "class",
+          "customElement": true,
+          "tagName": "own-controller-cmp",
+          "name": "OwnControllerCmp",
+          "description": "Used by hydrate-timeout.e2e.ts to verify the AbortController shim: a\ncomponent that creates its own AbortController has that controller cascade-aborted \nautomatically when the render times out\n\nThe outcome is reported via `global` (not observable through\nrenderToString's result) so the test can assert on it."
+        }
+      ],
+      "exports": [
+        {
+          "kind": "js",
+          "name": "OwnControllerCmp",
+          "declaration": {
+            "name": "OwnControllerCmp"
+          }
+        },
+        {
+          "kind": "custom-element-definition",
+          "name": "own-controller-cmp",
+          "declaration": {
+            "name": "OwnControllerCmp"
+          }
+        }
+      ]
+    },
+    {
+      "kind": "javascript-module",
       "path": "src/path-alias-cmp/path-alias-cmp.tsx",
       "declarations": [
         {

--- a/test/end-to-end/src/components.d.ts
+++ b/test/end-to-end/src/components.d.ts
@@ -163,7 +163,7 @@ export namespace Components {
     }
     /**
      * Used by hydrate-timeout.e2e.ts to verify the AbortController shim: a
-     * component that creates its own AbortController has that controller cascade-aborted 
+     * component that creates its own AbortController has that controller cascade-aborted
      * automatically when the render times out
      * The outcome is reported via `global` (not observable through
      * renderToString's result) so the test can assert on it.
@@ -517,7 +517,7 @@ declare global {
     };
     /**
      * Used by hydrate-timeout.e2e.ts to verify the AbortController shim: a
-     * component that creates its own AbortController has that controller cascade-aborted 
+     * component that creates its own AbortController has that controller cascade-aborted
      * automatically when the render times out
      * The outcome is reported via `global` (not observable through
      * renderToString's result) so the test can assert on it.
@@ -842,7 +842,7 @@ declare namespace LocalJSX {
     }
     /**
      * Used by hydrate-timeout.e2e.ts to verify the AbortController shim: a
-     * component that creates its own AbortController has that controller cascade-aborted 
+     * component that creates its own AbortController has that controller cascade-aborted
      * automatically when the render times out
      * The outcome is reported via `global` (not observable through
      * renderToString's result) so the test can assert on it.
@@ -1084,7 +1084,7 @@ declare module "@stencil/core" {
             "non-shadow-wrapper": LocalJSX.IntrinsicElements["non-shadow-wrapper"] & JSXBase.HTMLAttributes<HTMLNonShadowWrapperElement>;
             /**
              * Used by hydrate-timeout.e2e.ts to verify the AbortController shim: a
-             * component that creates its own AbortController has that controller cascade-aborted 
+             * component that creates its own AbortController has that controller cascade-aborted
              * automatically when the render times out
              * The outcome is reported via `global` (not observable through
              * renderToString's result) so the test can assert on it.

--- a/test/end-to-end/src/components.d.ts
+++ b/test/end-to-end/src/components.d.ts
@@ -161,6 +161,15 @@ export namespace Components {
     }
     interface NonShadowWrapper {
     }
+    /**
+     * Used by hydrate-timeout.e2e.ts to verify the AbortController shim: a
+     * component that creates its own AbortController has that controller cascade-aborted 
+     * automatically when the render times out
+     * The outcome is reported via `global` (not observable through
+     * renderToString's result) so the test can assert on it.
+     */
+    interface OwnControllerCmp {
+    }
     interface PathAliasCmp {
     }
     interface PrerenderCmp {
@@ -506,6 +515,19 @@ declare global {
         prototype: HTMLNonShadowWrapperElement;
         new (): HTMLNonShadowWrapperElement;
     };
+    /**
+     * Used by hydrate-timeout.e2e.ts to verify the AbortController shim: a
+     * component that creates its own AbortController has that controller cascade-aborted 
+     * automatically when the render times out
+     * The outcome is reported via `global` (not observable through
+     * renderToString's result) so the test can assert on it.
+     */
+    interface HTMLOwnControllerCmpElement extends Components.OwnControllerCmp, HTMLStencilElement {
+    }
+    var HTMLOwnControllerCmpElement: {
+        prototype: HTMLOwnControllerCmpElement;
+        new (): HTMLOwnControllerCmpElement;
+    };
     interface HTMLPathAliasCmpElement extends Components.PathAliasCmp, HTMLStencilElement {
     }
     var HTMLPathAliasCmpElement: {
@@ -669,6 +691,7 @@ declare global {
         "non-shadow-forwarded-slot": HTMLNonShadowForwardedSlotElement;
         "non-shadow-multi-slots": HTMLNonShadowMultiSlotsElement;
         "non-shadow-wrapper": HTMLNonShadowWrapperElement;
+        "own-controller-cmp": HTMLOwnControllerCmpElement;
         "path-alias-cmp": HTMLPathAliasCmpElement;
         "prerender-cmp": HTMLPrerenderCmpElement;
         "prop-cmp": HTMLPropCmpElement;
@@ -816,6 +839,15 @@ declare namespace LocalJSX {
     interface NonShadowMultiSlots {
     }
     interface NonShadowWrapper {
+    }
+    /**
+     * Used by hydrate-timeout.e2e.ts to verify the AbortController shim: a
+     * component that creates its own AbortController has that controller cascade-aborted 
+     * automatically when the render times out
+     * The outcome is reported via `global` (not observable through
+     * renderToString's result) so the test can assert on it.
+     */
+    interface OwnControllerCmp {
     }
     interface PathAliasCmp {
     }
@@ -986,6 +1018,7 @@ declare namespace LocalJSX {
         "non-shadow-forwarded-slot": NonShadowForwardedSlot;
         "non-shadow-multi-slots": NonShadowMultiSlots;
         "non-shadow-wrapper": NonShadowWrapper;
+        "own-controller-cmp": OwnControllerCmp;
         "path-alias-cmp": PathAliasCmp;
         "prerender-cmp": PrerenderCmp;
         "prop-cmp": Omit<PropCmp, keyof PropCmpAttributes> & { [K in keyof PropCmp & keyof PropCmpAttributes]?: PropCmp[K] } & { [K in keyof PropCmp & keyof PropCmpAttributes as `attr:${K}`]?: PropCmpAttributes[K] } & { [K in keyof PropCmp & keyof PropCmpAttributes as `prop:${K}`]?: PropCmp[K] };
@@ -1049,6 +1082,14 @@ declare module "@stencil/core" {
             "non-shadow-forwarded-slot": LocalJSX.IntrinsicElements["non-shadow-forwarded-slot"] & JSXBase.HTMLAttributes<HTMLNonShadowForwardedSlotElement>;
             "non-shadow-multi-slots": LocalJSX.IntrinsicElements["non-shadow-multi-slots"] & JSXBase.HTMLAttributes<HTMLNonShadowMultiSlotsElement>;
             "non-shadow-wrapper": LocalJSX.IntrinsicElements["non-shadow-wrapper"] & JSXBase.HTMLAttributes<HTMLNonShadowWrapperElement>;
+            /**
+             * Used by hydrate-timeout.e2e.ts to verify the AbortController shim: a
+             * component that creates its own AbortController has that controller cascade-aborted 
+             * automatically when the render times out
+             * The outcome is reported via `global` (not observable through
+             * renderToString's result) so the test can assert on it.
+             */
+            "own-controller-cmp": LocalJSX.IntrinsicElements["own-controller-cmp"] & JSXBase.HTMLAttributes<HTMLOwnControllerCmpElement>;
             "path-alias-cmp": LocalJSX.IntrinsicElements["path-alias-cmp"] & JSXBase.HTMLAttributes<HTMLPathAliasCmpElement>;
             "prerender-cmp": LocalJSX.IntrinsicElements["prerender-cmp"] & JSXBase.HTMLAttributes<HTMLPrerenderCmpElement>;
             "prop-cmp": LocalJSX.IntrinsicElements["prop-cmp"] & JSXBase.HTMLAttributes<HTMLPropCmpElement>;

--- a/test/end-to-end/src/components.d.ts
+++ b/test/end-to-end/src/components.d.ts
@@ -217,6 +217,14 @@ export namespace Components {
     interface SlotParentCmp {
         "label": string;
     }
+    /**
+     * Used by hydrate-timeout.e2e.ts to reproduce stenciljs/core#6864: a
+     * component whose `componentWillLoad` is still awaiting `fetch()` when the
+     * render's `opts.timeout` fires.
+     */
+    interface SlowFetchCmp {
+        "url": string;
+    }
     interface SsrShadowCmp {
         "selected": boolean;
     }
@@ -596,6 +604,17 @@ declare global {
         prototype: HTMLSlotParentCmpElement;
         new (): HTMLSlotParentCmpElement;
     };
+    /**
+     * Used by hydrate-timeout.e2e.ts to reproduce stenciljs/core#6864: a
+     * component whose `componentWillLoad` is still awaiting `fetch()` when the
+     * render's `opts.timeout` fires.
+     */
+    interface HTMLSlowFetchCmpElement extends Components.SlowFetchCmp, HTMLStencilElement {
+    }
+    var HTMLSlowFetchCmpElement: {
+        prototype: HTMLSlowFetchCmpElement;
+        new (): HTMLSlowFetchCmpElement;
+    };
     interface HTMLSsrShadowCmpElement extends Components.SsrShadowCmp, HTMLStencilElement {
     }
     var HTMLSsrShadowCmpElement: {
@@ -662,6 +681,7 @@ declare global {
         "slot-cmp": HTMLSlotCmpElement;
         "slot-cmp-container": HTMLSlotCmpContainerElement;
         "slot-parent-cmp": HTMLSlotParentCmpElement;
+        "slow-fetch-cmp": HTMLSlowFetchCmpElement;
         "ssr-shadow-cmp": HTMLSsrShadowCmpElement;
         "state-cmp": HTMLStateCmpElement;
         "wrap-ssr-shadow-cmp": HTMLWrapSsrShadowCmpElement;
@@ -854,6 +874,14 @@ declare namespace LocalJSX {
     interface SlotParentCmp {
         "label"?: string;
     }
+    /**
+     * Used by hydrate-timeout.e2e.ts to reproduce stenciljs/core#6864: a
+     * component whose `componentWillLoad` is still awaiting `fetch()` when the
+     * render's `opts.timeout` fires.
+     */
+    interface SlowFetchCmp {
+        "url"?: string;
+    }
     interface SsrShadowCmp {
         "selected"?: boolean;
     }
@@ -912,6 +940,9 @@ declare namespace LocalJSX {
     interface SlotParentCmpAttributes {
         "label": string;
     }
+    interface SlowFetchCmpAttributes {
+        "url": string;
+    }
     interface SsrShadowCmpAttributes {
         "selected": boolean;
     }
@@ -967,6 +998,7 @@ declare namespace LocalJSX {
         "slot-cmp": SlotCmp;
         "slot-cmp-container": SlotCmpContainer;
         "slot-parent-cmp": Omit<SlotParentCmp, keyof SlotParentCmpAttributes> & { [K in keyof SlotParentCmp & keyof SlotParentCmpAttributes]?: SlotParentCmp[K] } & { [K in keyof SlotParentCmp & keyof SlotParentCmpAttributes as `attr:${K}`]?: SlotParentCmpAttributes[K] } & { [K in keyof SlotParentCmp & keyof SlotParentCmpAttributes as `prop:${K}`]?: SlotParentCmp[K] };
+        "slow-fetch-cmp": Omit<SlowFetchCmp, keyof SlowFetchCmpAttributes> & { [K in keyof SlowFetchCmp & keyof SlowFetchCmpAttributes]?: SlowFetchCmp[K] } & { [K in keyof SlowFetchCmp & keyof SlowFetchCmpAttributes as `attr:${K}`]?: SlowFetchCmpAttributes[K] } & { [K in keyof SlowFetchCmp & keyof SlowFetchCmpAttributes as `prop:${K}`]?: SlowFetchCmp[K] };
         "ssr-shadow-cmp": Omit<SsrShadowCmp, keyof SsrShadowCmpAttributes> & { [K in keyof SsrShadowCmp & keyof SsrShadowCmpAttributes]?: SsrShadowCmp[K] } & { [K in keyof SsrShadowCmp & keyof SsrShadowCmpAttributes as `attr:${K}`]?: SsrShadowCmpAttributes[K] } & { [K in keyof SsrShadowCmp & keyof SsrShadowCmpAttributes as `prop:${K}`]?: SsrShadowCmp[K] };
         "state-cmp": StateCmp;
         "wrap-ssr-shadow-cmp": Omit<WrapSsrShadowCmp, keyof WrapSsrShadowCmpAttributes> & { [K in keyof WrapSsrShadowCmp & keyof WrapSsrShadowCmpAttributes]?: WrapSsrShadowCmp[K] } & { [K in keyof WrapSsrShadowCmp & keyof WrapSsrShadowCmpAttributes as `attr:${K}`]?: WrapSsrShadowCmpAttributes[K] } & { [K in keyof WrapSsrShadowCmp & keyof WrapSsrShadowCmpAttributes as `prop:${K}`]?: WrapSsrShadowCmp[K] };
@@ -1032,6 +1064,12 @@ declare module "@stencil/core" {
             "slot-cmp": LocalJSX.IntrinsicElements["slot-cmp"] & JSXBase.HTMLAttributes<HTMLSlotCmpElement>;
             "slot-cmp-container": LocalJSX.IntrinsicElements["slot-cmp-container"] & JSXBase.HTMLAttributes<HTMLSlotCmpContainerElement>;
             "slot-parent-cmp": LocalJSX.IntrinsicElements["slot-parent-cmp"] & JSXBase.HTMLAttributes<HTMLSlotParentCmpElement>;
+            /**
+             * Used by hydrate-timeout.e2e.ts to reproduce stenciljs/core#6864: a
+             * component whose `componentWillLoad` is still awaiting `fetch()` when the
+             * render's `opts.timeout` fires.
+             */
+            "slow-fetch-cmp": LocalJSX.IntrinsicElements["slow-fetch-cmp"] & JSXBase.HTMLAttributes<HTMLSlowFetchCmpElement>;
             "ssr-shadow-cmp": LocalJSX.IntrinsicElements["ssr-shadow-cmp"] & JSXBase.HTMLAttributes<HTMLSsrShadowCmpElement>;
             "state-cmp": LocalJSX.IntrinsicElements["state-cmp"] & JSXBase.HTMLAttributes<HTMLStateCmpElement>;
             "wrap-ssr-shadow-cmp": LocalJSX.IntrinsicElements["wrap-ssr-shadow-cmp"] & JSXBase.HTMLAttributes<HTMLWrapSsrShadowCmpElement>;

--- a/test/end-to-end/src/hydrate-props/hydrate-props.e2e.ts
+++ b/test/end-to-end/src/hydrate-props/hydrate-props.e2e.ts
@@ -1,3 +1,5 @@
+export {};
+
 // @ts-ignore may not be existing when project hasn't been built
 type HydrateModule = typeof import('../../hydrate');
 let renderToString: HydrateModule['renderToString'];

--- a/test/end-to-end/src/hydrate-timeout/hydrate-timeout.e2e.ts
+++ b/test/end-to-end/src/hydrate-timeout/hydrate-timeout.e2e.ts
@@ -53,4 +53,16 @@ describe('hydrate timeout aborts in-flight component work', () => {
     expect(fetchCalls.length).toBe(1);
     expect(fetchCalls[0].init?.signal?.aborted).toBe(true);
   });
+
+  it("cascades to a component's own AbortController for non-fetch cancellable work", async () => {
+    delete (global as any).__ownControllerOutcome;
+
+    const result = await renderToString(`<own-controller-cmp></own-controller-cmp>`, {
+      timeout: 50,
+      fullDocument: false,
+    });
+
+    expect(result.diagnostics.some((d) => d.messageText.includes('Hydrate exceeded timeout'))).toBe(true);
+    expect((global as any).__ownControllerOutcome).toEqual({ ok: false, name: 'AbortError' });
+  });
 });

--- a/test/end-to-end/src/hydrate-timeout/hydrate-timeout.e2e.ts
+++ b/test/end-to-end/src/hydrate-timeout/hydrate-timeout.e2e.ts
@@ -1,0 +1,54 @@
+// @ts-ignore may not be existing when project hasn't been built
+type HydrateModule = typeof import('../../hydrate');
+let renderToString: HydrateModule['renderToString'];
+
+describe('hydrate timeout aborts in-flight component work', () => {
+  let originalFetch: any;
+  let fetchCalls: { input: any; init: any }[];
+
+  beforeAll(async () => {
+    // @ts-ignore may not be existing when project hasn't been built
+    const mod = await import('../../hydrate');
+    renderToString = mod.renderToString;
+  });
+
+  beforeEach(() => {
+    fetchCalls = [];
+    originalFetch = (global as any).fetch;
+    // A fetch that never settles on its own - standing in for a slow
+    // upstream API a component might be calling during SSR. It only settles
+    // if the caller's AbortSignal fires, so a passing test proves the render
+    // actually cancelled it rather than merely failing to wait for it.
+    (global as any).fetch = (input: any, init: any) => {
+      fetchCalls.push({ input, init });
+      return new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          const err: any = new Error('The operation was aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      });
+    };
+  });
+
+  afterEach(() => {
+    (global as any).fetch = originalFetch;
+  });
+
+  it('resolves at the timeout and cancels the pending fetch instead of waiting for it', async () => {
+    const start = Date.now();
+    const result = await renderToString(`<slow-fetch-cmp url="https://example.test/slow"></slow-fetch-cmp>`, {
+      timeout: 50,
+      fullDocument: false,
+    });
+    const elapsed = Date.now() - start;
+
+    // Generous upper bound: this checks we did NOT wait anywhere close to a
+    // second full timeout window not a tight timing budget.
+    expect(elapsed).toBeLessThan(1000);
+    expect(result.diagnostics.some((d) => d.messageText.includes('Hydrate exceeded timeout'))).toBe(true);
+
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0].init?.signal?.aborted).toBe(true);
+  });
+});

--- a/test/end-to-end/src/hydrate-timeout/hydrate-timeout.e2e.ts
+++ b/test/end-to-end/src/hydrate-timeout/hydrate-timeout.e2e.ts
@@ -1,3 +1,5 @@
+export {};
+
 // @ts-ignore may not be existing when project hasn't been built
 type HydrateModule = typeof import('../../hydrate');
 let renderToString: HydrateModule['renderToString'];

--- a/test/end-to-end/src/hydrate-timeout/own-controller-cmp.tsx
+++ b/test/end-to-end/src/hydrate-timeout/own-controller-cmp.tsx
@@ -1,0 +1,38 @@
+import { Component, h } from '@stencil/core';
+
+declare const global: any;
+
+/**
+ * Used by hydrate-timeout.e2e.ts to verify the AbortController shim: a
+ * component that creates its own AbortController has that controller cascade-aborted
+ * automatically when the render times out
+ *
+ * The outcome is reported via `global` (not observable through
+ * renderToString's result) so the test can assert on it.
+ */
+@Component({
+  tag: 'own-controller-cmp',
+  shadow: true,
+})
+export class OwnControllerCmp {
+  async componentWillLoad() {
+    const controller = new AbortController();
+    try {
+      await new Promise<void>((_resolve, reject) => {
+        controller.signal.addEventListener('abort', () => {
+          const err: any = new Error('The operation was aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+        // deliberately never resolves on its own
+      });
+      global.__ownControllerOutcome = { ok: true };
+    } catch (e: any) {
+      global.__ownControllerOutcome = { ok: false, name: e && e.name };
+    }
+  }
+
+  render() {
+    return <div>own-controller-cmp</div>;
+  }
+}

--- a/test/end-to-end/src/hydrate-timeout/readme.md
+++ b/test/end-to-end/src/hydrate-timeout/readme.md
@@ -1,0 +1,23 @@
+# slow-fetch-cmp
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Overview
+
+Used by hydrate-timeout.e2e.ts to reproduce stenciljs/core#6864: a
+component whose `componentWillLoad` is still awaiting `fetch()` when the
+render's `opts.timeout` fires.
+
+## Properties
+
+| Property | Attribute | Description | Type     | Default     |
+| -------- | --------- | ----------- | -------- | ----------- |
+| `url`    | `url`     |             | `string` | `undefined` |
+
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/test/end-to-end/src/hydrate-timeout/slow-fetch-cmp.tsx
+++ b/test/end-to-end/src/hydrate-timeout/slow-fetch-cmp.tsx
@@ -1,0 +1,26 @@
+import { Component, Prop, h } from '@stencil/core';
+
+/**
+ * Used by hydrate-timeout.e2e.ts to reproduce stenciljs/core#6864: a
+ * component whose `componentWillLoad` is still awaiting `fetch()` when the
+ * render's `opts.timeout` fires.
+ */
+@Component({
+  tag: 'slow-fetch-cmp',
+  shadow: true,
+})
+export class SlowFetchCmp {
+  @Prop() url: string;
+
+  async componentWillLoad() {
+    try {
+      await fetch(this.url);
+    } catch (e) {
+      // expected once the render times out and aborts this request
+    }
+  }
+
+  render() {
+    return <div>slow-fetch-cmp</div>;
+  }
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: https://github.com/stenciljs/core/issues/6864

When `renderToString` / `hydrateDocument` hits `opts.timeout` the mock window is destroyed while components can still be mid-`await` (e.g. `componentOnReady()` > a component doing a `fetch()` call). Those components then resume against a torn-down window and throw, and the pending promises keep the render's object graph alive - under concurrent load this compounds into unbounded memory growth.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Makes `timeout` actually cancels outstanding work instead of just tearing down around it: 
- Stencil's own post-render bookkeeping stops touching the window once time's up
- in-flight `fetch()` calls a component made are aborted rather than left to run to completion (via shimming `fetch` to add an `AbortController` (< whilst still respecting incoming `AbortController`s))
- `AbortController` _itself_ is also shimmed, so any `AbortController` a component creates for its own cancellable work (participating libs include Axios, AWS SDK, the MongoDB Node driver, etc.) is automatically aborted at `timeout` 
- Anything that manages to touch the destroyed window afterward fails with a clear error

Fixes https://github.com/stenciljs/core/issues/6864

**Limitation:** for a non-cancellable, truly hung promise, there's nothing Stencil can do - no in-language way exists to force-settle a promise nobody is ever going to resolve, so the object graph it's holding reachable can't be released either.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

**Why not the ceiling / drain approach?** 

#6865 (the issue raiser preferred solution) waits for pending components to settle before destroying the window, bounded by a second timeout (the same length as the original). To my mind, that's just a double timeout by a different name and kicks the timeout bomb down the road. 

It _only_ helps components that finish a bit late (and if that's the case just adjust `opts.timeout`). A genuinely stuck component (probably a more likely scenario) hits the identical crash, just now by double the timeout period. 
Additionally, doubling how long each timed-out render holds resources before releasing makes any memory pressure worse, not better. 


<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
