### PR TITLE
fix(compiler): stop double `transformTag` wrap

### DIFF
--- a/src/compiler/transformers/add-tag-transform.ts
+++ b/src/compiler/transformers/add-tag-transform.ts
@@ -119,7 +119,14 @@ export const addTagTransform = (
                 expression.expression.text === 'document'))
           ) {
             const [firstArg, ...restArgs] = node.arguments;
-            if (firstArg) {
+            // test for whether the first argument is already transformed
+            const alreadyTransformed =
+              firstArg &&
+              ts.isCallExpression(firstArg) &&
+              ts.isIdentifier(firstArg.expression) &&
+              (firstArg.expression.text === TRANSFORM_TAG || firstArg.expression.text === 'transformTag');
+
+            if (firstArg && !alreadyTransformed) {
               // Wrap the argument in transformTag(...)
               const newFirstArg = ts.factory.createCallExpression(
                 ts.factory.createIdentifier(TRANSFORM_TAG),

--- a/src/compiler/transformers/test/add-tag-transform.spec.ts
+++ b/src/compiler/transformers/test/add-tag-transform.spec.ts
@@ -236,6 +236,42 @@ describe('add-tag-transform', () => {
       expect(transpileResult.diagnostics).toHaveLength(0);
       expect(res).toContain("customElements.whenDefined(__stencil_transformTag('cmp-a'))");
     });
+
+    it('should not wrap an argument that is already a transformTag call (aliased runtime import)', async () => {
+      const cmp = `
+        @Component({ tag: 'cmp-a' })
+        export class CmpA {
+          someMethod() {
+            customElements.define(__stencil_transformTag('cmp-a'), CmpA);
+          }
+        }
+      `;
+
+      const transpileResult = transpileModule(cmp, buildCtx.config, compilerCtx, [], [transformer]);
+      const res = await formatCode(transpileResult.outputText);
+
+      expect(transpileResult.diagnostics).toHaveLength(0);
+      expect(res).toContain("customElements.define(__stencil_transformTag('cmp-a'), CmpA);");
+      expect(res).not.toContain('__stencil_transformTag(__stencil_transformTag(');
+    });
+
+    it('should not wrap an argument that is already a transformTag call (unaliased identifier)', async () => {
+      const cmp = `
+        @Component({ tag: 'cmp-a' })
+        export class CmpA {
+          someMethod() {
+            customElements.get(transformTag('cmp-a'));
+          }
+        }
+      `;
+
+      const transpileResult = transpileModule(cmp, buildCtx.config, compilerCtx, [], [transformer]);
+      const res = await formatCode(transpileResult.outputText);
+
+      expect(transpileResult.diagnostics).toHaveLength(0);
+      expect(res).toContain("customElements.get(transformTag('cmp-a'));");
+      expect(res).not.toContain('__stencil_transformTag(transformTag(');
+    });
   });
 
   // feels a bit OTT(?)

--- a/test/end-to-end/src/hydrate-timeout/hydrate-timeout.e2e.ts
+++ b/test/end-to-end/src/hydrate-timeout/hydrate-timeout.e2e.ts
@@ -62,7 +62,7 @@ describe('hydrate timeout aborts in-flight component work', () => {
       fullDocument: false,
     });
 
-    expect(result.diagnostics.some((d) => d.messageText.includes('Hydrate exceeded timeout'))).toBe(true);
+    expect(result.diagnostics.some((d: any) => d.messageText.includes('Hydrate exceeded timeout'))).toBe(true);
     expect((global as any).__ownControllerOutcome).toEqual({ ok: false, name: 'AbortError' });
   });
 });


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: #6872


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes #6872

Check for already wrapped `transformTag` arguments being passed to `get`, `define`, `whenDefined` to stop double wrapping

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->

In the linked issue it mentions 

>  Related: in src/runtime/update-component.ts (initializeComponent), customElements.whenDefined(cmpTag) is called with cmpTag = elm.localName — an already-transformed name. The visitor wraps it too, so the promise waits on a never-defined name and hostRef.$flags$ |= isWatchReady never runs — @Watch callbacks silently stop firing under tag transformation in dist-custom-elements builds.

This isn't correct .. `addTagTransform` only run on modules found in component modules (not core modules) - fixing this wasn't necessary 
