### PR TITLE
fix(runtime): create new element for new child when keyed tag changes

### DIFF
--- a/src/runtime/vdom/test/patch.spec.ts
+++ b/src/runtime/vdom/test/patch.spec.ts
@@ -363,6 +363,21 @@ describe('renderer', () => {
           expect(hostElm.children.length).toEqual(3);
           expect(hostElm.children[1].tagName).toEqual('I');
         });
+
+        it('creates a new element for a reused key that changes tag, without stealing a later sibling', () => {
+          const itemP = (n: number) => h('p', { key: n }, `text ${n}`);
+          const itemDiv = (n: number) => h('div', { key: n }, `box ${n}`);
+
+          const vnode1 = h('div', null, itemP(1), itemP(2), itemP(3), itemP(4), itemP(5));
+          const vnode2 = h('div', null, itemP(1), itemP(3), itemDiv(4), itemP(5));
+
+          patch(vnode0, vnode1);
+          expect(map(inner, hostElm.children)).toEqual(['text 1', 'text 2', 'text 3', 'text 4', 'text 5']);
+
+          patch(vnode1, vnode2);
+          expect(map(inner, hostElm.children)).toEqual(['text 1', 'text 3', 'box 4', 'text 5']);
+          expect(map((c: any) => c.tagName, hostElm.children)).toEqual(['P', 'P', 'DIV', 'P']);
+        });
       });
 
       describe('removal of elements', () => {

--- a/src/runtime/vdom/vdom-render.ts
+++ b/src/runtime/vdom/vdom-render.ts
@@ -582,7 +582,7 @@ const updateChildren = (
 
         if (elmToMove.$tag$ !== newStartVnode.$tag$) {
           // the tag doesn't match so we'll need a new DOM element
-          node = createElm(oldCh && oldCh[newStartIdx], newVNode, idxInOld);
+          node = createElm(oldCh && oldCh[newStartIdx], newVNode, newStartIdx);
         } else {
           patch(elmToMove, newStartVnode, isInitialRender);
           // invalidate the matching old node so that we won't try to update it

--- a/test/end-to-end/src/hydrate-timeout/hydrate-timeout.e2e.ts
+++ b/test/end-to-end/src/hydrate-timeout/hydrate-timeout.e2e.ts
@@ -48,7 +48,7 @@ describe('hydrate timeout aborts in-flight component work', () => {
     // Generous upper bound: this checks we did NOT wait anywhere close to a
     // second full timeout window not a tight timing budget.
     expect(elapsed).toBeLessThan(1000);
-    expect(result.diagnostics.some((d) => d.messageText.includes('Hydrate exceeded timeout'))).toBe(true);
+    expect(result.diagnostics.some((d: any) => d.messageText.includes('Hydrate exceeded timeout'))).toBe(true);
 
     expect(fetchCalls.length).toBe(1);
     expect(fetchCalls[0].init?.signal?.aborted).toBe(true);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://github.com/stenciljs/core/blob/main/CONTRIBUTING.md -->


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

GitHub Issue Number: https://github.com/stenciljs/core/issues/6879

`updateChildren` passes the wrong child index to `createElm` when a keyed child's tag changes between renders. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes https://github.com/stenciljs/core/issues/6879

Changes `idxInOld` > `newStartIdx` in that call so the new element is created for the child being processed. The stale old element is removed by the existing `removeVnodes` cleanup.

## Documentation

<!-- Please add any link(s) to documentation-related pull requests here -->

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## Testing

<!-- Please describe the steps you took to test the changes in this PR. These steps can be programmatic (e.g. unit tests) and/or manual. -->

## Other information

<!-- Any other information that is important to this PR such as screenshots of how a component looks before and after the change. -->
